### PR TITLE
Better modules feature

### DIFF
--- a/dftimewolf/cli/dftimewolf_recipes.py
+++ b/dftimewolf/cli/dftimewolf_recipes.py
@@ -119,11 +119,11 @@ def main():
 
   print('Setting up modules...')
   state.setup_modules(args)
-  print('Modules sucessfully set up!')
+  print('Modules successfully set up!')
 
   print('Running modules...')
   state.run_modules()
-  print('Recipe {0:s} executed succesfully.'.format(recipe['name']))
+  print('Recipe {0:s} executed successfully.'.format(recipe['name']))
 
 
 if __name__ == '__main__':

--- a/dftimewolf/cli/dftimewolf_recipes.py
+++ b/dftimewolf/cli/dftimewolf_recipes.py
@@ -35,7 +35,6 @@ from dftimewolf.lib.processors import grepper
 from dftimewolf.lib.collectors.gcloud import GoogleCloudCollector
 
 from dftimewolf.lib.state import DFTimewolfState
-from dftimewolf.lib.errors import DFTimewolfError
 
 signal.signal(signal.SIGINT, utils.signal_handler)
 
@@ -112,30 +111,19 @@ def main():
   args = parser.parse_args()
   recipe = args.recipe
 
-  # Thread all collectors.
-  state = DFTimewolfState()
+  state = DFTimewolfState(config.Config)
+  print('Loading recipes...')
+  state.load_recipe(recipe)
+  print('Loaded recipe {0:s} with {1:d} modules'.format(
+      recipe['name'], len(recipe['modules'])))
 
-  for module_description in recipe['modules']:
-    # Combine CLI args with args from the recipe description
-    new_args = utils.import_args_from_dict(
-        module_description['args'], vars(args), config.Config)
+  print('Setting up modules...')
+  state.setup_modules(args)
+  print('Modules sucessfully set up!')
 
-    # Create the module object and start processing
-    module_name = module_description['name']
-    print('Running module {0:s}'.format(module_name))
-    module = config.Config.get_module(module_name)(state)
-    module.setup(**new_args)
-    state.check_errors()
-    try:
-      module.process()
-    except DFTimewolfError as error:
-      state.add_error(error.message, critical=True)
-
-    # Check for eventual errors and clean up after each round.
-    state.check_errors()
-    state.cleanup()
-
-  print('Recipe executed successfully.')
+  print('Running modules...')
+  state.run_modules()
+  print('Recipe {0:s} executed succesfully.'.format(recipe['name']))
 
 
 if __name__ == '__main__':

