### PR TITLE
GRR recipes

### DIFF
--- a/dftimewolf/cli/dftimewolf_recipes.py
+++ b/dftimewolf/cli/dftimewolf_recipes.py
@@ -50,6 +50,7 @@ from dftimewolf.lib.exporters import timesketch
 from dftimewolf.cli.recipes import local_plaso
 from dftimewolf.cli.recipes import grr_artifact_hosts
 from dftimewolf.cli.recipes import grr_hunt_file
+from dftimewolf.cli.recipes import grr_huntresults_plaso_timesketch
 
 config.Config.register_collector(filesystem.FilesystemCollector)
 config.Config.register_collector(grr.GRRHuntArtifactCollector)
@@ -72,9 +73,9 @@ except IOError as exception:
           config_path, exception))
 
 config.Config.register_recipe(local_plaso)
-
 config.Config.register_recipe(grr_artifact_hosts)
 config.Config.register_recipe(grr_hunt_file)
+config.Config.register_recipe(grr_huntresults_plaso_timesketch)
 
 def main():
   """Main function for DFTimewolf."""

--- a/dftimewolf/cli/dftimewolf_recipes.py
+++ b/dftimewolf/cli/dftimewolf_recipes.py
@@ -77,6 +77,7 @@ config.Config.register_recipe(grr_artifact_hosts)
 config.Config.register_recipe(grr_hunt_file)
 config.Config.register_recipe(grr_huntresults_plaso_timesketch)
 
+
 def main():
   """Main function for DFTimewolf."""
   parser = argparse.ArgumentParser()

--- a/dftimewolf/cli/dftimewolf_recipes.py
+++ b/dftimewolf/cli/dftimewolf_recipes.py
@@ -129,22 +129,25 @@ def main():
 
   # EXPORTERS
   # Thread exporters
-  console_out.StdOut('Exporters:')
-  for exporter in recipe['exporters']:
-    console_out.StdOut('  {0:s}'.format(exporter['name']))
+  if recipe['exporters']:
+    console_out.StdOut('Exporters:')
+    for exporter in recipe['exporters']:
+      console_out.StdOut('  {0:s}'.format(exporter['name']))
 
-  exporter_objs = []
-  for exporter in recipe['exporters']:
-    new_args = dftw_utils.import_args_from_dict(exporter['args'], vars(args))
-    new_args['processor_output'] = processor_output
-    exporter_class = config.Config.get_exporter(exporter['name'])
-    exporter_objs.extend(exporter_class.launch_exporter(**new_args))
+    exporter_objs = []
+    for exporter in recipe['exporters']:
+      new_args = dftw_utils.import_args_from_dict(exporter['args'], vars(args))
+      new_args['processor_output'] = processor_output
+      exporter_class = config.Config.get_exporter(exporter['name'])
+      exporter_objs.extend(exporter_class.launch_exporter(**new_args))
 
-  # Wait for exporters to finish
-  exporter_output = []
-  for exporter in exporter_objs:
-    exporter.join()
-    exporter_output.extend(exporter.output)
+    # Wait for exporters to finish
+    exporter_output = []
+    for exporter in exporter_objs:
+      exporter.join()
+      exporter_output.extend(exporter.output)
+  else:
+    exporter_output = processor_output
 
   console_out.StdOut(
       'Recipe {0:s} executed successfully'.format(recipe['name']))

--- a/dftimewolf/cli/dftimewolf_recipes.py
+++ b/dftimewolf/cli/dftimewolf_recipes.py
@@ -48,6 +48,7 @@ from dftimewolf.lib.processors import localplaso
 from dftimewolf.lib.exporters import timesketch
 
 from dftimewolf.cli.recipes import local_plaso
+from dftimewolf.cli.recipes import grr_artifact_hosts
 
 config.Config.register_collector(filesystem.FilesystemCollector)
 config.Config.register_collector(grr.GRRHuntArtifactCollector)
@@ -71,6 +72,7 @@ except IOError as exception:
 
 config.Config.register_recipe(local_plaso)
 
+config.Config.register_recipe(grr_artifact_hosts)
 
 def main():
   """Main function for DFTimewolf."""

--- a/dftimewolf/cli/dftimewolf_recipes.py
+++ b/dftimewolf/cli/dftimewolf_recipes.py
@@ -93,8 +93,8 @@ def main():
     subparser = subparsers.add_parser(
         recipe['name'], description='{0:s}'.format(recipe.__doc__))
     subparser.set_defaults(recipe=recipe)
-    for switch, help_text in recipe_args:
-      subparser.add_argument(switch, help=help_text)
+    for switch, help_text, default in recipe_args:
+      subparser.add_argument(switch, help=help_text, default=default)
 
   args = parser.parse_args()
   recipe = args.recipe
@@ -110,7 +110,8 @@ def main():
 
   collector_objects = []
   for collector in recipe['collectors']:
-    new_args = dftw_utils.import_args_from_dict(collector['args'], vars(args))
+    new_args = dftw_utils.import_args_from_dict(
+        collector['args'], vars(args), config.Config)
     collector_cls = config.Config.get_collector(collector['name'])
     collector_objects.extend(collector_cls.launch_collector(**new_args))
 
@@ -129,7 +130,8 @@ def main():
 
     processor_objs = []
     for processor in recipe['processors']:
-      new_args = dftw_utils.import_args_from_dict(processor['args'], vars(args))
+      new_args = dftw_utils.import_args_from_dict(
+          processor['args'], vars(args), config.Config)
       new_args['collector_output'] = collector_output
       processor_class = config.Config.get_processor(processor['name'])
       processor_objs.extend(processor_class.launch_processor(**new_args))
@@ -151,7 +153,8 @@ def main():
 
     exporter_objs = []
     for exporter in recipe['exporters']:
-      new_args = dftw_utils.import_args_from_dict(exporter['args'], vars(args))
+      new_args = dftw_utils.import_args_from_dict(
+          exporter['args'], vars(args), config.Config)
       new_args['processor_output'] = processor_output
       exporter_class = config.Config.get_exporter(exporter['name'])
       exporter_objs.extend(exporter_class.launch_exporter(**new_args))

--- a/dftimewolf/cli/dftimewolf_recipes.py
+++ b/dftimewolf/cli/dftimewolf_recipes.py
@@ -49,6 +49,7 @@ from dftimewolf.lib.exporters import timesketch
 
 from dftimewolf.cli.recipes import local_plaso
 from dftimewolf.cli.recipes import grr_artifact_hosts
+from dftimewolf.cli.recipes import grr_hunt_file
 
 config.Config.register_collector(filesystem.FilesystemCollector)
 config.Config.register_collector(grr.GRRHuntArtifactCollector)
@@ -73,6 +74,7 @@ except IOError as exception:
 config.Config.register_recipe(local_plaso)
 
 config.Config.register_recipe(grr_artifact_hosts)
+config.Config.register_recipe(grr_hunt_file)
 
 def main():
   """Main function for DFTimewolf."""

--- a/dftimewolf/cli/dftimewolf_recipes.py
+++ b/dftimewolf/cli/dftimewolf_recipes.py
@@ -50,6 +50,7 @@ from dftimewolf.lib.exporters import timesketch
 from dftimewolf.cli.recipes import local_plaso
 from dftimewolf.cli.recipes import grr_artifact_hosts
 from dftimewolf.cli.recipes import grr_hunt_file
+from dftimewolf.cli.recipes import grr_hunt_artifacts
 from dftimewolf.cli.recipes import grr_huntresults_plaso_timesketch
 
 config.Config.register_collector(filesystem.FilesystemCollector)
@@ -75,6 +76,7 @@ except IOError as exception:
 config.Config.register_recipe(local_plaso)
 config.Config.register_recipe(grr_artifact_hosts)
 config.Config.register_recipe(grr_hunt_file)
+config.Config.register_recipe(grr_hunt_artifacts)
 config.Config.register_recipe(grr_huntresults_plaso_timesketch)
 
 

--- a/dftimewolf/cli/dftimewolf_recipes.py
+++ b/dftimewolf/cli/dftimewolf_recipes.py
@@ -43,12 +43,19 @@ from dftimewolf import config
 from dftimewolf.lib import utils as dftw_utils
 
 from dftimewolf.lib.collectors import filesystem
+from dftimewolf.lib.collectors import grr
 from dftimewolf.lib.processors import localplaso
 from dftimewolf.lib.exporters import timesketch
 
 from dftimewolf.cli.recipes import local_plaso
 
 config.Config.register_collector(filesystem.FilesystemCollector)
+config.Config.register_collector(grr.GRRHuntArtifactCollector)
+config.Config.register_collector(grr.GRRHuntFileCollector)
+config.Config.register_collector(grr.GRRHuntDownloader)
+config.Config.register_collector(grr.GRRArtifactCollector)
+config.Config.register_collector(grr.GRRFileCollector)
+config.Config.register_collector(grr.GRRFlowCollector)
 config.Config.register_processor(localplaso.LocalPlasoProcessor)
 config.Config.register_exporter(timesketch.TimesketchExporter)
 

--- a/dftimewolf/cli/recipes/grr_artifact_hosts.py
+++ b/dftimewolf/cli/recipes/grr_artifact_hosts.py
@@ -1,0 +1,59 @@
+"""Timeflow recipe for collecting data from hosts using GRR.
+
+- Collectors collect default artifacts from hosts using GRR
+- Processes them with a local install of plaso
+- Exports them to a new Timesketch sketch
+
+"""
+
+__author__ = u'tomchop@google.com (Thomas Chopitea)'
+
+
+contents = {
+    'name': 'grr_artifact_hosts',
+    'params': {},
+    'collectors': [
+        {
+            'name': 'GRRArtifactCollector',
+            'args': {
+                'hosts': '@hosts',
+                'flow_id': None,
+                'reason': '@reason',
+                'grr_server_url': 'http://localhost:8000',
+                'grr_auth': ('admin', 'admin'),
+                'approvers': ['grr-approvals@google.com'],
+                'verbose': True,
+                'artifact_list': 'AllUsersShellHistory,BrowserHistory,'
+                                 'LinuxLogFiles,AllLinuxScheduleFiles,'
+                                 'LinuxScheduleFiles,ZeitgeistDatabase,'
+                                 'AllShellConfigs',
+            },
+        }
+    ],
+    'processors': [
+        {
+            'name': 'LocalPlasoProcessor',
+            'args': {
+                'timezone': None,
+                'verbose': True,
+            },
+        }
+    ],
+    'exporters': [{
+        'name': 'TimesketchExporter',
+        'args': {
+            'ts_endpoint': '@ts_endpoint',
+            'ts_username': '@ts_username',
+            'ts_password': '@ts_password',
+            'incident_id': '@incident_id',
+            'sketch_id': None,
+            'verbose': True,
+        }
+    }],
+}
+
+
+args = [
+    ('hosts', 'Comma-separated list of hosts to process'),
+    ('reason', 'Reason for collection'),
+]

--- a/dftimewolf/cli/recipes/grr_artifact_hosts.py
+++ b/dftimewolf/cli/recipes/grr_artifact_hosts.py
@@ -1,4 +1,4 @@
-"""Timeflow recipe for collecting data from hosts using GRR.
+"""DFTimewolf recipe for collecting data from hosts using GRR.
 
 - Collectors collect default artifacts from hosts using GRR
 - Processes them with a local install of plaso

--- a/dftimewolf/cli/recipes/grr_artifact_hosts.py
+++ b/dftimewolf/cli/recipes/grr_artifact_hosts.py
@@ -22,11 +22,7 @@ contents = {
             'grr_auth': ('admin', 'admin'),
             'approvers': ['grr-approvals@google.com'],
             'verbose': True,
-            'artifact_list':
-                'AllUsersShellHistory,BrowserHistory,'
-                'LinuxLogFiles,AllLinuxScheduleFiles,'
-                'LinuxScheduleFiles,ZeitgeistDatabase,'
-                'AllShellConfigs',
+            'artifact_list': '@artifact_list',
         },
     }],
     'processors': [{
@@ -49,7 +45,13 @@ contents = {
     }],
 }
 
-args = [
-    ('hosts', 'Comma-separated list of hosts to process'),
-    ('reason', 'Reason for collection'),
-]
+DEFAULT_ARTIFACT_LIST = (
+    'AllUsersShellHistory,BrowserHistory,'
+    'LinuxLogFiles,AllLinuxScheduleFiles,'
+    'LinuxScheduleFiles,ZeitgeistDatabase,'
+    'AllShellConfigs')
+
+args = [('hosts', 'Comma-separated list of hosts to process', None),
+        ('reason', 'Reason for collection', None), (
+            '--artifact_list', 'Comma-separated list of artifacts to fetch',
+            DEFAULT_ARTIFACT_LIST)]

--- a/dftimewolf/cli/recipes/grr_artifact_hosts.py
+++ b/dftimewolf/cli/recipes/grr_artifact_hosts.py
@@ -5,8 +5,7 @@
 - Exports them to a new Timesketch sketch
 
 """
-
-__author__ = u'tomchop@google.com (Thomas Chopitea)'
+from __future__ import unicode_literals
 
 contents = {
     'name':
@@ -20,7 +19,7 @@ contents = {
             'reason': '@reason',
             'grr_server_url': 'http://localhost:8000',
             'grr_auth': ('admin', 'admin'),
-            'approvers': ['grr-approvals@google.com'],
+            'approvers': [],
             'verbose': True,
             'artifact_list': '@artifact_list',
         },

--- a/dftimewolf/cli/recipes/grr_artifact_hosts.py
+++ b/dftimewolf/cli/recipes/grr_artifact_hosts.py
@@ -8,37 +8,34 @@
 
 __author__ = u'tomchop@google.com (Thomas Chopitea)'
 
-
 contents = {
-    'name': 'grr_artifact_hosts',
+    'name':
+        'grr_artifact_hosts',
     'params': {},
-    'collectors': [
-        {
-            'name': 'GRRArtifactCollector',
-            'args': {
-                'hosts': '@hosts',
-                'flow_id': None,
-                'reason': '@reason',
-                'grr_server_url': 'http://localhost:8000',
-                'grr_auth': ('admin', 'admin'),
-                'approvers': ['grr-approvals@google.com'],
-                'verbose': True,
-                'artifact_list': 'AllUsersShellHistory,BrowserHistory,'
-                                 'LinuxLogFiles,AllLinuxScheduleFiles,'
-                                 'LinuxScheduleFiles,ZeitgeistDatabase,'
-                                 'AllShellConfigs',
-            },
-        }
-    ],
-    'processors': [
-        {
-            'name': 'LocalPlasoProcessor',
-            'args': {
-                'timezone': None,
-                'verbose': True,
-            },
-        }
-    ],
+    'collectors': [{
+        'name': 'GRRArtifactCollector',
+        'args': {
+            'hosts': '@hosts',
+            'flow_id': None,
+            'reason': '@reason',
+            'grr_server_url': 'http://localhost:8000',
+            'grr_auth': ('admin', 'admin'),
+            'approvers': ['grr-approvals@google.com'],
+            'verbose': True,
+            'artifact_list':
+                'AllUsersShellHistory,BrowserHistory,'
+                'LinuxLogFiles,AllLinuxScheduleFiles,'
+                'LinuxScheduleFiles,ZeitgeistDatabase,'
+                'AllShellConfigs',
+        },
+    }],
+    'processors': [{
+        'name': 'LocalPlasoProcessor',
+        'args': {
+            'timezone': None,
+            'verbose': True,
+        },
+    }],
     'exporters': [{
         'name': 'TimesketchExporter',
         'args': {
@@ -51,7 +48,6 @@ contents = {
         }
     }],
 }
-
 
 args = [
     ('hosts', 'Comma-separated list of hosts to process'),

--- a/dftimewolf/cli/recipes/grr_hunt_artifacts.py
+++ b/dftimewolf/cli/recipes/grr_hunt_artifacts.py
@@ -27,6 +27,6 @@ contents = {
 }
 
 args = [
-    ('artifacts', 'Comma-separated list of artifacts to hunt for'),
-    ('reason', 'Reason for collection'),
+    ('artifacts', 'Comma-separated list of artifacts to hunt for', None),
+    ('reason', 'Reason for collection', None),
 ]

--- a/dftimewolf/cli/recipes/grr_hunt_artifacts.py
+++ b/dftimewolf/cli/recipes/grr_hunt_artifacts.py
@@ -3,8 +3,7 @@
 Consists of a single collector that starts the hunt and provides a Hunt ID to
 the user.
 """
