### PR TITLE
Make recipe more intuitive and reflect that CSV upload is supported

### DIFF
--- a/dftimewolf/cli/dftimewolf_recipes.py
+++ b/dftimewolf/cli/dftimewolf_recipes.py
@@ -53,7 +53,7 @@ from dftimewolf.cli.recipes import grr_hunt_artifacts
 from dftimewolf.cli.recipes import grr_hunt_file
 from dftimewolf.cli.recipes import grr_huntresults_plaso_timesketch
 from dftimewolf.cli.recipes import local_plaso
-from dftimewolf.cli.recipes import plaso_file_timesketch
+from dftimewolf.cli.recipes import timesketch_upload
 
 config.Config.register_collector(filesystem.FilesystemCollector)
 config.Config.register_collector(grr.GRRHuntArtifactCollector)
@@ -78,7 +78,7 @@ config.Config.register_recipe(grr_hunt_file)
 config.Config.register_recipe(grr_hunt_artifacts)
 config.Config.register_recipe(grr_huntresults_plaso_timesketch)
 config.Config.register_recipe(grr_flow_download)
-config.Config.register_recipe(plaso_file_timesketch)
+config.Config.register_recipe(timesketch_upload)
 
 
 def main():

--- a/dftimewolf/cli/recipes/timesketch_upload.py
+++ b/dftimewolf/cli/recipes/timesketch_upload.py
@@ -1,14 +1,14 @@
-"""DFTimewolf recipe for exporting a Plaso storage file to Timesketch."""
+"""DFTimewolf recipe for exporting a CSV file or Plaso file to Timesketch."""
 
 from __future__ import unicode_literals
 
 contents = {
     'name':
-        'plaso_file_timesketch',
+        'timesketch_upload',
     'collectors': [{
         'name': 'FilesystemCollector',
         'args': {
-            'paths': '@plaso_file',
+            'paths': '@file',
             'verbose': True,
         },
     }],
@@ -27,7 +27,7 @@ contents = {
 }
 
 args = [
-    ('plaso_file', 'Path to Plaso storage file', None),
+    ('file', 'Path to CSV file or Plaso storage file', None),
     ('--sketch_id', 'Sketch to which the timeline should be added', None),
     ('--incident_id', 'Incident ID (used for Timesketch description)', None)
 ]


### PR DESCRIPTION
Timesketch supports CSV files uploaded as well. The name of the recipe shouls not be limited to plaso files.