--- a/dftimewolf/cli/recipes/artifact_grep.py
+++ b/dftimewolf/cli/recipes/artifact_grep.py
@@ -13,6 +13,7 @@ contents = {
         'artifact_grep',
     'short_description': _short_description,
     'modules': [{
+        'wants': [],
         'name': 'GRRArtifactCollector',
         'args': {
             'hosts': '@hosts',
@@ -27,6 +28,7 @@ contents = {
             'verify': '@verify',
         },
     }, {
+        'wants': ['GRRArtifactCollector'],
         'name': 'GrepperSearch',
         'args': {
             'keywords': '@keywords',

--- a/dftimewolf/cli/recipes/gcp_turbinia.py
+++ b/dftimewolf/cli/recipes/gcp_turbinia.py
@@ -16,6 +16,7 @@ contents = {
     'name': 'gcp_turbinia',
     'short_description': _short_description,
     'modules': [{
+        'wants': [],
         'name': 'TurbiniaProcessor',
         'args': {
             'disk_name': '@disk_name',
@@ -23,6 +24,7 @@ contents = {
             'turbinia_zone': '@turbinia_zone',
         },
     }, {
+        'wants': ['TurbiniaProcessor'],
         'name': 'TimesketchExporter',
         'args': {
             'endpoint': '@ts_endpoint',

--- a/dftimewolf/cli/recipes/gcp_turbinia_import.py
+++ b/dftimewolf/cli/recipes/gcp_turbinia_import.py
@@ -17,6 +17,7 @@ contents = {
     'name': 'gcp_turbinia_import',
     'short_description': _short_description,
     'modules': [{
+        'wants': [],
         'name': 'GoogleCloudCollector',
         'args': {
             'analysis_project_name': '@analysis_project_name',
@@ -31,6 +32,7 @@ contents = {
             'image_family': '@image_family',
         },
     }, {
+        'wants': ['GoogleCloudCollector'],
         'name': 'TurbiniaProcessor',
         'args': {
             'disk_name': None,  # Taken from GoogleCloudCollector's output
@@ -38,6 +40,7 @@ contents = {
             'turbinia_zone': '@turbinia_zone',
         },
     }, {
+        'wants': ['TurbiniaProcessor'],
         'name': 'TimesketchExporter',
         'args': {
             'endpoint': '@ts_endpoint',

--- a/dftimewolf/cli/recipes/grr_artifact_hosts.py
+++ b/dftimewolf/cli/recipes/grr_artifact_hosts.py
@@ -15,6 +15,7 @@ contents = {
         'grr_artifact_hosts',
     'short_description': _short_description,
     'modules': [{
+        'wants': [],
         'name': 'GRRArtifactCollector',
         'args': {
             'hosts': '@hosts',
@@ -29,11 +30,13 @@ contents = {
             'verify': '@verify',
         },
     }, {
+        'wants': ['GRRArtifactCollector'],
         'name': 'LocalPlasoProcessor',
         'args': {
             'timezone': None,
         },
     }, {
+        'wants': ['LocalPlasoProcessor'],
         'name': 'TimesketchExporter',
         'args': {
             'endpoint': '@ts_endpoint',

--- a/dftimewolf/cli/recipes/grr_fetch_files.py
+++ b/dftimewolf/cli/recipes/grr_fetch_files.py
@@ -8,6 +8,7 @@ contents = {
         'grr_fetch_files',
     'short_description': _short_description,
     'modules': [{
+        'wants': [],
         'name': 'GRRFileCollector',
         'args': {
             'hosts': '@hosts',
@@ -21,6 +22,7 @@ contents = {
             'verify': '@verify',
         },
     }, {
+        'wants': ['GRRFileCollector'],
         'name': 'LocalFilesystemCopy',
         'args': {
             'target_directory': '@directory',

--- a/dftimewolf/cli/recipes/grr_flow_download.py
+++ b/dftimewolf/cli/recipes/grr_flow_download.py
@@ -13,6 +13,7 @@ contents = {
         'grr_flow_download',
     'short_description': _short_description,
     'modules': [{
+        'wants': [],
         'name': 'GRRFlowCollector',
         'args': {
             'host': '@host',
@@ -25,6 +26,7 @@ contents = {
             'verify': '@verify',
         },
     }, {
+        'wants': ['GRRFlowCollector'],
         'name': 'LocalFilesystemCopy',
         'args': {
             'target_directory': '@directory',

--- a/dftimewolf/cli/recipes/grr_hunt_artifacts.py
+++ b/dftimewolf/cli/recipes/grr_hunt_artifacts.py
@@ -13,6 +13,7 @@ contents = {
         'grr_hunt_artifacts',
     'short_description': _short_description,
     'modules': [{
+        'wants': [],
         'name': 'GRRHuntArtifactCollector',
         'args': {
             'artifacts': '@artifacts',

--- a/dftimewolf/cli/recipes/grr_hunt_file.py
+++ b/dftimewolf/cli/recipes/grr_hunt_file.py
@@ -13,6 +13,7 @@ contents = {
         'grr_hunt_file',
     'short_description': _short_description,
     'modules': [{
+        'wants': [],
         'name': 'GRRHuntFileCollector',
         'args': {
             'file_path_list': '@file_path_list',

--- a/dftimewolf/cli/recipes/grr_huntresults_plaso_timesketch.py
+++ b/dftimewolf/cli/recipes/grr_huntresults_plaso_timesketch.py
@@ -15,6 +15,7 @@ contents = {
         'grr_huntresults_plaso_timesketch',
     'short_description': _short_description,
     'modules': [{
+        'wants': [],
         'name': 'GRRHuntDownloader',
         'args': {
             'hunt_id': '@hunt_id',
@@ -26,11 +27,13 @@ contents = {
             'verify': '@verify',
         },
     }, {
+        'wants': ['GRRHuntDownloader'],
         'name': 'LocalPlasoProcessor',
         'args': {
             'timezone': None,
         },
     }, {
+        'wants': ['LocalPlasoProcessor'],
         'name': 'TimesketchExporter',
         'args': {
             'endpoint': '@ts_endpoint',

--- a/dftimewolf/cli/recipes/local_plaso.py
+++ b/dftimewolf/cli/recipes/local_plaso.py
@@ -16,16 +16,19 @@ contents = {
         'local_plaso',
     'short_description': _short_description,
     'modules': [{
+        'wants': [],
         'name': 'FilesystemCollector',
         'args': {
             'paths': '@paths',
         },
     }, {
+        'wants': ['FilesystemCollector'],
         'name': 'LocalPlasoProcessor',
         'args': {
             'timezone': None,
         },
     }, {
+        'wants': ['LocalPlasoProcessor'],
         'name': 'TimesketchExporter',
         'args': {
             'endpoint': '@ts_endpoint',

--- a/dftimewolf/cli/recipes/timesketch_upload.py
+++ b/dftimewolf/cli/recipes/timesketch_upload.py
@@ -8,11 +8,13 @@ contents = {
     'name': 'timesketch_upload',
     'short_description': _short_description,
     'modules': [{
+        'wants': [],
         'name': 'FilesystemCollector',
         'args': {
             'paths': '@files',
         },
     }, {
+        'wants': ['FilesystemCollector'],
         'name': 'TimesketchExporter',
         'args': {
             'endpoint': '@ts_endpoint',

--- a/dftimewolf/lib/collectors/gcloud.py
+++ b/dftimewolf/lib/collectors/gcloud.py
@@ -41,7 +41,7 @@ class GoogleCloudCollector(module.BaseModule):
           snapshot, disk_name_prefix="incident" + self.incident_id)
       self.analysis_vm.attach_disk(new_disk)
       snapshot.delete()
-      print("Disk {0:s} succesfully copied to {1:s}".format(
+      print("Disk {0:s} successfully copied to {1:s}".format(
           disk.name, new_disk.name))
       self.state.output.append((self.analysis_vm.name, new_disk))
 

--- a/dftimewolf/lib/exporters/timesketch.py
+++ b/dftimewolf/lib/exporters/timesketch.py
@@ -80,7 +80,7 @@ class TimesketchExporter(BaseModule):
       self.timesketch_api.export_artifacts(named_timelines, self.sketch_id)
     except RuntimeError as e:
       self.state.add_error(
-          'Error occured while working with Timesketch: {0:s}'.format(str(e)),
+          'Error occurred while working with Timesketch: {0:s}'.format(str(e)),
           critical=True)
       return
     sketch_url = self.timesketch_api.get_sketch_url(self.sketch_id)

--- a/dftimewolf/lib/module.py
+++ b/dftimewolf/lib/module.py
@@ -26,7 +26,6 @@ class BaseModule(threading.Thread):
     super(BaseModule, self).__init__()
     self.critical = critical
     self.state = state
-    self.state.set_current_module(self)
 
   def setup(self, *args, **kwargs):
     """Sets up necessary module configuration options."""

--- a/dftimewolf/lib/state.py
+++ b/dftimewolf/lib/state.py
@@ -8,6 +8,11 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import sys
+import threading
+
+from dftimewolf.lib import utils
+from dftimewolf.lib.errors import DFTimewolfError
+
 
 class DFTimewolfState(object):
   """The main State class.
@@ -17,17 +22,110 @@ class DFTimewolfState(object):
         cleaned up after each module run using the cleanup() method.
     global_errors: [(str, bool)] the cleanup() method moves non critical errors
         to this attribute for later reporting.
-    current_module: The DFTimewolfModule module that is currently executing.
     input: list, The data that the current module will use as input.
     output: list, The data that the current module generates.
+    store: dict, store of arbitrary data for modules.
   """
 
-  def __init__(self):
+  def __init__(self, config):
     self.errors = []
     self.global_errors = []
-    self.current_module = None
     self.input = []
     self.output = []
+    self.store = {}
+    self._module_pool = {}
+    self.config = config
+    self.recipe = None
+    self.events = {}
+
+  def load_recipe(self, recipe):
+    """Populates the internal module pool with modules declared in a recipe.
+
+    Args:
+      recipe: Dict, recipe declaring modules to load.
+    """
+    self.recipe = recipe
+    for module_description in recipe['modules']:
+      # Combine CLI args with args from the recipe description
+      module_name = module_description['name']
+      module = self.config.get_module(module_name)(self)
+      self._module_pool[module_name] = module
+
+  def setup_modules(self, args):
+    """Performs setup tasks for each module in the module pool.
+
+    Threads declared modules' setup() functions. Takes CLI arguments into
+    account when replacing recipe parameters for each module.
+
+    Args:
+      args: Command line arguments that will be used to replace the parameters
+          declared in the recipe.
+    """
+
+    def _setup_module_thread(module_description):
+      """Calls the module's setup() function and sets an Event object for it.
+
+      Args:
+        module_description (dict): Corresponding recipe module description.
+      """
+      new_args = utils.import_args_from_dict(
+          module_description['args'], vars(args), self.config)
+      module = self._module_pool[module_description['name']]
+      try:
+        module.setup(**new_args)
+      except Exception as error:  # pylint: disable=broad-except
+        self.add_error(
+            'An unknown error occurred: {0!s}'.format(error), critical=True)
+      self.events[module_description['name']] = threading.Event()
+
+    threads = []
+    for module_description in self.recipe['modules']:
+      t = threading.Thread(
+          target=_setup_module_thread,
+          args=(module_description, )
+      )
+      threads.append(t)
+      t.start()
+    for t in threads:
+      t.join()
+
+    self.check_errors()
+
+  def run_modules(self):
+    """Performs the actual processing for each module in the module pool."""
+
+    def _run_module_thread(module_description):
+      """Runs the module's process() function.
+
+      Waits for any blockers to have finished before running process(), then
+      sets an Event flag declaring the module has completed.
+      """
+      for blocker in module_description['wants']:
+        self.events[blocker].wait()
+      module = self._module_pool[module_description['name']]
+      try:
+        module.process()
+      except DFTimewolfError as error:
+        self.add_error(error.message, critical=True)
+      except Exception as error:  # pylint: disable=broad-except
+        self.add_error(
+            'An unknown error occurred: {0!s}'.format(error), critical=True)
+      print('Module {0:s} completed'.format(module_description['name']))
+      self.events[module_description['name']].set()
+      self.cleanup()
+
+    threads = []
+    for module_description in self.recipe['modules']:
+      t = threading.Thread(
+          target=_run_module_thread,
+          args=(module_description, )
+      )
+      threads.append(t)
+      t.start()
+    for t in threads:
+      t.join()
+
+    self.check_errors()
 
   def add_error(self, error, critical=False):
     """Adds an error to the state.
@@ -38,14 +136,6 @@ class DFTimewolfState(object):
           dfTimewolf will abort.
     """
     self.errors.append((error, critical))
-
-  def set_current_module(self, module):
-    """Sets the current_module for the state.
-
-    Args:
-      module: The dfTimewolfModule to define as current module.
-    """
-    self.current_module = module
 
   def cleanup(self):
     """Basic cleanup after modules.

--- a/tests/cli/recipes.py
+++ b/tests/cli/recipes.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Tests the local filesystem collector."""
+
+from __future__ import unicode_literals
+
+import unittest
+import six
+
+from dftimewolf.cli.recipes import artifact_grep
+from dftimewolf.cli.recipes import gcp_turbinia_import
+from dftimewolf.cli.recipes import gcp_turbinia
+from dftimewolf.cli.recipes import grr_artifact_hosts
+from dftimewolf.cli.recipes import grr_fetch_files
+from dftimewolf.cli.recipes import grr_flow_download
+from dftimewolf.cli.recipes import grr_hunt_artifacts
+from dftimewolf.cli.recipes import grr_hunt_file
+from dftimewolf.cli.recipes import grr_huntresults_plaso_timesketch
+from dftimewolf.cli.recipes import local_plaso
+from dftimewolf.cli.recipes import timesketch_upload
+
+class RecipeTests(unittest.TestCase):
+  """Tests for recipe construction."""
+
+  def setUp(self):
+    self.recipes = [
+        artifact_grep,
+        gcp_turbinia_import,
+        gcp_turbinia,
+        grr_artifact_hosts,
+        grr_fetch_files,
+        grr_flow_download,
+        grr_hunt_artifacts,
+        grr_hunt_file,
+        grr_huntresults_plaso_timesketch,
+        local_plaso,
+        timesketch_upload,
+    ]
+
+  def testRecipeHasFields(self):
+    """Tests that all recipes have the correct fields."""
+    for recipe in self.recipes:
+      self.assertIn('name', recipe.contents)
+      self.assertIn('short_description', recipe.contents)
+      self.assertIn('modules', recipe.contents)
+      self.assertIsInstance(recipe.contents['modules'], list)
+
+      self.assertIsInstance(recipe.args, list)
+
+  def testRecipeModulesHaveFields(self):
+    """Tests that modules defined in the recipe have the correct fields."""
+    for recipe in self.recipes:
+      for module in recipe.contents['modules']:
+        error_msg = 'module {0:s} in recipe {1:s}'.format(
+            module['name'], recipe.contents['name'])
+
+        self.assertIn('wants', module, msg=error_msg)
+        self.assertIn('name', module, msg=error_msg)
+        self.assertIn('args', module, msg=error_msg)
+
+        self.assertIsInstance(module['wants'], list, msg=error_msg)
+        self.assertIsInstance(module['args'], dict, msg=error_msg)
+        self.assertIsInstance(module['name'], six.string_types, msg=error_msg)
+
+  def testRecipeModulesAllPresent(self):
+    """Tests that a recipe's modules depend only on modules present in the
+    recipe."""
+    for recipe in self.recipes:
+      declared_modules = set()
+      wanted_modules = set()
+      for module in recipe.contents['modules']:
+
+        declared_modules.add(module['name'])
+        for wanted in module['wants']:
+          wanted_modules.add(wanted)
+
+      for wanted_module in wanted_modules:
+        self.assertIn(wanted_module, declared_modules,
+                      msg='recipe: {0:s}'.format(recipe.contents['name']))
+
+  def testNoDeadlockInRecipe(self):
+    """Tests that a recipe will not deadlock."""
+    for recipe in self.recipes:
+      for module in recipe.contents['modules']:
+        dependencies = _find_module_dependencies(
+            module['name'], recipe, module['name'])
+        if module['name'] in dependencies:
+          self.fail('Cyclic dependency found in {0:s}: {1:s}'.format(
+              recipe.contents['name'],
+              module['name']
+          ))
+
+def _find_module_dependencies(module_name, recipe, original_module_name):
+  """Recursively looks for module dependencies.
+
+  Will stop whenever the original module is found to be a dependency of itself,
+  or when all dependencies are found.
+
+  Args:
+    module_name: The module to check dependencies for
+    recipe: The dftimewolf recipe
+    original_module_name: The original module name for which we want to check
+        for cyclic dependencies.
+
+  Returns:
+    A set of depencency names found so far.
+  """
+
+  module_dependencies = set()
+  for module in recipe.contents['modules']:
+    if module_name == module['name']:
+      module_dependencies.update(module['wants'])
+
+  if original_module_name in module_dependencies:
+    # We found a cyclic dependency, stop recursing and return immediately.
+    return module_dependencies
+
+  # otherwise, check for another level of dependencies.
+  for dependency in list(module_dependencies):
+    module_dependencies.update(_find_module_dependencies(
+        dependency, recipe, original_module_name))
+
+  return module_dependencies
+
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/lib/collectors/filesystem.py
+++ b/tests/lib/collectors/filesystem.py
@@ -11,20 +11,21 @@ import mock
 from dftimewolf.lib import state
 from dftimewolf.lib.collectors import filesystem
 
+from dftimewolf import config
 
 class LocalFileSystemTest(unittest.TestCase):
   """Tests for the local filesystem collector."""
 
   def testInitialization(self):
     """Tests that the collector can be initialized."""
-    test_state = state.DFTimewolfState()
+    test_state = state.DFTimewolfState(config.Config)
     filesystem_collector = filesystem.FilesystemCollector(test_state)
     self.assertIsNotNone(filesystem_collector)
 
   @mock.patch('dftimewolf.lib.collectors.filesystem.os.path')
   def testOutput(self, mock_path):
     """Tests that the module ouput is consistent with the input."""
-    test_state = state.DFTimewolfState()
+    test_state = state.DFTimewolfState(config.Config)
     filesystem_collector = filesystem.FilesystemCollector(test_state)
     fake_paths = '/fake/path/1,/fake/path/2'
     filesystem_collector.setup(paths=fake_paths)
@@ -39,7 +40,7 @@ class LocalFileSystemTest(unittest.TestCase):
   @mock.patch('dftimewolf.lib.state.DFTimewolfState.add_error')
   def testSetup(self, mock_add_error):
     """Tests that no paths specified in setup will generate an error."""
-    test_state = state.DFTimewolfState()
+    test_state = state.DFTimewolfState(config.Config)
     filesystem_collector = filesystem.FilesystemCollector(test_state)
     filesystem_collector.setup(paths=None)
     mock_add_error.assert_called_with(

--- a/tests/lib/collectors/grr_base.py
+++ b/tests/lib/collectors/grr_base.py
@@ -12,6 +12,9 @@ from grr_api_client import errors as grr_errors
 from dftimewolf.lib import state
 from dftimewolf.lib.collectors import grr_base
 
+from dftimewolf import config
+
+
 ACCESS_FORBIDDEN_MAX = 3
 
 class MockGRRObject(object):
@@ -34,7 +37,7 @@ class GRRBaseModuleTest(unittest.TestCase):
 
   def testInitialization(self):
     """Tests that the collector can be initialized."""
-    test_state = state.DFTimewolfState()
+    test_state = state.DFTimewolfState(config.Config)
     grr_base_module = grr_base.GRRBaseModule(test_state)
     self.assertIsNotNone(grr_base_module)
 
@@ -42,7 +45,7 @@ class GRRBaseModuleTest(unittest.TestCase):
   @mock.patch('grr_api_client.api.InitHttp')
   def testSetup(self, mock_grr_inithttp, mock_mkdtemp):
     """Tests that setup works"""
-    test_state = state.DFTimewolfState()
+    test_state = state.DFTimewolfState(config.Config)
     grr_base_module = grr_base.GRRBaseModule(test_state)
     mock_mkdtemp.return_value = '/fake'
     grr_base_module.setup(
@@ -63,7 +66,7 @@ class GRRBaseModuleTest(unittest.TestCase):
 
   def testApprovalWrapper(self):
     """Tests that the approval wrapper works correctly."""
-    test_state = state.DFTimewolfState()
+    test_state = state.DFTimewolfState(config.Config)
     grr_base_module = grr_base.GRRBaseModule(test_state)
     grr_base_module.setup(
         reason='random reason',
@@ -102,7 +105,7 @@ class GRRBaseModuleTest(unittest.TestCase):
     This should only error on unauthorized objects, which is how our mock
     behaves.
     """
-    test_state = state.DFTimewolfState()
+    test_state = state.DFTimewolfState(config.Config)
     grr_base_module = grr_base.GRRBaseModule(test_state)
     grr_base_module.setup(
         reason='random',

--- a/tests/lib/collectors/grr_hosts.py
+++ b/tests/lib/collectors/grr_hosts.py
@@ -11,11 +11,13 @@ import six
 from grr_response_proto import flows_pb2
 from grr_api_client import errors as grr_errors
 
+from dftimewolf import config
 from dftimewolf.lib import state
 from dftimewolf.lib.collectors import grr_hosts
 from dftimewolf.lib.errors import DFTimewolfError
 
 from tests.lib.collectors.test_data import mock_grr_hosts
+
 
 # Extensive access to protected members for testing, and mocking of classes.
 # pylint: disable=protected-access,invalid-name
@@ -23,7 +25,7 @@ class GRRFlowTests(unittest.TestCase):
   """Tests for the GRRFlow base class."""
 
   def setUp(self):
-    self.test_state = state.DFTimewolfState()
+    self.test_state = state.DFTimewolfState(config.Config)
     self.grr_flow_module = grr_hosts.GRRFlow(self.test_state)
     self.grr_flow_module.setup(
         reason='random reason',
@@ -160,7 +162,7 @@ class GRRArtifactCollectorTest(unittest.TestCase):
   """Tests for the GRR artifact collector."""
 
   def setUp(self):
-    self.test_state = state.DFTimewolfState()
+    self.test_state = state.DFTimewolfState(config.Config)
     self.grr_artifact_collector = grr_hosts.GRRArtifactCollector(
         self.test_state)
     self.grr_artifact_collector.setup(
@@ -254,7 +256,7 @@ class GRRFileCollectorTest(unittest.TestCase):
   """Tests for the GRR file collector."""
 
   def setUp(self):
-    self.test_state = state.DFTimewolfState()
+    self.test_state = state.DFTimewolfState(config.Config)
     self.grr_file_collector = grr_hosts.GRRFileCollector(self.test_state)
     self.grr_file_collector.setup(
         hosts='tomchop,tomchop2',
@@ -303,7 +305,7 @@ class GRRFlowCollector(unittest.TestCase):
   """Tests for the GRR flow collector."""
 
   def setUp(self):
-    self.test_state = state.DFTimewolfState()
+    self.test_state = state.DFTimewolfState(config.Config)
     self.grr_flow_collector = grr_hosts.GRRFlowCollector(self.test_state)
     self.grr_flow_collector.setup(
         host='tomchop',

--- a/tests/lib/collectors/grr_hunt.py
+++ b/tests/lib/collectors/grr_hunt.py
@@ -10,9 +10,11 @@ import mock
 
 from grr_response_proto import flows_pb2
 
+from dftimewolf import config
 from dftimewolf.lib import state
 from dftimewolf.lib.collectors import grr_hunt
 from tests.lib.collectors.test_data import mock_grr_hosts
+
 
 # Mocking of classes.
 # pylint: disable=invalid-name
@@ -20,7 +22,7 @@ class GRRHuntArtifactCollectorTest(unittest.TestCase):
   """Tests for the GRR artifact collector."""
 
   def setUp(self):
-    self.test_state = state.DFTimewolfState()
+    self.test_state = state.DFTimewolfState(config.Config)
     self.grr_hunt_artifact_collector = grr_hunt.GRRHuntArtifactCollector(
         self.test_state)
     self.grr_hunt_artifact_collector.setup(
@@ -50,7 +52,7 @@ class GRRHuntFileCollectorTest(unittest.TestCase):
   """Tests for the GRR file collector."""
 
   def setUp(self):
-    self.test_state = state.DFTimewolfState()
+    self.test_state = state.DFTimewolfState(config.Config)
     self.grr_hunt_file_collector = grr_hunt.GRRHuntFileCollector(
         self.test_state)
     self.grr_hunt_file_collector.setup(
@@ -88,7 +90,7 @@ class GRRFHuntDownloader(unittest.TestCase):
   """Tests for the GRR hunt downloader."""
 
   def setUp(self):
-    self.test_state = state.DFTimewolfState()
+    self.test_state = state.DFTimewolfState(config.Config)
     self.grr_hunt_downloader = grr_hunt.GRRHuntDownloader(self.test_state)
     self.grr_hunt_downloader.setup(
         hunt_id='H:12345',

--- a/tests/lib/exporters/local_filesystem.py
+++ b/tests/lib/exporters/local_filesystem.py
@@ -10,6 +10,9 @@ import mock
 from dftimewolf.lib import state
 from dftimewolf.lib.exporters import local_filesystem
 
+from dftimewolf import config
+
+
 FAKE_PATHS = {
     '/fake/evidence_directory': ['file1', 'file2'],
     '/fake/evidence_file': None
@@ -28,7 +31,7 @@ class LocalFileSystemTest(unittest.TestCase):
 
   def testInitialization(self):
     """Tests that the exporter can be initialized."""
-    test_state = state.DFTimewolfState()
+    test_state = state.DFTimewolfState(config.Config)
     local_filesystem_copy = local_filesystem.LocalFilesystemCopy(test_state)
     self.assertIsNotNone(local_filesystem_copy)
 
@@ -45,7 +48,7 @@ class LocalFileSystemTest(unittest.TestCase):
                   mock_copy2,
                   mock_copytree):
     """Tests that the module processes input correctly."""
-    test_state = state.DFTimewolfState()
+    test_state = state.DFTimewolfState(config.Config)
     test_state.input = [
         ('description', '/fake/evidence_directory'),
         ('description2', '/fake/evidence_file'),
@@ -64,7 +67,7 @@ class LocalFileSystemTest(unittest.TestCase):
   def testSetup(self, mock_mkdtemp):
     """Tests that the specified directory is used if created."""
     mock_mkdtemp.return_value = '/fake/random'
-    test_state = state.DFTimewolfState()
+    test_state = state.DFTimewolfState(config.Config)
     local_filesystem_copy = local_filesystem.LocalFilesystemCopy(test_state)
     local_filesystem_copy.setup()
     # pylint: disable=protected-access
@@ -74,7 +77,7 @@ class LocalFileSystemTest(unittest.TestCase):
   def testSetupError(self, mock_makedirs):
     """Tests that an error is generated if target_directory is unavailable."""
     mock_makedirs.side_effect = OSError('FAKEERROR')
-    test_state = state.DFTimewolfState()
+    test_state = state.DFTimewolfState(config.Config)
     local_filesystem_copy = local_filesystem.LocalFilesystemCopy(test_state)
     local_filesystem_copy.setup(target_directory="/nonexistent")
     self.assertEqual(test_state.errors[0][1], True)
@@ -83,7 +86,7 @@ class LocalFileSystemTest(unittest.TestCase):
   def testSetupManualDir(self, mock_makedirs):
     """Tests that the specified directory is used if created."""
     mock_makedirs.return_value = True
-    test_state = state.DFTimewolfState()
+    test_state = state.DFTimewolfState(config.Config)
     local_filesystem_copy = local_filesystem.LocalFilesystemCopy(test_state)
     local_filesystem_copy.setup(target_directory='/nonexistent')
     # pylint: disable=protected-access

--- a/tests/lib/exporters/timesketch.py
+++ b/tests/lib/exporters/timesketch.py
@@ -9,13 +9,15 @@ import unittest
 from dftimewolf.lib import state
 from dftimewolf.lib.exporters import timesketch
 
+from dftimewolf import config
+
 
 class TimesketchExporterTest(unittest.TestCase):
   """Tests for the Timesketch exporter."""
 
   def testInitialization(self):
     """Tests that the processor can be initialized."""
-    test_state = state.DFTimewolfState()
+    test_state = state.DFTimewolfState(config.Config)
     timesketch_exporter = timesketch.TimesketchExporter(test_state)
     self.assertIsNotNone(timesketch_exporter)
 

--- a/tests/lib/processors/grepper.py
+++ b/tests/lib/processors/grepper.py
@@ -9,12 +9,15 @@ import unittest
 from dftimewolf.lib import state
 from dftimewolf.lib.processors import grepper
 
+from dftimewolf import config
+
+
 class GrepperTest(unittest.TestCase):
   """Test case for the grep function. """
 
   def TestSingleGrep(self):
     """Test just single keyword grep search on text files."""
-    test_state = state.DFTimewolfState()
+    test_state = state.DFTimewolfState(config.Config)
     base_grepper_search = grepper.GrepperSearch(test_state)
     base_grepper_search.setup(
         keywords='foo|lorem|meow|triage|bar|homebrew'

--- a/tests/lib/processors/localplaso.py
+++ b/tests/lib/processors/localplaso.py
@@ -9,13 +9,15 @@ import unittest
 from dftimewolf.lib import state
 from dftimewolf.lib.processors import localplaso
 
+from dftimewolf import config
+
 
 class LocalPlasoTest(unittest.TestCase):
   """Tests for the local Plaso processor."""
 
   def testInitialization(self):
     """Tests that the processor can be initialized."""
-    test_state = state.DFTimewolfState()
+    test_state = state.DFTimewolfState(config.Config)
     local_plaso_processor = localplaso.LocalPlasoProcessor(test_state)
     self.assertIsNotNone(local_plaso_processor)
 

--- a/tests/lib/processors/turbinia.py
+++ b/tests/lib/processors/turbinia.py
@@ -50,7 +50,8 @@ class TurbiniaProcessorTest(unittest.TestCase):
     self.assertEqual(turbinia_processor.turbinia_region,
                      turbinia.turbinia_config.TURBINIA_REGION)
     # pylint: disable=protected-access
-    six.assertRegex(self, turbinia_processor._output_path, '/tmp/tmp.+')
+    six.assertRegex(self, turbinia_processor._output_path,
+                    '(/tmp/tmp|/var/folders).+')
 
   @mock.patch('turbinia.client.TurbiniaClient')
   # pylint: disable=invalid-name

--- a/tests/lib/processors/turbinia.py
+++ b/tests/lib/processors/turbinia.py
@@ -18,6 +18,7 @@ os.environ['TURBINIA_CONFIG_PATH'] = os.path.join(current_dir, 'test_data')
 # pylint: disable=wrong-import-position
 from dftimewolf.lib.processors import turbinia
 
+from dftimewolf import config
 
 
 class TurbiniaProcessorTest(unittest.TestCase):
@@ -25,7 +26,7 @@ class TurbiniaProcessorTest(unittest.TestCase):
 
   def testInitialization(self):
     """Tests that the processor can be initialized."""
-    test_state = state.DFTimewolfState()
+    test_state = state.DFTimewolfState(config.Config)
     turbinia_processor = turbinia.TurbiniaProcessor(test_state)
     self.assertIsNotNone(turbinia_processor)
 
@@ -33,7 +34,7 @@ class TurbiniaProcessorTest(unittest.TestCase):
   # pylint: disable=invalid-name
   def testSetup(self, _mock_TurbiniaClient):
     """Tests that the processor is set up correctly."""
-    test_state = state.DFTimewolfState()
+    test_state = state.DFTimewolfState(config.Config)
     turbinia_processor = turbinia.TurbiniaProcessor(test_state)
     turbinia_processor.setup(
         disk_name='disk-1',
@@ -55,7 +56,7 @@ class TurbiniaProcessorTest(unittest.TestCase):
   # pylint: disable=invalid-name
   def testWrongProject(self, _mock_TurbiniaClient):
     """Tests that specifying the wrong Turbinia project generates an error."""
-    test_state = state.DFTimewolfState()
+    test_state = state.DFTimewolfState(config.Config)
     turbinia_processor = turbinia.TurbiniaProcessor(test_state)
     turbinia_processor.setup(
         disk_name='disk-1',
@@ -95,7 +96,7 @@ class TurbiniaProcessorTest(unittest.TestCase):
                       'specified, bailing out')
 
     for combination in params:
-      test_state = state.DFTimewolfState()
+      test_state = state.DFTimewolfState(config.Config)
       turbinia_processor = turbinia.TurbiniaProcessor(test_state)
       turbinia_processor.setup(**combination)
       self.assertEqual(len(test_state.errors), 1)
@@ -115,7 +116,7 @@ class TurbiniaProcessorTest(unittest.TestCase):
                   mock_exists):
     """Tests that the processor processes data correctly."""
 
-    test_state = state.DFTimewolfState()
+    test_state = state.DFTimewolfState(config.Config)
     turbinia_processor = turbinia.TurbiniaProcessor(test_state)
     turbinia_processor.setup(
         disk_name='disk-1',
@@ -155,8 +156,8 @@ class TurbiniaProcessorTest(unittest.TestCase):
         'gs://bucket/data3.plaso',
         local_output_dir=turbinia_processor._output_path
     )
-    self.assertEquals(test_state.errors, [])
-    self.assertEquals(test_state.output, [
+    self.assertEqual(test_state.errors, [])
+    self.assertEqual(test_state.output, [
         ('turbinia-project-disk-1', '/fake/data.plaso'),
         ('turbinia-project-disk-1', '/fake/data2.plaso'),
         ('turbinia-project-disk-1', '/fake/local/path')


### PR DESCRIPTION
This PR changes the way modules are run in a given recipe.

* All modules are started and setup simultaneously.
* Recipes define which modules should be started as well as which modules act as blockers for other modules to start processing input. Modules can also store and retrieve data to the state object.

This introduces two new features for recipes:

* multiple modules can now re-use data provided by a single module (think threat intelligence used in different modules)
* multiple modules can store information that can later on be re-used (think multiple modules collecting report data that will ultimately be posted to an incident response platform)