-
-__author__ = u'tomchop@google.com (Thomas Chopitea)'
+from __future__ import unicode_literals
 
 contents = {
     'name':
@@ -18,7 +17,7 @@ contents = {
             'grr_server_url': 'http://localhost:8000',
             'grr_auth': ('admin', 'admin'),
             'use_tsk': False,
-            'approvers': ['grr-approvals@google.com'],
+            'approvers': [],
             'verbose': True,
         },
     }],

--- a/dftimewolf/cli/recipes/grr_hunt_artifacts.py
+++ b/dftimewolf/cli/recipes/grr_hunt_artifacts.py
@@ -1,0 +1,32 @@
+"""DFTimewolf recipe for starting artifact hunts using GRR.
+
+Consists of a single collector that starts the hunt and provides a Hunt ID to
+the user.
+"""
+
+__author__ = u'tomchop@google.com (Thomas Chopitea)'
+
+contents = {
+    'name':
+        'grr_hunt_artifacts',
+    'params': {},
+    'collectors': [{
+        'name': 'GRRHuntArtifactCollector',
+        'args': {
+            'artifacts': '@artifacts',
+            'reason': '@reason',
+            'grr_server_url': 'http://localhost:8000',
+            'grr_auth': ('admin', 'admin'),
+            'use_tsk': False,
+            'approvers': ['grr-approvals@google.com'],
+            'verbose': True,
+        },
+    }],
+    'processors': [],
+    'exporters': [],
+}
+
+args = [
+    ('artifacts', 'Comma-separated list of artifacts to hunt for'),
+    ('reason', 'Reason for collection'),
+]

--- a/dftimewolf/cli/recipes/grr_hunt_file.py
+++ b/dftimewolf/cli/recipes/grr_hunt_file.py
@@ -1,0 +1,35 @@
+"""Timeflow recipe for collecting data from hosts using GRR.
+
+- Collectors collect default artifacts from hosts using GRR
+- Processes them with a local install of plaso
+- Exports them to a new Timesketch sketch
+
+"""
+
+__author__ = u'tomchop@google.com (Thomas Chopitea)'
+
+
+contents = {
+    'name': 'grr_hunt_file',
+    'params': {},
+    'collectors': [
+        {
+            'name': 'GRRHuntFileCollector',
+            'args': {
+                'file_list': '@file_list',
+                'reason': '@reason',
+                'grr_server_url': 'http://localhost:8000',
+                'grr_auth': ('admin', 'admin'),
+                'approvers': ['grr-approvals@google.com'],
+                'verbose': True,
+            },
+        }
+    ],
+    'processors': [],
+    'exporters': [],
+}
+
+args = [
+    ('file_list', 'Comma-separated list of filepaths to hunt for'),
+    ('reason', 'Reason for collection'),
+]

--- a/dftimewolf/cli/recipes/grr_hunt_file.py
+++ b/dftimewolf/cli/recipes/grr_hunt_file.py
@@ -1,9 +1,7 @@
-"""Timeflow recipe for collecting data from hosts using GRR.
+"""DFTimewolf recipe for starting file hunts using GRR.
 
-- Collectors collect default artifacts from hosts using GRR
-- Processes them with a local install of plaso
-- Exports them to a new Timesketch sketch
-
+Consists of a single collector that starts the hunt and provides a Hunt ID to
+the user.
 """
 
 __author__ = u'tomchop@google.com (Thomas Chopitea)'

--- a/dftimewolf/cli/recipes/grr_hunt_file.py
+++ b/dftimewolf/cli/recipes/grr_hunt_file.py
@@ -8,23 +8,21 @@
 
 __author__ = u'tomchop@google.com (Thomas Chopitea)'
 
-
 contents = {
-    'name': 'grr_hunt_file',
+    'name':
+        'grr_hunt_file',
     'params': {},
-    'collectors': [
-        {
-            'name': 'GRRHuntFileCollector',
-            'args': {
-                'file_list': '@file_list',
-                'reason': '@reason',
-                'grr_server_url': 'http://localhost:8000',
-                'grr_auth': ('admin', 'admin'),
-                'approvers': ['grr-approvals@google.com'],
-                'verbose': True,
-            },
-        }
-    ],
+    'collectors': [{
+        'name': 'GRRHuntFileCollector',
+        'args': {
+            'file_list': '@file_list',
+            'reason': '@reason',
+            'grr_server_url': 'http://localhost:8000',
+            'grr_auth': ('admin', 'admin'),
+            'approvers': ['grr-approvals@google.com'],
+            'verbose': True,
+        },
+    }],
     'processors': [],
     'exporters': [],
 }

--- a/dftimewolf/cli/recipes/grr_hunt_file.py
+++ b/dftimewolf/cli/recipes/grr_hunt_file.py
@@ -26,6 +26,6 @@ contents = {
 }
 
 args = [
-    ('file_list', 'Comma-separated list of filepaths to hunt for'),
-    ('reason', 'Reason for collection'),
+    ('file_list', 'Comma-separated list of filepaths to hunt for', None),
+    ('reason', 'Reason for collection', None),
 ]

--- a/dftimewolf/cli/recipes/grr_hunt_file.py
+++ b/dftimewolf/cli/recipes/grr_hunt_file.py
@@ -3,8 +3,7 @@
 Consists of a single collector that starts the hunt and provides a Hunt ID to
 the user.
 """
-
-__author__ = u'tomchop@google.com (Thomas Chopitea)'
+from __future__ import unicode_literals
 
 contents = {
     'name':
@@ -17,7 +16,7 @@ contents = {
             'reason': '@reason',
             'grr_server_url': 'http://localhost:8000',
             'grr_auth': ('admin', 'admin'),
-            'approvers': ['grr-approvals@google.com'],
+            'approvers': [],
             'verbose': True,
         },
     }],

--- a/dftimewolf/cli/recipes/grr_huntresults_plaso_timesketch.py
+++ b/dftimewolf/cli/recipes/grr_huntresults_plaso_timesketch.py
@@ -5,8 +5,8 @@
 - Processes results with a local install of plaso
 - Exports processed items to a new Timesketch sketch
 """
+from __future__ import unicode_literals
 
-__author__ = 'tomchop@google.com (Thomas Chopitea)'
 
 contents = {
     'name':

--- a/dftimewolf/cli/recipes/grr_huntresults_plaso_timesketch.py
+++ b/dftimewolf/cli/recipes/grr_huntresults_plaso_timesketch.py
@@ -9,7 +9,8 @@
 __author__ = 'tomchop@google.com (Thomas Chopitea)'
 
 contents = {
-    'name': 'grr_huntresults_plaso_timesketch',
+    'name':
+        'grr_huntresults_plaso_timesketch',
     'params': {},
     'collectors': [{
         'name': 'GRRHuntDownloader',
@@ -43,5 +44,6 @@ contents = {
 
 args = [
     ('hunt_id', 'ID of GRR Hunt results to fetch', None),
-    ('reason', 'Reason for exporting hunt (used for Timesketch description)', None),
+    ('reason', 'Reason for exporting hunt (used for Timesketch description)',
+     None),
 ]

--- a/dftimewolf/cli/recipes/grr_huntresults_plaso_timesketch.py
+++ b/dftimewolf/cli/recipes/grr_huntresults_plaso_timesketch.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-"""DFTimewolf recipe for collecting data from the filesystem.
+"""DFTimewolf recipe for downloading the results of a GRR Hunt and process them.
 
-- Collectors collect from a path in the FS
-- Processes them with a local install of plaso
-- Exports them to a new Timesketch sketch
+- Collect results of a hunt given its Hunt ID
+- Processes results with a local install of plaso
+- Exports processed items to a new Timesketch sketch
 """
 
 __author__ = 'tomchop@google.com (Thomas Chopitea)'

--- a/dftimewolf/cli/recipes/grr_huntresults_plaso_timesketch.py
+++ b/dftimewolf/cli/recipes/grr_huntresults_plaso_timesketch.py
@@ -42,6 +42,6 @@ contents = {
 }
 
 args = [
-    ('hunt_id', 'ID of GRR Hunt results to fetch'),
-    ('reason', 'Reason for exporting hunt (used for Timesketch description)'),
+    ('hunt_id', 'ID of GRR Hunt results to fetch', None),
+    ('reason', 'Reason for exporting hunt (used for Timesketch description)', None),
 ]

--- a/dftimewolf/cli/recipes/grr_huntresults_plaso_timesketch.py
+++ b/dftimewolf/cli/recipes/grr_huntresults_plaso_timesketch.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+"""DFTimewolf recipe for collecting data from the filesystem.
+
+- Collectors collect from a path in the FS
+- Processes them with a local install of plaso
+- Exports them to a new Timesketch sketch
+"""
+
+from __future__ import unicode_literals
+
+contents = {
+    'name': 'grr_huntresults_plaso_timesketch',
+    'params': {},
+    'collectors': [{
+        'name': 'GRRHuntDownloader',
+        'args': {
+            'hunt_id': '@hunt_id',
+            'grr_server_url': 'http://localhost:8000',
+            'grr_auth': ('admin', 'admin'),
+            'verbose': True,
+            'reason': '@reason',
+        },
+    }],
+    'processors': [{
+        'name': 'LocalPlasoProcessor',
+        'args': {
+            'timezone': None,
+            'verbose': True,
+        },
+    }],
+    'exporters': [{
+        'name': 'TimesketchExporter',
+        'args': {
+            'ts_endpoint': '@ts_endpoint',
+            'ts_username': '@ts_username',
+            'ts_password': '@ts_password',
+            'incident_id': '@incident_id',
+            'sketch_id': None,
+            'verbose': True,
+        }
+    }],
+}
+
+args = [
+    ('hunt_id', 'ID of GRR Hunt results to fetch'),
+    ('reason', 'Reason for exporting hunt (used for Timesketch description)'),
+]

--- a/dftimewolf/cli/recipes/grr_huntresults_plaso_timesketch.py
+++ b/dftimewolf/cli/recipes/grr_huntresults_plaso_timesketch.py
@@ -6,7 +6,7 @@
 - Exports them to a new Timesketch sketch
 """
 
-from __future__ import unicode_literals
+__author__ = 'tomchop@google.com (Thomas Chopitea)'
 
 contents = {
     'name': 'grr_huntresults_plaso_timesketch',

--- a/dftimewolf/cli/recipes/local_plaso.py
+++ b/dftimewolf/cli/recipes/local_plaso.py
@@ -42,6 +42,6 @@ contents = {
 }
 
 args = [
-    ('paths', 'Paths to process'),
-    ('--incident_id', 'Incident ID (used for Timesketch description)'),
+    ('paths', 'Paths to process', None),
+    ('--incident_id', 'Incident ID (used for Timesketch description)', None),
 ]

--- a/dftimewolf/config.py
+++ b/dftimewolf/config.py
@@ -6,8 +6,6 @@ from __future__ import unicode_literals
 import json
 import sys
 
-from dftimewolf.lib import utils as dftw_utils
-
 
 class Config(object):
   """Class that handles DFTimewolf's configuration parameters."""
@@ -69,19 +67,11 @@ class Config(object):
     cls._extra_config = {}
 
   @classmethod
-  def register_recipe(cls, recipe, **kwargs):
+  def register_recipe(cls, recipe):
     """Registers a dftimewolf recipe.
-
-    Registers a DFTimeWolf recipe with specified parameters. Parameters can be
-    specified in three ways, in order of precedence:
-      * Defined in config.json
-      * Passed as arguments to the register_recipe function call
-      * Passed as CLI args
 
     Args:
       recipe: imported python module representing the recipe.
-      **kwargs: parameters to be replaced in the recipe before checking the
-          CLI arguments.
     """
     # Update kwargs with what we already loaded from config.json
     recipe_name = recipe.contents['name']

--- a/dftimewolf/config.py
+++ b/dftimewolf/config.py
@@ -64,6 +64,11 @@ class Config(object):
       exit(-1)
 
   @classmethod
+  def clear_extra(cls):
+    """Clears any extra arguments loaded from a config JSON blob."""
+    cls._extra_config = {}
+
+  @classmethod
   def register_recipe(cls, recipe, **kwargs):
     """Registers a dftimewolf recipe.
 
@@ -79,8 +84,6 @@ class Config(object):
           CLI arguments.
     """
     # Update kwargs with what we already loaded from config.json
-    kwargs.update(cls._extra_config)
-    recipe.contents = dftw_utils.import_args_from_dict(recipe.contents, kwargs)
     recipe_name = recipe.contents['name']
     cls._recipe_classes[recipe_name] = (recipe.contents, recipe.args)
 

