### PR TITLE
Add overwrite boolean

### DIFF
--- a/dftimewolf/lib/modules/manager.py
+++ b/dftimewolf/lib/modules/manager.py
@@ -5,9 +5,15 @@ from __future__ import unicode_literals
 
 
 class ModulesManager(object):
-  """Modules manager."""
+  """Modules manager.
+
+  Attribs:
+    enable_overwrite: Whether an exception is raised if an existing module is
+        registered more than once.
+  """
 
   _module_classes = {}
+  enable_overwrite = False
 
   @classmethod
   def DeregisterModule(cls, module_class):
@@ -55,7 +61,7 @@ class ModulesManager(object):
       KeyError: if module class is already set for the corresponding class name.
     """
     class_name = module_class.__name__
-    if class_name in cls._module_classes:
+    if class_name in cls._module_classes and not cls.enable_overwrite:
       raise KeyError('Module class already set for: {0:s}.'.format(class_name))
 
     cls._module_classes[class_name] = module_class

--- a/dftimewolf/lib/modules/manager.py
+++ b/dftimewolf/lib/modules/manager.py
@@ -5,15 +5,12 @@ from __future__ import unicode_literals
 
 
 class ModulesManager(object):
-  """Modules manager.
+  """Modules manager."""
 
-  Attribs:
-    enable_overwrite: Whether an exception is raised if an existing module is
-        registered more than once.
-  """
+  # Allow a previously registered module to be overridden.
+  ALLOW_MODULE_OVERRIDE = False
 
   _module_classes = {}
-  enable_overwrite = False
 
   @classmethod
   def DeregisterModule(cls, module_class):
@@ -61,7 +58,7 @@ class ModulesManager(object):
       KeyError: if module class is already set for the corresponding class name.
     """
     class_name = module_class.__name__
-    if class_name in cls._module_classes and not cls.enable_overwrite:
+    if class_name in cls._module_classes and not cls.ALLOW_MODULE_OVERRIDE:
       raise KeyError('Module class already set for: {0:s}.'.format(class_name))
 
     cls._module_classes[class_name] = module_class

--- a/dftimewolf/lib/recipes/manager.py
+++ b/dftimewolf/lib/recipes/manager.py
@@ -13,9 +13,17 @@ from dftimewolf.lib import resources
 
 
 class RecipesManager(object):
-  """Recipes manager."""
+  """Recipes manager.
+
+  Attribs:
+    enable_overwrite: Whether an exception is raised if an existing module is
+        registered more than once.
+  """
 
   _recipes = {}
+
+  def __init__(self):
+    self.enable_overwrite = False
 
   def _ReadRecipeFromFileObject(self, file_object):
     """Reads a recipe from a JSON file-like object.
@@ -101,7 +109,7 @@ class RecipesManager(object):
       KeyError: if recipe is already set for the corresponding name.
     """
     recipe_name = recipe.name.lower()
-    if recipe_name in self._recipes:
+    if recipe_name in self._recipes and not self.enable_overwrite:
       raise KeyError('Recipe already set for name: {0:s}.'.format(recipe.name))
 
     self._recipes[recipe_name] = recipe

--- a/dftimewolf/lib/recipes/manager.py
+++ b/dftimewolf/lib/recipes/manager.py
@@ -13,17 +13,12 @@ from dftimewolf.lib import resources
 
 
 class RecipesManager(object):
-  """Recipes manager.
+  """Recipes manager."""
 
-  Attribs:
-    enable_overwrite: Whether an exception is raised if an existing module is
-        registered more than once.
-  """
+  # Allow a previously registered recipe to be overridden.
+  ALLOW_RECIPE_OVERRIDE = False
 
   _recipes = {}
-
-  def __init__(self):
-    self.enable_overwrite = False
 
   def _ReadRecipeFromFileObject(self, file_object):
     """Reads a recipe from a JSON file-like object.
@@ -109,7 +104,7 @@ class RecipesManager(object):
       KeyError: if recipe is already set for the corresponding name.
     """
     recipe_name = recipe.name.lower()
-    if recipe_name in self._recipes and not self.enable_overwrite:
+    if recipe_name in self._recipes and not self.ALLOW_RECIPE_OVERRIDE:
       raise KeyError('Recipe already set for name: {0:s}.'.format(recipe.name))
 
     self._recipes[recipe_name] = recipe

--- a/tests/lib/modules/manager.py
+++ b/tests/lib/modules/manager.py
@@ -17,6 +17,9 @@ class TestModule(module.BaseModule):  # pylint: disable=abstract-method
 class ModulesManagerTest(unittest.TestCase):
   """Tests for the modules manager."""
 
+  def setUp(self):
+    manager.ModulesManager.ALLOW_MODULE_OVERRIDE = False
+
   def testModuleRegistration(self):
     """Tests the RegisterModule and DeregisterModule functions."""
     # pylint: disable=protected-access
@@ -29,6 +32,27 @@ class ModulesManagerTest(unittest.TestCase):
 
     with self.assertRaises(KeyError):
       manager.ModulesManager.RegisterModule(TestModule)