--- a/dftimewolf/lib/collectors/grr.py
+++ b/dftimewolf/lib/collectors/grr.py
@@ -1,0 +1,1029 @@
+"""Collects artifacts with GRR."""
+
+import datetime
+import os
+import re
+import syslog
+import tempfile
+import time
+import zipfile
+
+from dftimewolf.lib.collectors.collectors import BaseCollector
+
+
+from grr_api_client import errors as grr_errors
+from grr_api_client import api as grr_api
+from grr_api_client.proto.grr.proto import flows_pb2
+
+
+class GRRHuntCollector(BaseCollector):
+  """Base collector for GRR hunt collections.
+
+  Attributes:
+    output_path: Path to store collected artifacts
+    grr_api: GRR HTTP API client
+    reason: Justification for GRR access
+    approvers: list of GRR approval recipients
+  """
+  _CHECK_APPROVAL_INTERVAL_SEC = 10
+
+  def __init__(self,
+               reason,
+               grr_server_url,
+               grr_auth,
+               approvers=None,
+               verbose=False):
+    """Initializes a GRR hunt results collector.
+
+    Args:
+      reason: justification for GRR access
+      grr_server_url: GRR server url
+      grr_auth: Tuple containing a (username, password) combination
+      approvers: comma-separated list of GRR approval recipients
+      verbose: toggle for verbose output
+    """
+    super(GRRHuntCollector, self).__init__(verbose=verbose)
+    self.output_path = tempfile.mkdtemp()
+    self.grr_api = grr_api.InitHttp(api_endpoint=grr_server_url, auth=grr_auth)
+    self.approvers = approvers
+    self.reason = reason
+
+  def _StartHunt(self, name, args):
+    """Create specified hunt.
+
+    Args:
+      name: string containing hunt name
+      args: proto (*FlowArgs) for type of hunt, as defined in GRR flow proto
+
+    Returns:
+      str representing hunt ID.
+
+      Raises:
+        ValueError: if approval is needed and approvers were not specified.
+    """
+    runner_args = self.grr_api.types.CreateHuntRunnerArgs()
+    runner_args.description = self.reason
+    hunt = self.grr_api.CreateHunt(
+        flow_name=name, flow_args=args, hunt_runner_args=runner_args)
+    hunt_id = hunt.hunt_id
+    syslog.syslog('Hunt {0:s}: Created'.format(hunt_id))
+    self.console_out.VerboseOut('Hunt {0:s}: Created'.format(hunt_id))
+
+    try:
+      hunt.Start()
+      return hunt_id
+    except grr_errors.AccessForbiddenError:
+      syslog.syslog('Hunt {0:s}: No valid hunt approval found'.format(hunt_id))
+      self.console_out.VerboseOut('No valid hunt approval found')
+      if not self.approvers:
+        raise ValueError('GRR hunt needs approval but no approvers specified '
+                         '(hint: use --approvers)')
+      self.console_out.VerboseOut(
+          'Hunt {0:s}: approval request sent to: {1:s} (reason: {2:s})'.format(
+              hunt_id, self.approvers, self.reason))
+      self.console_out.VerboseOut(
+          'Hunt {0:s}: Waiting for approval (this can take a while..)'.format(
+              hunt_id))
+      # Send a request for approval and wait until there is a valid one
+      # available in GRR.
+      hunt.CreateApproval(reason=self.reason, notified_users=self.approvers)
+      syslog.syslog('Hunt {0:s}: Request for hunt approval sent'.format(
+          hunt_id))
+      while True:
+        try:
+          hunt.Start()
+          syslog.syslog('Hunt {0:s}: Hunt approval is valid'.format(hunt_id))
+          self.console_out.VerboseOut('Hunt approval is valid.')
+          return hunt_id
+        except grr_errors.AccessForbiddenError:
+          time.sleep(self._CHECK_APPROVAL_INTERVAL_SEC)
+
+  def collect(self):
+    """Download current set of files in results.
+
+    Returns:
+      list: tuples containing:
+          str: human-readable description of the source of the collection. For
+              example, the name of the source host.
+          str: path to the collected data.
+    Raises:
+      ValueError: if approval is needed and approvers were not specified.
+    """
+    if not os.path.isdir(self.output_path):
+      os.makedirs(self.output_path)
+
+    output_file_path = os.path.join(self.output_path, '.'.join(
+        (self.hunt_id, 'zip')))
+
+    if os.path.exists(output_file_path):
+      self.console_out.StdOut(
+          '{0:s} already exists: Skipping'.format(output_file_path))
+      return None
+
+    try:
+      self._hunt.GetFilesArchive().WriteToFile(output_file_path)
+      syslog.syslog('Hunt {0:s}: Results downloaded'.format(self.hunt_id))
+      self.console_out.VerboseOut('Hunt {0:s}: Downloaded: {1:s}'.format(
+          self.hunt_id, output_file_path))
+    except grr_errors.AccessForbiddenError:
+      syslog.syslog('Hunt {0:s}: No valid hunt approval found'.format(
+          self.hunt_id))
+      self.console_out.VerboseOut('No valid hunt approval found')
+      if not self.approvers:
+        raise ValueError('GRR hunt needs approval but no approvers specified '
+                         '(hint: use --approvers)')
+      self.console_out.VerboseOut(
+          'Hunt {0:s}: approval request sent to: {1:s} (reason: {2:s})'.format(
+              self.hunt_id, self.approvers, self.reason))
+      self.console_out.VerboseOut(
+          'Hunt {0:s}: Waiting for approval (this can take a while..)'.format(
+              self.hunt_id))
+      # Send a request for approval and wait until there is a valid one
+      # available in GRR.
+      self._hunt.CreateApproval(
+          reason=self.reason, notified_users=self.approvers)
+      syslog.syslog('Hunt {0:s}: Request for hunt approval sent'.format(
+          self.hunt_id))
+      while True:
+        try:
+          hunt_archive = self._hunt.GetFilesArchive()
+          hunt_archive.WriteToFile(output_file_path)
+          self.console_out.VerboseOut(
+              'Hunt {0:s}: Downloaded results to {1:s}'.format(
+                  self.hunt_id, output_file_path))
+          syslog.syslog('Hunt {0:s}: Results downloaded'.format(self.hunt_id))
+          self.console_out.VerboseOut('Hunt {0:s}: Downloaded: {1:s}'.format(
+              self.hunt_id, output_file_path))
+          break
+        except grr_errors.AccessForbiddenError:
+          time.sleep(self._CHECK_APPROVAL_INTERVAL_SEC)
+    return self._ExtractHuntResults(output_file_path)
+
+  def _ExtractHuntResults(self, output_file_path):
+    """Open a hunt output archive and extract files.
+
+    Args:
+      output_file_path: The path where the hunt archive is downloaded to.
+
+    Returns:
+      list: tuples containing:
+          str: The name of the client from where the files were downloaded.
+          str: The directory where the files were downloaded to.
+    """
+    # Extract items from archive by host for processing
+    collection_paths = []
+    with zipfile.ZipFile(output_file_path) as archive:
+      items = archive.infolist()
+      base = items[0].filename.split('/')[0]
+      for f in items:
+        client_id = f.filename.split('/')[1]
+        if client_id.startswith('C.'):
+          client = self.grr_api.Client(client_id).Get()
+          client_name = client.data.os_info.fqdn
+          client_directory = os.path.join(self.output_path, client_id)
+          if not os.path.isdir(client_directory):
+            os.makedirs(client_directory)
+          collection_paths.append((client_name, client_directory))
+          real_file_path = os.path.join(base, 'hashes',
+                                        os.path.basename(archive.read(f)))
+          try:
+            archive.extract(real_file_path, client_directory)
+            os.rename(
+                os.path.join(client_directory, real_file_path),
+                os.path.join(client_directory, os.path.basename(f.filename)))
+          except KeyError, e:
+            self.console_out.StdErr('Extraction error: {0:s}'.format(e))
+            return None
+
+    os.remove(output_file_path)
+
+    return collection_paths
+
+  def PrintStatus(self):
+    """Print status of hunt."""
+    status = self.grr_api.Hunt(self.hunt_id).Get().data
+    self.console_out.StdOut(
+        'Status of hunt {0:s}\nTotal clients: {1:d}\nCompleted clients: '
+        '{2:d}\nOutstanding clients: {3:d}\n'.format(
+            self.hunt_id, status.all_clients_count,
+            status.completed_clients_count, status.remaining_clients_count))
+
+  @property
+  def collection_name(self):
+    """Name for the collection of collected artifacts."""
+    collection_name = '{0:s}: {1:s}'.format(
+        self.hunt_id, self._hunt.data.hunt_runner_args.description)
+    self.console_out.VerboseOut('Artifact collection name: {0:s}'.format(
+        collection_name))
+    return collection_name
+
+
+class GRRHuntArtifactCollector(GRRHuntCollector):
+  """Artifact collector for GRR hunts.
+
+  Attributes:
+    output_path: Path to where to store collected items
+    grr_api: GRR HTTP API client
+    reason: Justification for GRR access
+    approvers: list of GRR approval recipients
+    artifacts: comma-separated list of GRR-defined artifacts
+    use_tsk: toggle for use_tsk flag
+  """
+
+  def __init__(self,
+               reason,
+               grr_server_url,
+               grr_auth,
+               artifacts,
+               use_tsk,
+               approvers=None,
+               verbose=False):
+    """Initializes a GRR Hunt artifact collector.
+
+    Args:
+      reason: justification for GRR access
+      grr_server_url: GRR server url
+      grr_auth: Tuple containing a (username, password) combination
+      artifacts: str, comma-separated list of GRR-defined artifacts
+      use_tsk: toggle for use_tsk flag
+      approvers: str, comma-separated list of GRR approval recipients
+      verbose: toggle for verbose output
+    """
+    super(GRRHuntCollector, self).__init__(reason, grr_server_url, grr_auth,
+                                           approvers=approvers, verbose=verbose)
+    self.artifacts = artifacts
+    self.use_tsk = use_tsk
+    self.hunt_id = self._NewHunt()
+    self._hunt = self.grr_api.Hunt(self.hunt_id).Get()
+
+  def _NewHunt(self):
+    """Construct and start new GRR hunt.
+
+    Returns:
+      str representing hunt ID.
+
+    Raises:
+      RuntimeError: if no items specified for collection
+    """
+    artifact_list = self.artifacts.split(',')
+    if not artifact_list:
+      raise RuntimeError('Artifacts must be specified for artifact collection')
+
+    syslog.syslog('Artifacts to be collected: {0:s}'.format(self.artifacts))
+    hunt_name = 'ArtifactCollectorFlow'
+    hunt_args = grr_api.types.CreateFlowArgs("ArtifactCollectorFlow")
+    hunt_args.artifact_list = artifact_list
+    hunt_args.use_tsk = self.use_tsk
+    hunt_args.ignore_interpolation_errors = True
+    hunt_args.apply_parsers = False
+    # hunt_args = flows_pb2.ArtifactCollectorFlowArgs(
+    #     artifact_list=artifact_list,
+    #     use_tsk=self.use_tsk,
+    #     ignore_interpolation_errors=True,
+    #     apply_parsers=False,)
+
+    return self._StartHunt(hunt_name, hunt_args)
+
+  @staticmethod
+  def launch_collector(self, *args, **kwargs):
+    "Start an artifact collection hunt"
+    pass
+
+
+class GRRHuntFileCollector(GRRHuntCollector):
+  """File collector for GRR hunts.
+
+  Attributes:
+    output_path: Path to where to store collected items
+    grr_api: GRR HTTP API client
+    reason: Justification for GRR access
+    approvers: list of GRR approval recipients
+    files: comma-separated list of file paths
+  """
+
+  def __init__(self,
+               reason,
+               grr_server_url,
+               grr_auth,
+               file_list,
+               approvers=None,
+               verbose=False):
+    """Initializes a GRR Hunt file collector.
+
+    Args:
+      reason: justification for GRR access
+      grr_server_url: GRR server url
+      grr_auth: Tuple containing a (username, password) combination
+      files: comma-separated list of file paths
+      approvers: comma-separated list of GRR approval recipients
+      verbose: toggle for verbose output
+    """
+    super(GRRHuntFileCollector, self).__init__(
+        reason, grr_server_url, grr_auth, approvers=approvers, verbose=verbose)
+    self.file_list = file_list
+    self.hunt_id = self._NewHunt()
+    self._hunt = self.grr_api.Hunt(self.hunt_id).Get()
+
+  def _NewHunt(self):
+    """Construct and start new GRR hunt.
+
+    Returns:
+      str representing hunt ID.
+
+    Raises:
+      RuntimeError: if no items specified for collection
+    """
+    file_list = self.file_list.split(',')
+    if not file_list:
+      raise RuntimeError('File must be specified for hunts')
+
+    syslog.syslog('Hunt to collect {0:d} items'.format(len(self.file_list)))
+    self.console_out.VerboseOut('Files to be collected: {0:s}'.format(
+        self.file_list))
+    hunt_name = 'FileFinder'
+
+    hunt_action = flows_pb2.FileFinderAction(
+        action_type=flows_pb2.FileFinderAction.DOWNLOAD,)
+    hunt_args = flows_pb2.FileFinderArgs(
+        paths=file_list,
+        action=hunt_action,)
+
+    return self._StartHunt(hunt_name, hunt_args)
+
+  @staticmethod
+  def launch_collector(reason, grr_server_url, grr_auth, file_list,
+                       approvers=None,
+                       verbose=False):
+    """Start a file collector Hunt"""
+    hunt = GRRHuntFileCollector(
+        reason, grr_server_url, grr_auth, file_list, approvers, verbose)
+    hunt.console_out.StdOut("\nHunt {0:s} created succesfully!")
+    hunt.console_out.StdOut("Go grab some coffee while it completes and run a GRRHuntDownloader recipe to fetch results.".format(hunt.hunt_id))
+    hunt.console_out.StdOut("e.g. $ dftimewolf huntresults_plaso_timesketch {0:s}\n".format(hunt.hunt_id))
+
+    return []
+
+
+class GRRHuntDownloader(GRRHuntCollector):
+  """File collector for GRR hunts.
+
+  Attributes:
+    output_path: path to where to store collected items
+    grr_api: GRR HTTP API client
+    reason: justification for GRR access
+    approvers: list of GRR approval recipients
+    hunt_id: ID of GRR hunt to retrieve results from
+  """
+
+  def __init__(self,
+               reason,
+               grr_server_url,
+               grr_auth,
+               hunt_id,
+               approvers=None,
+               verbose=False):
+    """Initializes a GRR hunt results collector.
+
+    Args:
+      reason: justification for GRR access
+      grr_server_url: GRR server url
+      grr_auth: Tuple containing a (username, password) combination
+      hunt_id: ID of GRR hunt to retrieve results from
+      approvers: comma-separated list of GRR approval recipients
+      verbose: toggle for verbose output
+    """
+    super(GRRHuntDownloader, self).__init__(
+        reason, grr_server_url, grr_auth, approvers=approvers, verbose=verbose)
+    self.hunt_id = hunt_id
+    self._hunt = self.grr_api.Hunt(self.hunt_id).Get()
+
+  @staticmethod
+  def launch_collector(reason,
+                       grr_server_url,
+                       grr_auth,
+                       hunt_id,
+                       approvers=None,
+                       verbose=False):
+    """Launch downloads of files previously hunted for,"""
+    hunt_downloader = GRRHuntDownloader(
+        reason, grr_server_url, grr_auth, hunt_id, approvers, verbose)
+    hunt_downloader.start()
+    return [hunt_downloader]
+
+
+class GRRHostCollector(BaseCollector):
+  """Collect artifacts with GRR.
+
+  Attributes:
+    output_path: Path to where to store collected items
+    grr_api: GRR HTTP API client
+    host: Target of GRR collection
+    reason: Justification for GRR access
+    approvers: list of GRR approval recipients
+  """
+  _CHECK_APPROVAL_INTERVAL_SEC = 10
+  _CHECK_FLOW_INTERVAL_SEC = 10
+
+  def __init__(self,
+               hostname,
+               reason,
+               grr_server_url,
+               grr_auth,
+               approvers=None,
+               verbose=False,
+               keepalive=False):
+    """Initializes a GRR collector.
+
+    Args:
+      hostname: hostname of machine
+      reason: justification for GRR access
+      grr_server_url: GRR server url
+      grr_auth: Tuple containing a (username, password) combination
+      approvers: comma-separated list of GRR approval recipients
+      verbose: toggle for verbose output
+      keepalive: toggle for scheduling a KeepAlive flow
+    """
+    super(GRRHostCollector, self).__init__(verbose=verbose)
+    self.output_path = tempfile.mkdtemp()
+    self.grr_api = grr_api.InitHttp(api_endpoint=grr_server_url, auth=grr_auth)
+    self.host = hostname
+    self.reason = reason
+    self.approvers = approvers
+    self._client_id = self._GetClientId(hostname)
+    self._client = None
+    self.keepalive = keepalive
+
+  def _GetClientId(self, hostname):
+    """Search GRR by hostname and get the latest active client.
+
+    Args:
+      hostname: hostname to search for.
+
+    Returns:
+      str: ID of most recently active client.
+
+    Raises:
+      RuntimeError: if no client ID found for hostname
+    """
+    client_id_pattern = re.compile(r'^c\.[0-9a-f]{16}$', re.IGNORECASE)
+    if client_id_pattern.match(hostname):
+      return hostname
+
+    # Search for the hostname in GRR
+    syslog.syslog('Searching for client')
+    self.console_out.VerboseOut('Searching for client: {0:s}'.format(hostname))
+    search_result = self.grr_api.SearchClients(hostname)
+
+    result = {}
+    for client in search_result:
+      client_id = client.client_id
+      client_fqdn = client.data.os_info.fqdn
+      client_last_seen_at = client.data.last_seen_at
+      if hostname.lower() in client_fqdn.lower():
+        result[client_id] = client_last_seen_at
+
+    if not result:
+      raise RuntimeError('Could not get client_id for {0:s}'.format(hostname))
+
+    active_client_id = sorted(result, key=result.get, reverse=True)[0]
+    last_seen_timestamp = result[active_client_id]
+    # Remove microseconds and create datetime object
+    last_seen_datetime = datetime.datetime.utcfromtimestamp(
+        last_seen_timestamp / 1000000)
+    # Timedelta between now and when the client was last seen, in minutes.
+    # First, count total seconds. This will return a float.
+    last_seen_seconds = (
+        datetime.datetime.utcnow() - last_seen_datetime).total_seconds()
+    last_seen_minutes = int(round(last_seen_seconds)) / 60
+
+    syslog.syslog('{0:s}: Found active client'.format(active_client_id))
+    self.console_out.VerboseOut('Found active client: {0:s}'.format(
+        active_client_id))
+    self.console_out.VerboseOut(
+        'Client last seen: {0:s} ({1:d} minutes ago)'.format(
+            last_seen_datetime.strftime('%Y-%m-%dT%H:%M:%S+0000'),
+            last_seen_minutes))
+
+    return active_client_id
+
+  def _GetClient(self, client_id, reason, approvers):
+    """Get GRR client dictionary and make sure valid approvals exist.
+
+    Args:
+      client_id: GRR client ID
+      reason: justification for GRR access
+      approvers: comma-separated list of GRR approval recipients
+
+    Returns:
+      GRR API Client object
+
+    Raises:
+      ValueError: if no approvals exist and no approvers are specified
+    """
+    client = self.grr_api.Client(client_id)
+    self.console_out.VerboseOut('Checking for client approval')
+    try:
+      client.ListFlows()
+    except grr_errors.AccessForbiddenError:
+      syslog.syslog('{0:s}: No valid client approval found'.format(client_id))
+      self.console_out.VerboseOut('No valid client approval found')
+      if not approvers:
+        raise ValueError(
+            'GRR client needs approval but no approvers specified '
+            '(hint: use --approvers)')
+      self.console_out.VerboseOut(
+          'Client approval request sent to: {0:s} (reason: {1:s})'.format(
+              approvers, reason))
+      self.console_out.VerboseOut(
+          'Waiting for approval (this can take a while...)')
+      # Send a request for approval and wait until there is a valid one
+      # available in GRR.
+      client.CreateApproval(reason=reason, notified_users=approvers)
+      syslog.syslog('{0:s}: Request for client approval sent'.format(
+          client_id))
+      while True:
+        try:
+          client.ListFlows()
+          break
+        except grr_errors.AccessForbiddenError:
+          time.sleep(self._CHECK_APPROVAL_INTERVAL_SEC)
+
+    syslog.syslog('{0:s}: Client approval is valid'.format(client_id))
+    self.console_out.VerboseOut('Client approval is valid')
+    return client.Get()
+
+  def _LaunchFlow(self, name, args):
+    """Create specified flow, setting KeepAlive if requested.
+
+    Args:
+      name: string containing flow name
+      args: proto (*FlowArgs) for type of flow, as defined in GRR flow proto
+
+    Returns:
+      string containing ID of launched flow
+    """
+    # Start the flow and get the flow ID
+    flow = self._client.CreateFlow(name=name, args=args)
+    flow_id = flow.flow_id
+    syslog.syslog('Flow {0:s}: Scheduled'.format(flow_id))
+    self.console_out.VerboseOut('Flow {0:s}: Scheduled'.format(flow_id))
+
+    if self.keepalive:
+      flow_name = 'KeepAlive'
+      flow_args = flows_pb2.KeepAliveArgs()
+      keepalive_flow = self._client.CreateFlow(name=flow_name, args=flow_args)
+      syslog.syslog('KeepAlive scheduled')
+      self.console_out.VerboseOut('KeepAlive Flow:{0:s} scheduled'.format(
+          keepalive_flow.flow_id))
+
+    return flow_id
+
+  def _AwaitFlow(self, flow_id):
+    """Awaits flow completion.
+
+    Args:
+      flow_id: string containing ID of flow to await
+
+    Raises:
+      RuntimeError: if flow error encountered
+    """
+    # Wait for the flow to finish
+    self.console_out.VerboseOut('Flow {0:s}: Waiting to finish'.format(
+        flow_id))
+    while True:
+      try:
+        status = self._client.Flow(flow_id).Get().data
+      except grr_errors.UnknownError:
+        raise RuntimeError('Unable to stat flow {0:s} for host {1:s}'.format(
+            flow_id, self.host))
+      state = status.state
+      if state == flows_pb2.FlowContext.ERROR:
+        # TODO(jbn): If one artifact fails, what happens? Test.
+        raise RuntimeError('Flow {0:s}: FAILED! Backtrace from GRR:\n\n{1:s}'.
+                           format(flow_id, status.context.backtrace))
+      elif state == flows_pb2.FlowContext.TERMINATED:
+        syslog.syslog('Flow {0:s}: Complete'.format(flow_id))
+        self.console_out.VerboseOut('Flow {0:s}: Finished successfully'.format(
+            flow_id))
+        break
+      time.sleep(self._CHECK_FLOW_INTERVAL_SEC)
+
+    # Download the files collected by the flow
+    syslog.syslog('Flow {0:s}: Downloading artifacts'.format(
+        flow_id))
+    self.console_out.VerboseOut('Flow {0:s}: Downloading artifacts'.format(
+        flow_id))
+    collected_file_path = self._DownloadFiles(flow_id)
+
+    if collected_file_path:
+      syslog.syslog('Flow {0:s}: Downloaded artifacts'.format(flow_id))
+      self.console_out.VerboseOut('Flow {0:s}: Downloaded: {1:s}'.format(
+          flow_id, collected_file_path))
+
+  def PrintStatus(self):
+    """Print status of flow.
+
+    Raises:
+      RuntimeError: if error encountered getting flow data
+    """
+    self._client = self._GetClient(self._client_id, self.reason, self.approvers)
+    try:
+      status = self._client.Flow(self.flow_id).Get().data
+    except grr_errors.UnknownError:
+      raise RuntimeError('Unable to stat flow {0:s} for host {1:s}'.format(
+          self.flow_id, self.host))
+
+    state = status.state
+    if state == flows_pb2.FlowContext.ERROR:
+      msg = 'ERROR'
+    elif state == flows_pb2.FlowContext.TERMINATED:
+      msg = 'Complete'
+    elif state == flows_pb2.FlowContext.RUNNING:
+      msg = 'Running...'
+    self.console_out.StdOut('Status of flow {0:s}: {1:s}\n'.format(
+        self.flow_id, msg))
+
+  def _DownloadFiles(self, flow_id):
+    """Download files from the specified flow.
+
+    Args:
+      flow_id: GRR flow ID
+
+    Returns:
+      str: path of downloaded files
+    """
+    if not os.path.isdir(self.output_path):
+      os.makedirs(self.output_path)
+
+    output_file_path = os.path.join(self.output_path, '.'.join(
+        (flow_id, 'zip')))
+
+    if os.path.exists(output_file_path):
+      self.console_out.StdOut('{0:s} already exists: Skipping'.format(
+          output_file_path))
+      return None
+
+    flow = self._client.Flow(flow_id)
+    file_archive = flow.GetFilesArchive()
+    file_archive.WriteToFile(output_file_path)
+
+    # Unzip archive for processing and remove redundant zip
+    with zipfile.ZipFile(output_file_path) as archive:
+      archive.extractall(path=self.output_path)
+    os.remove(output_file_path)
+
+    return output_file_path
+
+  @property
+  def collection_name(self):
+    """Name for the collection of collected artifacts."""
+    collection_name = self._client.data.os_info.fqdn
+    self.console_out.VerboseOut('Artifact collection name: {0:s}'.format(
+        collection_name))
+    return self._client.data.os_info.fqdn
+
+  @staticmethod
+  def launch_collector(hosts,
+                       flow_id,
+                       reason,
+                       grr_server_url,
+                       grr_auth,
+                       artifact_list=None,
+                       file_list=None,
+                       use_tsk=False,
+                       approvers=None,
+                       verbose=False,
+                       keepalive=False,
+                       status=False):
+    """Launches a series of GRR Artifact collectors.
+
+    Iterates over the values of hosts and starts a GRRArtifactCollector
+    for each.
+
+    Args:
+      hosts: List of strings representing hosts to collect artifacts from
+      flow_id: ID of GRR flow to retrieve artifacts from
+      reason: justification for GRR access (usually a SEM ID)
+      grr_server_url: GRR server url
+      grr_auth: Tuple containing a (username, password) combination
+      artifact_list: comma-separated list of GRR-defined artifacts
+      file_list: comma-separated list of GRR file paths
+      use_tsk: toggle for use_tsk flag on GRR flow
+      approvers: comma-separated list of GRR approval recipients
+      verbose: toggle for verbose output
+      keepalive: toggle for scheduling a KeepAlive flow
+      status: print the status of each collector
+
+    Returns:
+      A list of started collectors for each path
+    """
+    collectors = []
+    for hostname in hosts.split(','):
+      host_collectors = []
+      # Launch artifact collector if artifacts present or if no file/flow passed
+      if artifact_list or not (file_list or flow_id):
+        host_collectors.append(GRRArtifactCollector(
+            hostname,
+            reason,
+            grr_server_url,
+            grr_auth,
+            artifact_list,
+            use_tsk,
+            approvers,
+            verbose=verbose,
+            keepalive=keepalive))
+      if file_list:
+        host_collectors.append(GRRFileCollector(
+            hostname,
+            reason,
+            grr_server_url,
+            grr_auth,
+            file_list,
+            approvers,
+            verbose=verbose,
+            keepalive=keepalive))
+      if flow_id:
+        host_collectors.append(GRRFlowCollector(
+            hostname,
+            reason,
+            grr_server_url,
+            grr_auth,
+            flow_id,
+            approvers,
+            verbose=verbose))
+
+      for collector in host_collectors:
+        if flow_id and status:
+          collector.PrintStatus()
+        else:
+          collector.start()
+          collectors.append(collector)
+
+    return collectors
+
+
+class GRRArtifactCollector(GRRHostCollector):
+  """Artifact collector for GRR flows.
+
+  Attributes:
+    output_path: Path to where to store collected items
+    grr_api: GRR HTTP API client
+    host: Target of GRR collection
+    artifacts: comma-separated list of GRR-defined artifacts
+    use_tsk: Toggle for use_tsk flag on GRR flow
+    reason: Justification for GRR access
+    approvers: list of GRR approval recipients
+  """
+  _DEFAULT_ARTIFACTS_LINUX = ['LinuxAuditLogs',
+                              'LinuxAuthLogs',
+                              'LinuxCronLogs',
+                              'LinuxWtmp',
+                              'AllUsersShellHistory',
+                              'ZeitgeistDatabase'
+                             ]  # pyformat: disable
+
+  _DEFAULT_ARTIFACTS_DARWIN = ['OSXAppleSystemLogs',
+                               'OSXAuditLogs',
+                               'OSXBashHistory',
+                               'OSXInstallationHistory',
+                               'OSXInstallationLog',
+                               'OSXInstallationTime',
+                               'OSXLaunchAgents',
+                               'OSXLaunchDaemons',
+                               'OSXMiscLogs',
+                               'OSXRecentItems',
+                               'OSXSystemLogs',
+                               'OSXUserApplicationLogs',
+                               'OSXQuarantineEvents'
+                              ]  # pyformat: disable
+
+  _DEFAULT_ARTIFACTS_WINDOWS = ['WindowsAppCompatCache',
+                                'WindowsEventLogs',
+                                'WindowsPrefetchFiles',
+                                'WindowsScheduledTasks',
+                                'WindowsSearchDatabase',
+                                'WindowsSuperFetchFiles',
+                                'WindowsSystemRegistryFiles',
+                                'WindowsUserRegistryFiles',
+                                'WindowsXMLEventLogTerminalServices'
+                               ]  # pyformat: disable
+
+  def __init__(self,
+               hostname,
+               reason,
+               grr_server_url,
+               grr_auth,
+               artifacts=None,
+               use_tsk=False,
+               approvers=None,
+               verbose=False,
+               keepalive=False):
+    """Initializes a GRR artifact collector.
+
+    Args:
+      hostname: hostname of machine
+      reason: justification for GRR access
+      grr_server_url: GRR server url
+      grr_auth: Tuple containing a (username, password) combination
+      artifacts: comma-separated list of GRR-defined artifacts
+      use_tsk: toggle for use_tsk flag on GRR flow
+      approvers: comma-separated list of GRR approval recipients
+      verbose: toggle for verbose output
+      keepalive: toggle for scheduling a KeepAlive flow
+    """
+    super(GRRArtifactCollector, self).__init__(hostname,
+                                               reason,
+                                               grr_server_url,
+                                               grr_auth,
+                                               approvers=approvers,
+                                               verbose=verbose,
+                                               keepalive=keepalive)
+    self.artifacts = artifacts
+    self.use_tsk = use_tsk
+
+  def collect(self):
+    """Collect the artifacts.
+
+    Returns:
+      list of tuples containing:
+          str: human-readable description of the source of the collection. For
+              example, the name of the source host.
+          str: path to the collected data.
+
+    Raises:
+      RuntimeError: if no artifacts specified nor resolved by platform
+    """
+    self._client = self._GetClient(self._client_id, self.reason, self.approvers)
+
+    # Create a list of artifacts to collect.
+    artifact_registry = {
+        'Linux': self._DEFAULT_ARTIFACTS_LINUX,
+        'Darwin': self._DEFAULT_ARTIFACTS_DARWIN,
+        'Windows': self._DEFAULT_ARTIFACTS_WINDOWS
+    }
+    system_type = self._client.data.os_info.system
+    self.console_out.VerboseOut('System type: {0:s}'.format(system_type))
+
+    # If the list is supplied by the user via a flag, honor that.
+    if self.artifacts:
+      syslog.syslog('Artifacts to be collected: {0:s}'.format(
+          self.artifacts))
+      artifact_list = self.artifacts.split(',')
+    else:
+      syslog.syslog('Artifacts to be collected: Default')
+      artifact_list = artifact_registry.get(system_type, None)
+
+    if not artifact_list:
+      raise RuntimeError('No artifacts to collect')
+    flow_name = 'ArtifactCollectorFlow'
+    flow_args = flows_pb2.ArtifactCollectorFlowArgs(
+        artifact_list=artifact_list,
+        use_tsk=self.use_tsk,
+        ignore_interpolation_errors=True,
+        apply_parsers=False,)
+    self.console_out.VerboseOut('Artifacts to collect: {0:s}'.format(
+        artifact_list))
+    flow_id = self._LaunchFlow(flow_name, flow_args)
+    self._AwaitFlow(flow_id)
+    return [(self.host, self.output_path)]
+
+
+class GRRFileCollector(GRRHostCollector):
+  """File collector for GRR flows.
+
+  Attributes:
+    output_path: Path to where to store collected items
+    grr_api: GRR HTTP API client
+    host: Target of GRR collection
+    files: comma-separated list of file paths
+    reason: Justification for GRR access
+    approvers: list of GRR approval recipients
+    client_id: GRR client ID
+    client: Dictionary with information about a GRR client
+  """
+
+  def __init__(self,
+               hostname,
+               reason,
+               grr_server_url,
+               grr_auth,
+               files=None,
+               approvers=None,
+               verbose=False,
+               keepalive=False):
+    """Initializes a GRR file collector.
+
+    Args:
+      hostname: hostname of machine
+      reason: justification for GRR access
+      grr_server_url: GRR server url
+      grr_auth: Tuple containing a (username, password) combination
+      files: comma-separated list of file paths
+      approvers: comma-separated list of GRR approval recipients
+      verbose: toggle for verbose output
+      keepalive: toggle for scheduling a KeepAlive flow
+    """
+    super(GRRFileCollector, self).__init__(hostname, reason, grr_server_url,
+                                           grr_auth=grr_auth,
+                                           approvers=approvers,
+                                           verbose=verbose,
+                                           keepalive=keepalive)
+    self.files = files
+
+  def collect(self):
+    """Collect the files.
+
+    Returns:
+      list of tuples containing:
+          str: human-readable description of the source of the collection. For
+              example, the name of the source host.
+          str: path to the collected data.
+
+    Raises:
+      RuntimeError: if no files specified
+    """
+    self._client = self._GetClient(self._client_id, self.reason, self.approvers)
+
+    file_list = self.files.split(',')
+    if not file_list:
+      raise RuntimeError('File paths must be specified for FileFinder')
+    syslog.syslog('Filefinder to collect {0:d} items'.format(len(file_list)))
+    self.console_out.VerboseOut('Files to be collected: {0:s}'.format(
+        self.files))
+    flow_name = 'FileFinder'
+    flow_action = flows_pb2.FileFinderAction(
+        action_type=flows_pb2.FileFinderAction.DOWNLOAD,)
+    flow_args = flows_pb2.FileFinderArgs(
+        paths=file_list,
+        action=flow_action,)
+    flow_id = self._LaunchFlow(flow_name, flow_args)
+    self._AwaitFlow(flow_id)
+    return [(self.host, self.output_path)]
+
+
+class GRRFlowCollector(GRRHostCollector):
+  """Flow collector.
+
+  Attributes:
+    output_path: Path to where to store collected items
+    grr_api: GRR HTTP API client
+    host: Target of GRR collection
+    flow_id: ID of GRR flow to retrieve
+    reason: Justification for GRR access
+    approvers: list of GRR approval recipients
+    client_id: GRR client ID
+    client: Dictionary with information about a GRR client
+  """
+
+  def __init__(self,
+               hostname,
+               reason,
+               grr_server_url,
+               grr_auth,
+               flow_id=None,
+               approvers=None,
+               verbose=False):
+    """Initializes a GRR flow collector.
+
+    Args:
+      hostname: hostname of machine
+      reason: justification for GRR access
+      grr_server_url: GRR server url
+      grr_auth: Tuple containing a (username, password) combination
+      flow_id: ID of GRR flow to retrieve
+      approvers: comma-separated list of GRR approval recipients
+      verbose: toggle for verbose output
+    """
+    super(GRRFlowCollector, self).__init__(hostname, reason, grr_server_url,
+                                           grr_auth,
+                                           approvers=approvers,
+                                           verbose=verbose)
+    self.flow_id = flow_id
+
+  def collect(self):
+    """Collect the results.
+
+    Returns:
+      list: containing:
+          str: human-readable description of the source of the collection. For
+              example, the name of the source host.
+          str: path to the collected data.
+
+    Raises:
+      RuntimeError: if no files specified
+    """
+    self._client = self._GetClient(self._client_id, self.reason, self.approvers)
+    self._AwaitFlow(self.flow_id)
+    return [(self.host, self.output_path)]
+
+
+MODCLASS = [
+    ('google_grr_hunt_collector', GRRHuntCollector),
+    ('google_grr_hunt_artifact_collector', GRRHuntArtifactCollector),
+    ('google_grr_hunt_file_collector', GRRHuntFileCollector),
+    ('google_grr_hunt_downloader', GRRHuntDownloader),
+    ('google_grr_host_collector', GRRHostCollector),
+    ('google_grr_artifact_collector', GRRArtifactCollector),
+    ('google_grr_file_collector', GRRFileCollector),
+    ('google_grr_flow_collector', GRRFlowCollector)
+]

--- a/dftimewolf/lib/collectors/grr.py
+++ b/dftimewolf/lib/collectors/grr.py
@@ -10,7 +10,6 @@ import zipfile
 
 from dftimewolf.lib.collectors.collectors import BaseCollector
 
-
 from grr_api_client import errors as grr_errors
 from grr_api_client import api as grr_api
 from grr_api_client.proto.grr.proto import flows_pb2
@@ -27,12 +26,8 @@ class GRRHuntCollector(BaseCollector):
   """
   _CHECK_APPROVAL_INTERVAL_SEC = 10
 
-  def __init__(self,
-               reason,
-               grr_server_url,
-               grr_auth,
-               approvers=None,
-               verbose=False):
+  def __init__(
+      self, reason, grr_server_url, grr_auth, approvers=None, verbose=False):
     """Initializes a GRR hunt results collector.
 
     Args:
@@ -76,8 +71,9 @@ class GRRHuntCollector(BaseCollector):
       syslog.syslog('Hunt {0:s}: No valid hunt approval found'.format(hunt_id))
       self.console_out.VerboseOut('No valid hunt approval found')
       if not self.approvers:
-        raise ValueError('GRR hunt needs approval but no approvers specified '
-                         '(hint: use --approvers)')
+        raise ValueError(
+            'GRR hunt needs approval but no approvers specified '
+            '(hint: use --approvers)')
       self.console_out.VerboseOut(
           'Hunt {0:s}: approval request sent to: {1:s} (reason: {2:s})'.format(
               hunt_id, self.approvers, self.reason))