+
+    manager.ModulesManager.DeregisterModule(TestModule)
+    self.assertEqual(
+        len(manager.ModulesManager._module_classes), number_of_module_classes)
+
+  def testOverrideModuleRegistration(self):
+    """Tests the RegisterModule with override functionality."""
+    # pylint: disable=protected-access
+    manager.ModulesManager.ALLOW_MODULE_OVERRIDE = True
+    number_of_module_classes = len(manager.ModulesManager._module_classes)
+
+    manager.ModulesManager.RegisterModule(TestModule)
+    self.assertEqual(
+        len(manager.ModulesManager._module_classes),
+        number_of_module_classes + 1)
+
+    # Registering the same module twice should not raise an exception.
+    manager.ModulesManager.RegisterModule(TestModule)
+    self.assertEqual(
+        len(manager.ModulesManager._module_classes),
+        number_of_module_classes + 1)
 
     manager.ModulesManager.DeregisterModule(TestModule)
     self.assertEqual(

--- a/tests/lib/modules/manager.py
+++ b/tests/lib/modules/manager.py
@@ -17,12 +17,13 @@ class TestModule(module.BaseModule):  # pylint: disable=abstract-method
 class ModulesManagerTest(unittest.TestCase):
   """Tests for the modules manager."""
 
+  # pylint: disable=protected-access
+
   def setUp(self):
     manager.ModulesManager.ALLOW_MODULE_OVERRIDE = False
 
   def testModuleRegistration(self):
     """Tests the RegisterModule and DeregisterModule functions."""
-    # pylint: disable=protected-access
     number_of_module_classes = len(manager.ModulesManager._module_classes)
 
     manager.ModulesManager.RegisterModule(TestModule)

--- a/tests/lib/modules/manager.py
+++ b/tests/lib/modules/manager.py
@@ -40,7 +40,6 @@ class ModulesManagerTest(unittest.TestCase):
 
   def testOverrideModuleRegistration(self):
     """Tests the RegisterModule with override functionality."""
-    # pylint: disable=protected-access
     manager.ModulesManager.ALLOW_MODULE_OVERRIDE = True
     number_of_module_classes = len(manager.ModulesManager._module_classes)
 
@@ -63,7 +62,6 @@ class ModulesManagerTest(unittest.TestCase):
 
   def testRegisterModules(self):
     """Tests the RegisterModules function."""
-    # pylint: disable=protected-access
     number_of_module_classes = len(manager.ModulesManager._module_classes)
 
     manager.ModulesManager.RegisterModules([TestModule])

--- a/tests/lib/recipes/manager.py
+++ b/tests/lib/recipes/manager.py
@@ -60,6 +60,9 @@ class RecipesManagerTest(unittest.TestCase):
 }
 """
 
+  def setUp(self):
+    manager.RecipesManager.ALLOW_RECIPE_OVERRIDE = False
+
   def testReadRecipeFromFileObject(self):
     """Tests the _ReadRecipeFromFileObject function."""
     test_manager = manager.RecipesManager()
@@ -91,6 +94,28 @@ class RecipesManagerTest(unittest.TestCase):
 
     test_manager.DeregisterRecipe(test_recipe)
     self.assertEqual(len(test_manager._recipes), number_of_recipes)
+
+  def testOverrideRecipeRegistration(self):
+    """Tests the RegisterRecipe with override functionality."""
+    manager.RecipesManager.ALLOW_RECIPE_OVERRIDE = True
+    test_manager = manager.RecipesManager()
+
+    test_recipe = TestRecipe()
+
+    # pylint: disable=protected-access
+    number_of_recipes = len(test_manager._recipes)
+
+    test_manager.RegisterRecipe(test_recipe)
+    self.assertEqual(len(test_manager._recipes), number_of_recipes + 1)
+
+    override = TestRecipe()
+    override.description = 'override'
+    test_manager.RegisterRecipe(override)
+
+    self.assertEqual(len(test_manager._recipes), number_of_recipes + 1)
+    self.assertEqual(test_manager._recipes['test'].description, 'override')
+
+    test_manager.DeregisterRecipe(override)
 
   def testGetRecipes(self):
     """Tests the GetRecipes function."""

--- a/tests/lib/recipes/manager.py
+++ b/tests/lib/recipes/manager.py
@@ -83,7 +83,6 @@ class RecipesManagerTest(unittest.TestCase):
 
     test_recipe = TestRecipe()
 
-    # pylint: disable=protected-access
     number_of_recipes = len(test_manager._recipes)
 
     test_manager.RegisterRecipe(test_recipe)
@@ -102,7 +101,6 @@ class RecipesManagerTest(unittest.TestCase):
 
     test_recipe = TestRecipe()
 
-    # pylint: disable=protected-access
     number_of_recipes = len(test_manager._recipes)
 
     test_manager.RegisterRecipe(test_recipe)
@@ -136,7 +134,6 @@ class RecipesManagerTest(unittest.TestCase):
 
     test_recipe = TestRecipe()
 
-    # pylint: disable=protected-access
     number_of_recipes = len(test_manager._recipes)
 
     test_manager.RegisterRecipes([test_recipe])


### PR DESCRIPTION
This makes it easier to register recipes and modules that have been declared in separate files without knowing their names in advance.