@@ -87,8 +83,8 @@ class GRRHuntCollector(BaseCollector):
       # Send a request for approval and wait until there is a valid one
       # available in GRR.
       hunt.CreateApproval(reason=self.reason, notified_users=self.approvers)
-      syslog.syslog('Hunt {0:s}: Request for hunt approval sent'.format(
-          hunt_id))
+      syslog.syslog(
+          'Hunt {0:s}: Request for hunt approval sent'.format(hunt_id))
       while True:
         try:
           hunt.Start()
@@ -112,8 +108,8 @@ class GRRHuntCollector(BaseCollector):
     if not os.path.isdir(self.output_path):
       os.makedirs(self.output_path)
 
-    output_file_path = os.path.join(self.output_path, '.'.join(
-        (self.hunt_id, 'zip')))
+    output_file_path = os.path.join(
+        self.output_path, '.'.join((self.hunt_id, 'zip')))
 
     if os.path.exists(output_file_path):
       self.console_out.StdOut(
@@ -123,15 +119,17 @@ class GRRHuntCollector(BaseCollector):
     try:
       self._hunt.GetFilesArchive().WriteToFile(output_file_path)
       syslog.syslog('Hunt {0:s}: Results downloaded'.format(self.hunt_id))
-      self.console_out.VerboseOut('Hunt {0:s}: Downloaded: {1:s}'.format(
-          self.hunt_id, output_file_path))
+      self.console_out.VerboseOut(
+          'Hunt {0:s}: Downloaded: {1:s}'.format(
+              self.hunt_id, output_file_path))
     except grr_errors.AccessForbiddenError:
-      syslog.syslog('Hunt {0:s}: No valid hunt approval found'.format(
-          self.hunt_id))
+      syslog.syslog(
+          'Hunt {0:s}: No valid hunt approval found'.format(self.hunt_id))
       self.console_out.VerboseOut('No valid hunt approval found')
       if not self.approvers:
-        raise ValueError('GRR hunt needs approval but no approvers specified '
-                         '(hint: use --approvers)')
+        raise ValueError(
+            'GRR hunt needs approval but no approvers specified '
+            '(hint: use --approvers)')
       self.console_out.VerboseOut(
           'Hunt {0:s}: approval request sent to: {1:s} (reason: {2:s})'.format(
               self.hunt_id, self.approvers, self.reason))
@@ -142,8 +140,8 @@ class GRRHuntCollector(BaseCollector):
       # available in GRR.
       self._hunt.CreateApproval(
           reason=self.reason, notified_users=self.approvers)
-      syslog.syslog('Hunt {0:s}: Request for hunt approval sent'.format(
-          self.hunt_id))
+      syslog.syslog(
+          'Hunt {0:s}: Request for hunt approval sent'.format(self.hunt_id))
       while True:
         try:
           hunt_archive = self._hunt.GetFilesArchive()
@@ -152,8 +150,9 @@ class GRRHuntCollector(BaseCollector):
               'Hunt {0:s}: Downloaded results to {1:s}'.format(
                   self.hunt_id, output_file_path))
           syslog.syslog('Hunt {0:s}: Results downloaded'.format(self.hunt_id))
-          self.console_out.VerboseOut('Hunt {0:s}: Downloaded: {1:s}'.format(
-              self.hunt_id, output_file_path))
+          self.console_out.VerboseOut(
+              'Hunt {0:s}: Downloaded: {1:s}'.format(
+                  self.hunt_id, output_file_path))
           break
         except grr_errors.AccessForbiddenError:
           time.sleep(self._CHECK_APPROVAL_INTERVAL_SEC)
@@ -184,8 +183,8 @@ class GRRHuntCollector(BaseCollector):
           if not os.path.isdir(client_directory):
             os.makedirs(client_directory)
           collection_paths.append((client_name, client_directory))
-          real_file_path = os.path.join(base, 'hashes',
-                                        os.path.basename(archive.read(f)))
+          real_file_path = os.path.join(
+              base, 'hashes', os.path.basename(archive.read(f)))
           try:
             archive.extract(real_file_path, client_directory)
             os.rename(
@@ -213,8 +212,8 @@ class GRRHuntCollector(BaseCollector):
     """Name for the collection of collected artifacts."""
     collection_name = '{0:s}: {1:s}'.format(
         self.hunt_id, self._hunt.data.hunt_runner_args.description)
-    self.console_out.VerboseOut('Artifact collection name: {0:s}'.format(
-        collection_name))
+    self.console_out.VerboseOut(
+        'Artifact collection name: {0:s}'.format(collection_name))
     return collection_name
 
 
@@ -230,14 +229,15 @@ class GRRHuntArtifactCollector(GRRHuntCollector):
     use_tsk: toggle for use_tsk flag
   """
 
-  def __init__(self,
-               reason,
-               grr_server_url,
-               grr_auth,
-               artifacts,
-               use_tsk,
-               approvers=None,
-               verbose=False):
+  def __init__(
+      self,
+      reason,
+      grr_server_url,
+      grr_auth,
+      artifacts,
+      use_tsk,
+      approvers=None,
+      verbose=False):
     """Initializes a GRR Hunt artifact collector.
 
     Args:
@@ -249,8 +249,8 @@ class GRRHuntArtifactCollector(GRRHuntCollector):
       approvers: str, comma-separated list of GRR approval recipients
       verbose: toggle for verbose output
     """
-    super(GRRHuntCollector, self).__init__(reason, grr_server_url, grr_auth,
-                                           approvers=approvers, verbose=verbose)
+    super(GRRHuntCollector, self).__init__(
+        reason, grr_server_url, grr_auth, approvers=approvers, verbose=verbose)
     self.artifacts = artifacts
     self.use_tsk = use_tsk
     self.hunt_id = self._NewHunt()
@@ -301,13 +301,14 @@ class GRRHuntFileCollector(GRRHuntCollector):
     files: comma-separated list of file paths
   """
 
-  def __init__(self,
-               reason,
-               grr_server_url,
-               grr_auth,
-               file_list,
-               approvers=None,
-               verbose=False):
+  def __init__(
+      self,
+      reason,
+      grr_server_url,
+      grr_auth,
+      file_list,
+      approvers=None,
+      verbose=False):
     """Initializes a GRR Hunt file collector.
 
     Args:
@@ -338,8 +339,8 @@ class GRRHuntFileCollector(GRRHuntCollector):
       raise RuntimeError('File must be specified for hunts')
 
     syslog.syslog('Hunt to collect {0:d} items'.format(len(self.file_list)))
-    self.console_out.VerboseOut('Files to be collected: {0:s}'.format(
-        self.file_list))
+    self.console_out.VerboseOut(
+        'Files to be collected: {0:s}'.format(self.file_list))
     hunt_name = 'FileFinder'
 
     hunt_action = flows_pb2.FileFinderAction(
@@ -351,15 +352,22 @@ class GRRHuntFileCollector(GRRHuntCollector):
     return self._StartHunt(hunt_name, hunt_args)
 
   @staticmethod
-  def launch_collector(reason, grr_server_url, grr_auth, file_list,
-                       approvers=None,
-                       verbose=False):
+  def launch_collector(
+      reason,
+      grr_server_url,
+      grr_auth,
+      file_list,
+      approvers=None,
+      verbose=False):
     """Start a file collector Hunt"""
     hunt = GRRHuntFileCollector(
         reason, grr_server_url, grr_auth, file_list, approvers, verbose)
-    hunt.console_out.StdOut("\nHunt {0:s} created succesfully!")
-    hunt.console_out.StdOut("Go grab some coffee while it completes and run a GRRHuntDownloader recipe to fetch results.".format(hunt.hunt_id))
-    hunt.console_out.StdOut("e.g. $ dftimewolf huntresults_plaso_timesketch {0:s}\n".format(hunt.hunt_id))
+    hunt.console_out.StdOut(
+        "\nHunt {0:s} created succesfully!".format(hunt.hunt_id))
+    hunt.console_out.StdOut("Run a GRRHuntDownloader recipe to fetch results.")
+    hunt.console_out.StdOut(
+        "e.g. $ dftimewolf huntresults_plaso_timesketch {0:s}\n".format(
+            hunt.hunt_id))
 
     return []
 
@@ -375,13 +383,14 @@ class GRRHuntDownloader(GRRHuntCollector):
     hunt_id: ID of GRR hunt to retrieve results from
   """
 
-  def __init__(self,
-               reason,
-               grr_server_url,
-               grr_auth,
-               hunt_id,
-               approvers=None,
-               verbose=False):
+  def __init__(
+      self,
+      reason,
+      grr_server_url,
+      grr_auth,
+      hunt_id,
+      approvers=None,
+      verbose=False):
     """Initializes a GRR hunt results collector.
 
     Args:
@@ -398,12 +407,8 @@ class GRRHuntDownloader(GRRHuntCollector):
     self._hunt = self.grr_api.Hunt(self.hunt_id).Get()
 
   @staticmethod
-  def launch_collector(reason,
-                       grr_server_url,
-                       grr_auth,
-                       hunt_id,
-                       approvers=None,
-                       verbose=False):
+  def launch_collector(
+      reason, grr_server_url, grr_auth, hunt_id, approvers=None, verbose=False):
     """Launch downloads of files previously hunted for,"""
     hunt_downloader = GRRHuntDownloader(
         reason, grr_server_url, grr_auth, hunt_id, approvers, verbose)
@@ -424,14 +429,15 @@ class GRRHostCollector(BaseCollector):
   _CHECK_APPROVAL_INTERVAL_SEC = 10
   _CHECK_FLOW_INTERVAL_SEC = 10
 
-  def __init__(self,
-               hostname,
-               reason,
-               grr_server_url,
-               grr_auth,
-               approvers=None,
-               verbose=False,
-               keepalive=False):
+  def __init__(
+      self,
+      hostname,
+      reason,
+      grr_server_url,
+      grr_auth,
+      approvers=None,
+      verbose=False,
+      keepalive=False):
     """Initializes a GRR collector.
 
     Args:
@@ -497,8 +503,8 @@ class GRRHostCollector(BaseCollector):
     last_seen_minutes = int(round(last_seen_seconds)) / 60
 
     syslog.syslog('{0:s}: Found active client'.format(active_client_id))
-    self.console_out.VerboseOut('Found active client: {0:s}'.format(
-        active_client_id))
+    self.console_out.VerboseOut(
+        'Found active client: {0:s}'.format(active_client_id))
     self.console_out.VerboseOut(
         'Client last seen: {0:s} ({1:d} minutes ago)'.format(
             last_seen_datetime.strftime('%Y-%m-%dT%H:%M:%S+0000'),
@@ -539,8 +545,7 @@ class GRRHostCollector(BaseCollector):
       # Send a request for approval and wait until there is a valid one
       # available in GRR.
       client.CreateApproval(reason=reason, notified_users=approvers)
-      syslog.syslog('{0:s}: Request for client approval sent'.format(
-          client_id))
+      syslog.syslog('{0:s}: Request for client approval sent'.format(client_id))
       while True:
         try:
           client.ListFlows()
@@ -573,8 +578,8 @@ class GRRHostCollector(BaseCollector):
       flow_args = flows_pb2.KeepAliveArgs()
       keepalive_flow = self._client.CreateFlow(name=flow_name, args=flow_args)
       syslog.syslog('KeepAlive scheduled')
-      self.console_out.VerboseOut('KeepAlive Flow:{0:s} scheduled'.format(
-          keepalive_flow.flow_id))
+      self.console_out.VerboseOut(
+          'KeepAlive Flow:{0:s} scheduled'.format(keepalive_flow.flow_id))
 
     return flow_id
 
@@ -588,37 +593,37 @@ class GRRHostCollector(BaseCollector):
       RuntimeError: if flow error encountered
     """
     # Wait for the flow to finish
-    self.console_out.VerboseOut('Flow {0:s}: Waiting to finish'.format(
-        flow_id))
+    self.console_out.VerboseOut('Flow {0:s}: Waiting to finish'.format(flow_id))
     while True:
       try:
         status = self._client.Flow(flow_id).Get().data
       except grr_errors.UnknownError:
-        raise RuntimeError('Unable to stat flow {0:s} for host {1:s}'.format(
-            flow_id, self.host))
+        raise RuntimeError(
+            'Unable to stat flow {0:s} for host {1:s}'.format(
+                flow_id, self.host))
       state = status.state
       if state == flows_pb2.FlowContext.ERROR:
         # TODO(jbn): If one artifact fails, what happens? Test.
-        raise RuntimeError('Flow {0:s}: FAILED! Backtrace from GRR:\n\n{1:s}'.
-                           format(flow_id, status.context.backtrace))
+        raise RuntimeError(
+            'Flow {0:s}: FAILED! Backtrace from GRR:\n\n{1:s}'.format(
+                flow_id, status.context.backtrace))
       elif state == flows_pb2.FlowContext.TERMINATED:
         syslog.syslog('Flow {0:s}: Complete'.format(flow_id))
-        self.console_out.VerboseOut('Flow {0:s}: Finished successfully'.format(
-            flow_id))
+        self.console_out.VerboseOut(
+            'Flow {0:s}: Finished successfully'.format(flow_id))
         break
       time.sleep(self._CHECK_FLOW_INTERVAL_SEC)
 
     # Download the files collected by the flow
-    syslog.syslog('Flow {0:s}: Downloading artifacts'.format(
-        flow_id))
-    self.console_out.VerboseOut('Flow {0:s}: Downloading artifacts'.format(
-        flow_id))
+    syslog.syslog('Flow {0:s}: Downloading artifacts'.format(flow_id))
+    self.console_out.VerboseOut(
+        'Flow {0:s}: Downloading artifacts'.format(flow_id))
     collected_file_path = self._DownloadFiles(flow_id)
 
     if collected_file_path:
       syslog.syslog('Flow {0:s}: Downloaded artifacts'.format(flow_id))
-      self.console_out.VerboseOut('Flow {0:s}: Downloaded: {1:s}'.format(
-          flow_id, collected_file_path))
+      self.console_out.VerboseOut(
+          'Flow {0:s}: Downloaded: {1:s}'.format(flow_id, collected_file_path))
 
   def PrintStatus(self):
     """Print status of flow.
@@ -630,8 +635,9 @@ class GRRHostCollector(BaseCollector):
     try:
       status = self._client.Flow(self.flow_id).Get().data
     except grr_errors.UnknownError:
-      raise RuntimeError('Unable to stat flow {0:s} for host {1:s}'.format(
-          self.flow_id, self.host))
+      raise RuntimeError(
+          'Unable to stat flow {0:s} for host {1:s}'.format(
+              self.flow_id, self.host))
 
     state = status.state
     if state == flows_pb2.FlowContext.ERROR:
@@ -640,8 +646,8 @@ class GRRHostCollector(BaseCollector):
       msg = 'Complete'
     elif state == flows_pb2.FlowContext.RUNNING:
       msg = 'Running...'
-    self.console_out.StdOut('Status of flow {0:s}: {1:s}\n'.format(
-        self.flow_id, msg))
+    self.console_out.StdOut(
+        'Status of flow {0:s}: {1:s}\n'.format(self.flow_id, msg))
 
   def _DownloadFiles(self, flow_id):
     """Download files from the specified flow.
@@ -655,12 +661,12 @@ class GRRHostCollector(BaseCollector):
     if not os.path.isdir(self.output_path):
       os.makedirs(self.output_path)
 
-    output_file_path = os.path.join(self.output_path, '.'.join(
-        (flow_id, 'zip')))
+    output_file_path = os.path.join(
+        self.output_path, '.'.join((flow_id, 'zip')))
 
     if os.path.exists(output_file_path):
-      self.console_out.StdOut('{0:s} already exists: Skipping'.format(
-          output_file_path))
+      self.console_out.StdOut(
+          '{0:s} already exists: Skipping'.format(output_file_path))
       return None
 
     flow = self._client.Flow(flow_id)
@@ -678,23 +684,24 @@ class GRRHostCollector(BaseCollector):
   def collection_name(self):
     """Name for the collection of collected artifacts."""
     collection_name = self._client.data.os_info.fqdn
-    self.console_out.VerboseOut('Artifact collection name: {0:s}'.format(
-        collection_name))
+    self.console_out.VerboseOut(
+        'Artifact collection name: {0:s}'.format(collection_name))
     return self._client.data.os_info.fqdn
 
   @staticmethod
-  def launch_collector(hosts,
-                       flow_id,
-                       reason,
-                       grr_server_url,
-                       grr_auth,
-                       artifact_list=None,
-                       file_list=None,
-                       use_tsk=False,
-                       approvers=None,
-                       verbose=False,
-                       keepalive=False,
-                       status=False):
+  def launch_collector(
+      hosts,
+      flow_id,
+      reason,
+      grr_server_url,
+      grr_auth,
+      artifact_list=None,
+      file_list=None,
+      use_tsk=False,
+      approvers=None,
+      verbose=False,
+      keepalive=False,
+      status=False):
     """Launches a series of GRR Artifact collectors.
 
     Iterates over the values of hosts and starts a GRRArtifactCollector
@@ -722,35 +729,38 @@ class GRRHostCollector(BaseCollector):
       host_collectors = []
       # Launch artifact collector if artifacts present or if no file/flow passed
       if artifact_list or not (file_list or flow_id):
-        host_collectors.append(GRRArtifactCollector(
-            hostname,
-            reason,
-            grr_server_url,
-            grr_auth,
-            artifact_list,
-            use_tsk,
-            approvers,
-            verbose=verbose,
-            keepalive=keepalive))
+        host_collectors.append(
+            GRRArtifactCollector(
+                hostname,
+                reason,
+                grr_server_url,
+                grr_auth,
+                artifact_list,
+                use_tsk,
+                approvers,
+                verbose=verbose,
+                keepalive=keepalive))
       if file_list:
-        host_collectors.append(GRRFileCollector(
-            hostname,
-            reason,
-            grr_server_url,
-            grr_auth,
-            file_list,
-            approvers,
-            verbose=verbose,
-            keepalive=keepalive))
+        host_collectors.append(
+            GRRFileCollector(
+                hostname,
+                reason,
+                grr_server_url,
+                grr_auth,
+                file_list,
+                approvers,
+                verbose=verbose,
+                keepalive=keepalive))
       if flow_id:
-        host_collectors.append(GRRFlowCollector(
-            hostname,
-            reason,
-            grr_server_url,
-            grr_auth,
-            flow_id,
-            approvers,
-            verbose=verbose))
+        host_collectors.append(
+            GRRFlowCollector(
+                hostname,
+                reason,
+                grr_server_url,
+                grr_auth,
+                flow_id,
+                approvers,
+                verbose=verbose))
 
       for collector in host_collectors:
         if flow_id and status:
@@ -774,50 +784,36 @@ class GRRArtifactCollector(GRRHostCollector):
     reason: Justification for GRR access
     approvers: list of GRR approval recipients
   """
-  _DEFAULT_ARTIFACTS_LINUX = ['LinuxAuditLogs',
-                              'LinuxAuthLogs',
-                              'LinuxCronLogs',
-                              'LinuxWtmp',
-                              'AllUsersShellHistory',
-                              'ZeitgeistDatabase'
-                             ]  # pyformat: disable
+  _DEFAULT_ARTIFACTS_LINUX = [
+      'LinuxAuditLogs', 'LinuxAuthLogs', 'LinuxCronLogs', 'LinuxWtmp',
+      'AllUsersShellHistory', 'ZeitgeistDatabase'
+  ]  # pyformat: disable
 
-  _DEFAULT_ARTIFACTS_DARWIN = ['OSXAppleSystemLogs',
-                               'OSXAuditLogs',
-                               'OSXBashHistory',
-                               'OSXInstallationHistory',
-                               'OSXInstallationLog',
-                               'OSXInstallationTime',
-                               'OSXLaunchAgents',
-                               'OSXLaunchDaemons',
-                               'OSXMiscLogs',
-                               'OSXRecentItems',
-                               'OSXSystemLogs',
-                               'OSXUserApplicationLogs',
-                               'OSXQuarantineEvents'
-                              ]  # pyformat: disable
+  _DEFAULT_ARTIFACTS_DARWIN = [
+      'OSXAppleSystemLogs', 'OSXAuditLogs', 'OSXBashHistory',
+      'OSXInstallationHistory', 'OSXInstallationLog', 'OSXInstallationTime',
+      'OSXLaunchAgents', 'OSXLaunchDaemons', 'OSXMiscLogs', 'OSXRecentItems',
+      'OSXSystemLogs', 'OSXUserApplicationLogs', 'OSXQuarantineEvents'
+  ]  # pyformat: disable
 
-  _DEFAULT_ARTIFACTS_WINDOWS = ['WindowsAppCompatCache',
-                                'WindowsEventLogs',
-                                'WindowsPrefetchFiles',
-                                'WindowsScheduledTasks',
-                                'WindowsSearchDatabase',
-                                'WindowsSuperFetchFiles',
-                                'WindowsSystemRegistryFiles',
-                                'WindowsUserRegistryFiles',
-                                'WindowsXMLEventLogTerminalServices'
-                               ]  # pyformat: disable
+  _DEFAULT_ARTIFACTS_WINDOWS = [
+      'WindowsAppCompatCache', 'WindowsEventLogs', 'WindowsPrefetchFiles',
+      'WindowsScheduledTasks', 'WindowsSearchDatabase',
+      'WindowsSuperFetchFiles', 'WindowsSystemRegistryFiles',
+      'WindowsUserRegistryFiles', 'WindowsXMLEventLogTerminalServices'
+  ]  # pyformat: disable
 
-  def __init__(self,
-               hostname,
-               reason,
-               grr_server_url,
-               grr_auth,
-               artifacts=None,
-               use_tsk=False,
-               approvers=None,
-               verbose=False,
-               keepalive=False):
+  def __init__(
+      self,
+      hostname,
+      reason,
+      grr_server_url,
+      grr_auth,
+      artifacts=None,
+      use_tsk=False,
+      approvers=None,
+      verbose=False,
+      keepalive=False):
     """Initializes a GRR artifact collector.
 
     Args:
@@ -831,13 +827,14 @@ class GRRArtifactCollector(GRRHostCollector):
       verbose: toggle for verbose output
       keepalive: toggle for scheduling a KeepAlive flow
     """
-    super(GRRArtifactCollector, self).__init__(hostname,
-                                               reason,
-                                               grr_server_url,
-                                               grr_auth,
-                                               approvers=approvers,
-                                               verbose=verbose,
-                                               keepalive=keepalive)
+    super(GRRArtifactCollector, self).__init__(
+        hostname,
+        reason,
+        grr_server_url,
+        grr_auth,
+        approvers=approvers,
+        verbose=verbose,
+        keepalive=keepalive)
     self.artifacts = artifacts
     self.use_tsk = use_tsk
 
@@ -866,8 +863,7 @@ class GRRArtifactCollector(GRRHostCollector):
 
     # If the list is supplied by the user via a flag, honor that.
     if self.artifacts:
-      syslog.syslog('Artifacts to be collected: {0:s}'.format(
-          self.artifacts))
+      syslog.syslog('Artifacts to be collected: {0:s}'.format(self.artifacts))
       artifact_list = self.artifacts.split(',')
     else:
       syslog.syslog('Artifacts to be collected: Default')
@@ -881,8 +877,8 @@ class GRRArtifactCollector(GRRHostCollector):
         use_tsk=self.use_tsk,
         ignore_interpolation_errors=True,
         apply_parsers=False,)
-    self.console_out.VerboseOut('Artifacts to collect: {0:s}'.format(
-        artifact_list))
+    self.console_out.VerboseOut(
+        'Artifacts to collect: {0:s}'.format(artifact_list))
     flow_id = self._LaunchFlow(flow_name, flow_args)
     self._AwaitFlow(flow_id)
     return [(self.host, self.output_path)]
@@ -902,15 +898,16 @@ class GRRFileCollector(GRRHostCollector):
     client: Dictionary with information about a GRR client
   """
 
-  def __init__(self,
-               hostname,
-               reason,
-               grr_server_url,
-               grr_auth,
-               files=None,
-               approvers=None,
-               verbose=False,
-               keepalive=False):
+  def __init__(
+      self,
+      hostname,
+      reason,
+      grr_server_url,
+      grr_auth,
+      files=None,
+      approvers=None,
+      verbose=False,
+      keepalive=False):
     """Initializes a GRR file collector.
 
     Args:
@@ -923,11 +920,14 @@ class GRRFileCollector(GRRHostCollector):
       verbose: toggle for verbose output
       keepalive: toggle for scheduling a KeepAlive flow
     """
-    super(GRRFileCollector, self).__init__(hostname, reason, grr_server_url,
-                                           grr_auth=grr_auth,
-                                           approvers=approvers,
-                                           verbose=verbose,
-                                           keepalive=keepalive)
+    super(GRRFileCollector, self).__init__(
+        hostname,
+        reason,
+        grr_server_url,
+        grr_auth=grr_auth,
+        approvers=approvers,
+        verbose=verbose,
+        keepalive=keepalive)
     self.files = files
 
   def collect(self):
@@ -948,8 +948,8 @@ class GRRFileCollector(GRRHostCollector):
     if not file_list:
       raise RuntimeError('File paths must be specified for FileFinder')
     syslog.syslog('Filefinder to collect {0:d} items'.format(len(file_list)))
-    self.console_out.VerboseOut('Files to be collected: {0:s}'.format(
-        self.files))
+    self.console_out.VerboseOut(
+        'Files to be collected: {0:s}'.format(self.files))
     flow_name = 'FileFinder'
     flow_action = flows_pb2.FileFinderAction(
         action_type=flows_pb2.FileFinderAction.DOWNLOAD,)
@@ -975,14 +975,15 @@ class GRRFlowCollector(GRRHostCollector):
     client: Dictionary with information about a GRR client
   """
 
-  def __init__(self,
-               hostname,
-               reason,
-               grr_server_url,
-               grr_auth,
-               flow_id=None,
-               approvers=None,
-               verbose=False):
+  def __init__(
+      self,
+      hostname,
+      reason,
+      grr_server_url,
+      grr_auth,
+      flow_id=None,
+      approvers=None,
+      verbose=False):
     """Initializes a GRR flow collector.
 
     Args:
@@ -994,10 +995,13 @@ class GRRFlowCollector(GRRHostCollector):
       approvers: comma-separated list of GRR approval recipients
       verbose: toggle for verbose output
     """
-    super(GRRFlowCollector, self).__init__(hostname, reason, grr_server_url,
-                                           grr_auth,
-                                           approvers=approvers,
-                                           verbose=verbose)
+    super(GRRFlowCollector, self).__init__(
+        hostname,
+        reason,
+        grr_server_url,
+        grr_auth,
+        approvers=approvers,
+        verbose=verbose)
     self.flow_id = flow_id
 
   def collect(self):
@@ -1020,10 +1024,10 @@ class GRRFlowCollector(GRRHostCollector):
 MODCLASS = [
     ('google_grr_hunt_collector', GRRHuntCollector),
     ('google_grr_hunt_artifact_collector', GRRHuntArtifactCollector),
-    ('google_grr_hunt_file_collector', GRRHuntFileCollector),
-    ('google_grr_hunt_downloader', GRRHuntDownloader),
-    ('google_grr_host_collector', GRRHostCollector),
-    ('google_grr_artifact_collector', GRRArtifactCollector),
-    ('google_grr_file_collector', GRRFileCollector),
-    ('google_grr_flow_collector', GRRFlowCollector)
+    ('google_grr_hunt_file_collector',
+     GRRHuntFileCollector), ('google_grr_hunt_downloader', GRRHuntDownloader),
+    ('google_grr_host_collector',
+     GRRHostCollector), ('google_grr_artifact_collector', GRRArtifactCollector),
+    ('google_grr_file_collector',
+     GRRFileCollector), ('google_grr_flow_collector', GRRFlowCollector)
 ]

--- a/dftimewolf/lib/collectors/grr.py
+++ b/dftimewolf/lib/collectors/grr.py
@@ -19,10 +19,10 @@ class GRRHuntCollector(BaseCollector):
   """Base collector for GRR hunt collections.
 
   Attributes:
-    output_path: Path to store collected artifacts
-    grr_api: GRR HTTP API client
-    reason: Justification for GRR access
-    approvers: list of GRR approval recipients
+    output_path: Path to store collected artifacts.
+    grr_api: GRR HTTP API client.
+    reason: Justification for GRR access.
+    approvers: list of GRR approval recipients.
   """
   _CHECK_APPROVAL_INTERVAL_SEC = 10
 
@@ -31,11 +31,11 @@ class GRRHuntCollector(BaseCollector):
     """Initializes a GRR hunt results collector.
 
     Args:
-      reason: justification for GRR access
-      grr_server_url: GRR server url
-      grr_auth: Tuple containing a (username, password) combination
-      approvers: comma-separated list of GRR approval recipients
-      verbose: toggle for verbose output
+      reason: justification for GRR access.
+      grr_server_url: GRR server URL.
+      grr_auth: Tuple containing a (username, password) combination.
+      approvers: comma-separated list of GRR approval recipients.
+      verbose: toggle for verbose output.
     """
     super(GRRHuntCollector, self).__init__(verbose=verbose)
     self.output_path = tempfile.mkdtemp()
@@ -47,8 +47,8 @@ class GRRHuntCollector(BaseCollector):
     """Create specified hunt.
 
     Args:
-      name: string containing hunt name
-      args: proto (*FlowArgs) for type of hunt, as defined in GRR flow proto
+      name: string containing hunt name.
+      args: proto (*FlowArgs) for type of hunt, as defined in GRR flow proto.
 
     Returns:
       str representing hunt ID.
@@ -221,12 +221,12 @@ class GRRHuntArtifactCollector(GRRHuntCollector):
   """Artifact collector for GRR hunts.
 
   Attributes:
-    output_path: Path to where to store collected items
-    grr_api: GRR HTTP API client
-    reason: Justification for GRR access
-    approvers: list of GRR approval recipients
-    artifacts: comma-separated list of GRR-defined artifacts
-    use_tsk: toggle for use_tsk flag
+    output_path: Path to where to store collected items.
+    grr_api: GRR HTTP API client.
+    reason: Justification for GRR access.
+    approvers: list of GRR approval recipients.
+    artifacts: comma-separated list of GRR-defined artifacts.
+    use_tsk: toggle for use_tsk flag.
   """
 
   def __init__(
@@ -241,13 +241,13 @@ class GRRHuntArtifactCollector(GRRHuntCollector):
     """Initializes a GRR Hunt artifact collector.
 
     Args:
-      reason: justification for GRR access
-      grr_server_url: GRR server url
-      grr_auth: Tuple containing a (username, password) combination
-      artifacts: str, comma-separated list of GRR-defined artifacts
-      use_tsk: toggle for use_tsk flag
-      approvers: str, comma-separated list of GRR approval recipients
-      verbose: toggle for verbose output
+      reason: justification for GRR access.
+      grr_server_url: GRR server URL.
+      grr_auth: Tuple containing a (username, password) combination.
+      artifacts: str, comma-separated list of GRR-defined artifacts.
+      use_tsk: toggle for use_tsk flag.
+      approvers: str, comma-separated list of GRR approval recipients.
+      verbose: toggle for verbose output.
     """
     super(GRRHuntCollector, self).__init__(
         reason, grr_server_url, grr_auth, approvers=approvers, verbose=verbose)
@@ -263,7 +263,7 @@ class GRRHuntArtifactCollector(GRRHuntCollector):
       str representing hunt ID.
 
     Raises:
-      RuntimeError: if no items specified for collection
+      RuntimeError: if no items specified for collection.
     """
     artifact_list = self.artifacts.split(',')
     if not artifact_list:
@@ -294,11 +294,11 @@ class GRRHuntFileCollector(GRRHuntCollector):
   """File collector for GRR hunts.
 
   Attributes:
-    output_path: Path to where to store collected items
-    grr_api: GRR HTTP API client
-    reason: Justification for GRR access
-    approvers: list of GRR approval recipients
-    files: comma-separated list of file paths
+    output_path: Path to where to store collected items.
+    grr_api: GRR HTTP API client.
+    reason: Justification for GRR access.
+    approvers: list of GRR approval recipients.
+    files: comma-separated list of file paths.
   """
 
   def __init__(
@@ -312,12 +312,12 @@ class GRRHuntFileCollector(GRRHuntCollector):
     """Initializes a GRR Hunt file collector.
 
     Args:
-      reason: justification for GRR access
-      grr_server_url: GRR server url
-      grr_auth: Tuple containing a (username, password) combination
-      files: comma-separated list of file paths
-      approvers: comma-separated list of GRR approval recipients
-      verbose: toggle for verbose output
+      reason: justification for GRR access.
+      grr_server_url: GRR server URL.
+      grr_auth: Tuple containing a (username, password) combination.
+      files: comma-separated list of file paths.
+      approvers: comma-separated list of GRR approval recipients.
+      verbose: toggle for verbose output.
     """
     super(GRRHuntFileCollector, self).__init__(
         reason, grr_server_url, grr_auth, approvers=approvers, verbose=verbose)
@@ -332,7 +332,7 @@ class GRRHuntFileCollector(GRRHuntCollector):
       str representing hunt ID.
 
     Raises:
-      RuntimeError: if no items specified for collection
+      RuntimeError: if no items specified for collection.
     """
     file_list = self.file_list.split(',')
     if not file_list:
@@ -359,7 +359,15 @@ class GRRHuntFileCollector(GRRHuntCollector):
       file_list,
       approvers=None,
       verbose=False):
-    """Start a file collector Hunt"""
+    """Start a file collector Hunt using GRRHuntFileCollector.
+
+    Attributes:
+      grr_server_url: GRR server URL.
+      grr_auth: Tuple containing a (username, password) combination.
+      file_list: Comma-separated list of files to download in the Hunt.
+      approvers: comma-separated list of GRR approval recipients.
+      verbose: toggle for verbose output.
+    """
     hunt = GRRHuntFileCollector(
         reason, grr_server_url, grr_auth, file_list, approvers, verbose)
     hunt.console_out.StdOut(
@@ -376,11 +384,11 @@ class GRRHuntDownloader(GRRHuntCollector):
   """File collector for GRR hunts.
 
   Attributes:
-    output_path: path to where to store collected items
-    grr_api: GRR HTTP API client
-    reason: justification for GRR access
-    approvers: list of GRR approval recipients
-    hunt_id: ID of GRR hunt to retrieve results from
+    output_path: path to where to store collected items.
+    grr_api: GRR HTTP API client.
+    reason: justification for GRR access.
+    approvers: list of GRR approval recipients.
+    hunt_id: ID of GRR hunt to retrieve results from.
   """
 
   def __init__(
@@ -394,12 +402,12 @@ class GRRHuntDownloader(GRRHuntCollector):
     """Initializes a GRR hunt results collector.
 
     Args:
-      reason: justification for GRR access
-      grr_server_url: GRR server url
-      grr_auth: Tuple containing a (username, password) combination
-      hunt_id: ID of GRR hunt to retrieve results from
-      approvers: comma-separated list of GRR approval recipients
-      verbose: toggle for verbose output
+      reason: justification for GRR access.
+      grr_server_url: GRR server URL.
+      grr_auth: Tuple containing a (username, password) combination.
+      hunt_id: ID of GRR hunt to retrieve results from.
+      approvers: comma-separated list of GRR approval recipients.
+      verbose: toggle for verbose output.
     """
     super(GRRHuntDownloader, self).__init__(
         reason, grr_server_url, grr_auth, approvers=approvers, verbose=verbose)
@@ -409,7 +417,16 @@ class GRRHuntDownloader(GRRHuntCollector):
   @staticmethod
   def launch_collector(
       reason, grr_server_url, grr_auth, hunt_id, approvers=None, verbose=False):
-    """Launch downloads of files previously hunted for,"""
+    """Downloads the files found during a given GRR Hunt.
+
+    Args:
+      reason: justification for GRR access.
+      grr_server_url: GRR server URL.
+      grr_auth: Tuple containing a (username, password) combination.
+      hunt_id: GRR Hunt id to download files from.
+      approvers: comma-separated list of GRR approval recipients.
+      verbose: toggle for verbose output.
+    """
     hunt_downloader = GRRHuntDownloader(
         reason, grr_server_url, grr_auth, hunt_id, approvers, verbose)
     hunt_downloader.start()
@@ -420,11 +437,11 @@ class GRRHostCollector(BaseCollector):
   """Collect artifacts with GRR.
 
   Attributes:
-    output_path: Path to where to store collected items
-    grr_api: GRR HTTP API client
-    host: Target of GRR collection
-    reason: Justification for GRR access
-    approvers: list of GRR approval recipients
+    output_path: Path to where to store collected items.
+    grr_api: GRR HTTP API client.
+    host: Target of GRR collection.
+    reason: Justification for GRR access.
+    approvers: list of GRR approval recipients.
   """
   _CHECK_APPROVAL_INTERVAL_SEC = 10
   _CHECK_FLOW_INTERVAL_SEC = 10
@@ -441,13 +458,13 @@ class GRRHostCollector(BaseCollector):
     """Initializes a GRR collector.
 
     Args:
-      hostname: hostname of machine
-      reason: justification for GRR access
-      grr_server_url: GRR server url
-      grr_auth: Tuple containing a (username, password) combination
-      approvers: comma-separated list of GRR approval recipients
-      verbose: toggle for verbose output
-      keepalive: toggle for scheduling a KeepAlive flow
+      hostname: hostname of machine.
+      reason: justification for GRR access.
+      grr_server_url: GRR server URL.
+      grr_auth: Tuple containing a (username, password) combination.
+      approvers: comma-separated list of GRR approval recipients.
+      verbose: toggle for verbose output.
+      keepalive: toggle for scheduling a KeepAlive flow.
     """
     super(GRRHostCollector, self).__init__(verbose=verbose)
     self.output_path = tempfile.mkdtemp()
@@ -469,7 +486,7 @@ class GRRHostCollector(BaseCollector):
       str: ID of most recently active client.
 
     Raises:
-      RuntimeError: if no client ID found for hostname
+      RuntimeError: if no client ID found for hostname.
     """
     client_id_pattern = re.compile(r'^c\.[0-9a-f]{16}$', re.IGNORECASE)
     if client_id_pattern.match(hostname):
@@ -516,15 +533,15 @@ class GRRHostCollector(BaseCollector):
     """Get GRR client dictionary and make sure valid approvals exist.
 
     Args:
-      client_id: GRR client ID
-      reason: justification for GRR access
-      approvers: comma-separated list of GRR approval recipients
+      client_id: GRR client ID.
+      reason: justification for GRR access.
+      approvers: comma-separated list of GRR approval recipients.
 
     Returns:
       GRR API Client object
 
     Raises:
-      ValueError: if no approvals exist and no approvers are specified
+      ValueError: if no approvals exist and no approvers are specified.
     """
     client = self.grr_api.Client(client_id)
     self.console_out.VerboseOut('Checking for client approval')
@@ -561,8 +578,8 @@ class GRRHostCollector(BaseCollector):
     """Create specified flow, setting KeepAlive if requested.
 
     Args:
-      name: string containing flow name
-      args: proto (*FlowArgs) for type of flow, as defined in GRR flow proto
+      name: string containing flow name.
+      args: proto (*FlowArgs) for type of flow, as defined in GRR flow proto.
 
     Returns:
       string containing ID of launched flow
@@ -587,10 +604,10 @@ class GRRHostCollector(BaseCollector):
     """Awaits flow completion.
 
     Args:
-      flow_id: string containing ID of flow to await
+      flow_id: string containing ID of flow to await.
 
     Raises:
-      RuntimeError: if flow error encountered
+      RuntimeError: if flow error encountered.
     """
     # Wait for the flow to finish
     self.console_out.VerboseOut('Flow {0:s}: Waiting to finish'.format(flow_id))
@@ -629,7 +646,7 @@ class GRRHostCollector(BaseCollector):
     """Print status of flow.
 
     Raises:
-      RuntimeError: if error encountered getting flow data
+      RuntimeError: if error encountered getting flow data.
     """
     self._client = self._GetClient(self._client_id, self.reason, self.approvers)
     try:
@@ -653,10 +670,10 @@ class GRRHostCollector(BaseCollector):
     """Download files from the specified flow.
 
     Args:
-      flow_id: GRR flow ID
+      flow_id: GRR flow ID.
 
     Returns:
-      str: path of downloaded files
+      str: path of downloaded files.
     """
     if not os.path.isdir(self.output_path):
       os.makedirs(self.output_path)
@@ -708,18 +725,18 @@ class GRRHostCollector(BaseCollector):
     for each.
 
     Args:
-      hosts: List of strings representing hosts to collect artifacts from
-      flow_id: ID of GRR flow to retrieve artifacts from
-      reason: justification for GRR access (usually a SEM ID)
-      grr_server_url: GRR server url
-      grr_auth: Tuple containing a (username, password) combination
-      artifact_list: comma-separated list of GRR-defined artifacts
-      file_list: comma-separated list of GRR file paths
-      use_tsk: toggle for use_tsk flag on GRR flow
-      approvers: comma-separated list of GRR approval recipients
-      verbose: toggle for verbose output
-      keepalive: toggle for scheduling a KeepAlive flow
-      status: print the status of each collector
+      hosts: List of strings representing hosts to collect artifacts from.
+      flow_id: ID of GRR flow to retrieve artifacts from.
+      reason: justification for GRR access (usually a SEM ID).
+      grr_server_url: GRR server URL.
+      grr_auth: Tuple containing a (username, password) combination.
+      artifact_list: comma-separated list of GRR-defined artifacts.
+      file_list: comma-separated list of GRR file paths.
+      use_tsk: toggle for use_tsk flag on GRR flow.
+      approvers: comma-separated list of GRR approval recipients.
+      verbose: toggle for verbose output.
+      keepalive: toggle for scheduling a KeepAlive flow.
+      status: print the status of each collector.
 
     Returns:
       A list of started collectors for each path
@@ -776,13 +793,13 @@ class GRRArtifactCollector(GRRHostCollector):
   """Artifact collector for GRR flows.
 
   Attributes:
-    output_path: Path to where to store collected items
-    grr_api: GRR HTTP API client
-    host: Target of GRR collection
-    artifacts: comma-separated list of GRR-defined artifacts
-    use_tsk: Toggle for use_tsk flag on GRR flow
-    reason: Justification for GRR access
-    approvers: list of GRR approval recipients
+    output_path: Path to where to store collected items.
+    grr_api: GRR HTTP API client.
+    host: Target of GRR collection.
+    artifacts: comma-separated list of GRR-defined artifacts.
+    use_tsk: Toggle for use_tsk flag on GRR flow.
+    reason: Justification for GRR access.
+    approvers: list of GRR approval recipients.
   """
   _DEFAULT_ARTIFACTS_LINUX = [
       'LinuxAuditLogs', 'LinuxAuthLogs', 'LinuxCronLogs', 'LinuxWtmp',
@@ -817,15 +834,15 @@ class GRRArtifactCollector(GRRHostCollector):
     """Initializes a GRR artifact collector.
 
     Args:
-      hostname: hostname of machine
-      reason: justification for GRR access
-      grr_server_url: GRR server url
-      grr_auth: Tuple containing a (username, password) combination
-      artifacts: comma-separated list of GRR-defined artifacts
-      use_tsk: toggle for use_tsk flag on GRR flow
-      approvers: comma-separated list of GRR approval recipients
-      verbose: toggle for verbose output
-      keepalive: toggle for scheduling a KeepAlive flow
+      hostname: hostname of machine.
+      reason: justification for GRR access.
+      grr_server_url: GRR server URL.
+      grr_auth: Tuple containing a (username, password) combination.
+      artifacts: comma-separated list of GRR-defined artifacts.
+      use_tsk: toggle for use_tsk flag on GRR flow.
+      approvers: comma-separated list of GRR approval recipients.
+      verbose: toggle for verbose output.
+      keepalive: toggle for scheduling a KeepAlive flow.
     """
     super(GRRArtifactCollector, self).__init__(
         hostname,
@@ -848,7 +865,7 @@ class GRRArtifactCollector(GRRHostCollector):
           str: path to the collected data.
 
     Raises:
-      RuntimeError: if no artifacts specified nor resolved by platform
+      RuntimeError: if no artifacts specified nor resolved by platform.
     """
     self._client = self._GetClient(self._client_id, self.reason, self.approvers)
 
@@ -888,14 +905,14 @@ class GRRFileCollector(GRRHostCollector):
   """File collector for GRR flows.
 
   Attributes:
-    output_path: Path to where to store collected items
-    grr_api: GRR HTTP API client
-    host: Target of GRR collection
-    files: comma-separated list of file paths
-    reason: Justification for GRR access
-    approvers: list of GRR approval recipients
-    client_id: GRR client ID
-    client: Dictionary with information about a GRR client
+    output_path: Path to where to store collected items.
+    grr_api: GRR HTTP API client.
+    host: Target of GRR collection.
+    files: comma-separated list of file paths.
+    reason: Justification for GRR access.
+    approvers: list of GRR approval recipients.
+    client_id: GRR client ID.
+    client: Dictionary with information about a GRR client.
   """
 
   def __init__(
@@ -911,14 +928,14 @@ class GRRFileCollector(GRRHostCollector):
     """Initializes a GRR file collector.
 
     Args:
-      hostname: hostname of machine
-      reason: justification for GRR access
-      grr_server_url: GRR server url
-      grr_auth: Tuple containing a (username, password) combination
-      files: comma-separated list of file paths
-      approvers: comma-separated list of GRR approval recipients
-      verbose: toggle for verbose output
-      keepalive: toggle for scheduling a KeepAlive flow
+      hostname: hostname of machine.
+      reason: justification for GRR access.
+      grr_server_url: GRR server URL.
+      grr_auth: Tuple containing a (username, password) combination.
+      files: comma-separated list of file paths.
+      approvers: comma-separated list of GRR approval recipients.
+      verbose: toggle for verbose output.
+      keepalive: toggle for scheduling a KeepAlive flow.
     """
     super(GRRFileCollector, self).__init__(
         hostname,
@@ -940,7 +957,7 @@ class GRRFileCollector(GRRHostCollector):
           str: path to the collected data.
 
     Raises:
-      RuntimeError: if no files specified
+      RuntimeError: if no files specified.
     """
     self._client = self._GetClient(self._client_id, self.reason, self.approvers)
 
@@ -965,14 +982,14 @@ class GRRFlowCollector(GRRHostCollector):
   """Flow collector.
 
   Attributes:
-    output_path: Path to where to store collected items
-    grr_api: GRR HTTP API client
-    host: Target of GRR collection
-    flow_id: ID of GRR flow to retrieve
-    reason: Justification for GRR access
-    approvers: list of GRR approval recipients
-    client_id: GRR client ID
-    client: Dictionary with information about a GRR client
+    output_path: Path to where to store collected items.
+    grr_api: GRR HTTP API client.
+    host: Target of GRR collection.
+    flow_id: ID of GRR flow to retrieve.
+    reason: Justification for GRR access.
+    approvers: list of GRR approval recipients.
+    client_id: GRR client ID.
+    client: Dictionary with information about a GRR client.
   """
 
   def __init__(
@@ -987,13 +1004,13 @@ class GRRFlowCollector(GRRHostCollector):
     """Initializes a GRR flow collector.
 
     Args:
-      hostname: hostname of machine
-      reason: justification for GRR access
-      grr_server_url: GRR server url
-      grr_auth: Tuple containing a (username, password) combination
-      flow_id: ID of GRR flow to retrieve
-      approvers: comma-separated list of GRR approval recipients
-      verbose: toggle for verbose output
+      hostname: hostname of machine.
+      reason: justification for GRR access.
+      grr_server_url: GRR server URL.
+      grr_auth: Tuple containing a (username, password) combination.
+      flow_id: ID of GRR flow to retrieve.
+      approvers: comma-separated list of GRR approval recipients.
+      verbose: toggle for verbose output.
     """
     super(GRRFlowCollector, self).__init__(
         hostname,

--- a/dftimewolf/lib/collectors/grr.py
+++ b/dftimewolf/lib/collectors/grr.py
@@ -799,10 +799,14 @@ class GRRHostCollector(BaseCollector):
         if flow_id and status:
           collector.PrintStatus()
         else:
-          collector.start()
+          collector.collect()
           collectors.append(collector)
 
     return collectors
+
+  # pylint-disable=W0223
+  # GRRHostCollector is never concretely instantiated, only extended.
+  # Classes that extend GRRHostCollector should implement the collect method()
 
 
 class GRRArtifactCollector(GRRHostCollector):

--- a/dftimewolf/lib/collectors/grr.py
+++ b/dftimewolf/lib/collectors/grr.py
@@ -199,8 +199,8 @@ class GRRHuntCollector(BaseCollector):
             os.rename(
                 os.path.join(client_directory, real_file_path),
                 os.path.join(client_directory, os.path.basename(f.filename)))
-          except KeyError, e:
-            self.console_out.StdErr('Extraction error: {0:s}'.format(e))
+          except KeyError as exception:
+            self.console_out.StdErr('Extraction error: {0:s}'.format(exception))
             return None
 
     os.remove(output_file_path)
@@ -278,7 +278,7 @@ class GRRHuntArtifactCollector(GRRHuntCollector):
 
     syslog.syslog('Artifacts to be collected: {0:s}'.format(self.artifacts))
     hunt_name = 'ArtifactCollectorFlow'
-    hunt_args = self.grr_api.types.CreateFlowArgs("ArtifactCollectorFlow")
+    hunt_args = self.grr_api.types.CreateFlowArgs('ArtifactCollectorFlow')
     for artifact in artifact_list:
       hunt_args.artifact_list.append(artifact)
     hunt_args.use_tsk = self.use_tsk
@@ -305,10 +305,10 @@ class GRRHuntArtifactCollector(GRRHuntCollector):
         reason, grr_server_url, grr_auth, artifacts, use_tsk, approvers,
         verbose)
     hunt.console_out.StdOut(
-        "\nArtifact hunt {0:s} created succesfully!".format(hunt.hunt_id))
-    hunt.console_out.StdOut("Run a GRRHuntDownloader recipe to fetch results.")
+        '\nArtifact hunt {0:s} created successfully!'.format(hunt.hunt_id))
+    hunt.console_out.StdOut('Run a GRRHuntDownloader recipe to fetch results.')
     hunt.console_out.StdOut(
-        "e.g. $ dftimewolf grr_huntresults_plaso_timesketch {0:s}\n".format(
+        'e.g. $ dftimewolf grr_huntresults_plaso_timesketch {0:s}\n'.format(
             hunt.hunt_id))
     return []
 
@@ -388,10 +388,10 @@ class GRRHuntFileCollector(GRRHuntCollector):
     hunt = GRRHuntFileCollector(
         reason, grr_server_url, grr_auth, file_list, approvers, verbose)
     hunt.console_out.StdOut(
-        "\nHunt {0:s} created successfully!".format(hunt.hunt_id))
-    hunt.console_out.StdOut("Run a GRRHuntDownloader recipe to fetch results.")
+        '\nHunt {0:s} created successfully!'.format(hunt.hunt_id))
+    hunt.console_out.StdOut('Run a GRRHuntDownloader recipe to fetch results.')
     hunt.console_out.StdOut(
-        "e.g. $ dftimewolf grr_huntresults_plaso_timesketch {0:s}\n".format(
+        'e.g. $ dftimewolf grr_huntresults_plaso_timesketch {0:s}\n'.format(
             hunt.hunt_id))
 
     return []

--- a/dftimewolf/lib/utils.py
+++ b/dftimewolf/lib/utils.py
@@ -101,7 +101,7 @@ def IsValidTimezone(timezone):
   return timezone in pytz.all_timezones
 
 
-def import_args_from_dict(value, args):
+def import_args_from_dict(value, args, config):
   """Replaces some arguments by those specified by a key-value dictionary.
 
   This function will be recursively called on a dictionary looking for any
@@ -126,10 +126,12 @@ def import_args_from_dict(value, args):
     match = TOKEN_REGEX.search(str(value))
     if match and args.get(match.group(1)):
       return TOKEN_REGEX.sub(args[match.group(1)] or '', value)
+    if match and config.get_extra(str(match.group(1))):
+      return TOKEN_REGEX.sub(config.get_extra(str(match.group(1))) or '', value)
   elif isinstance(value, list):
-    return [import_args_from_dict(item, args) for item in value]
+    return [import_args_from_dict(item, args, config) for item in value]
   elif isinstance(value, dict):
-    return {key: import_args_from_dict(val, args) for key, val in value.items()}
+    return {key: import_args_from_dict(val, args, config) for key, val in value.items()}
   return value
 
 

--- a/dftimewolf/lib/utils.py
+++ b/dftimewolf/lib/utils.py
@@ -131,7 +131,10 @@ def import_args_from_dict(value, args, config):
   elif isinstance(value, list):
     return [import_args_from_dict(item, args, config) for item in value]
   elif isinstance(value, dict):
-    return {key: import_args_from_dict(val, args, config) for key, val in value.items()}
+    return {
+        key: import_args_from_dict(val, args, config)
+        for key, val in value.items()
+    }
   return value
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytz
 bs4
 requests
+grr_api_client

--- a/tests/test_dftimewolf.py
+++ b/tests/test_dftimewolf.py
@@ -16,7 +16,7 @@ parser.add_argument('explosion')
 
 
 class DFTimewolfTest(TestCase):
-  """Tests for timeflow_recipes functions."""
+  """Tests for dftimewolf_recipes functions."""
 
   def test_import_args_from_cli(self):
     """Tries parsing the CLI arguments and updating a recipe dictionary."""

--- a/tests/test_dftimewolf.py
+++ b/tests/test_dftimewolf.py
@@ -9,7 +9,6 @@ from unittest import TestCase
 from dftimewolf.lib import utils as dftw_utils
 from dftimewolf import config
 
-
 parser = argparse.ArgumentParser()
 parser.add_argument('parameterone')
 parser.add_argument('--optional_param')
@@ -49,8 +48,8 @@ class DFTimewolfTest(TestCase):
         'BOOM',
     ])
 
-
-    imported_args = dftw_utils.import_args_from_dict(recipe_args, vars(args), config.Config)
+    imported_args = dftw_utils.import_args_from_dict(
+        recipe_args, vars(args), config.Config)
 
     self.assertEqual(imported_args, expected_args)
 
@@ -79,6 +78,9 @@ class DFTimewolfTest(TestCase):
       dftw_utils.check_placeholders(imported)
 
   def test_cli_precedence_over_config(self):
+    """Tests that the same argument provided via the CLI overrides the one
+    specified in the config file."""
+
     provided_args = {
         'arg1': 'I want whatever CLI says: @parameterone',
     }
@@ -88,19 +90,19 @@ class DFTimewolfTest(TestCase):
 
     config.Config.load_extra_data('{"parameterone": "CONFIG WINS!"}')
     args = parser.parse_args(['CLI WINS!', 'BOOM'])
-    imported_args = dftw_utils.import_args_from_dict(provided_args, vars(args), config.Config)
+    imported_args = dftw_utils.import_args_from_dict(
+        provided_args, vars(args), config.Config)
     self.assertEqual(imported_args, expected_args)
 
-
   def test_config_fills_missing_args(self):
-    provided_args = {
-        'arg1': 'This should remain intact',
-        'arg2': '@config'
-    }
+    """Tests that a configuration file will fill-in arguments that are missing
+    from the CLI."""
+    provided_args = {'arg1': 'This should remain intact', 'arg2': '@config'}
     expected_args = {
         'arg1': 'This should remain intact',
         'arg2': 'A config arg',
     }
     config.Config.load_extra_data('{"config": "A config arg"}')
-    imported_args = dftw_utils.import_args_from_dict(provided_args, {}, config.Config)
+    imported_args = dftw_utils.import_args_from_dict(
+        provided_args, {}, config.Config)
     self.assertEqual(imported_args, expected_args)


### PR DESCRIPTION
The GRR lib that had disappeared was restored and adapted to work with the new dfTimewolf core:

* **GRRHuntArtifactCollector** - starts Artifact collection Hunt
* **GRRHuntFileCollector** - starts File collection Hunt
* **GRRHuntDownloader** - downloads the results of a Hunt to the local filesystem
* **GRRArtifactCollector** - starts an ArtifactCollection flow and downloads results to the local filesystem
* **GRRFileCollector** - starts a FileCollection flow and downloads results to the local filesystem
* **GRRFlowCollector** - downloads the results of a flow to the local filesystem

Additionally some changes were made:

* Some yapf formatting
* CLI arguments take precedence over those in the config file
  * Two new tests
* Exporters are skipped if none are specified in the recipes (like the processors)