### PR TITLE
Use Turbinia reports and version bump

### DIFF
--- a/dftimewolf/lib/containers/report.py
+++ b/dftimewolf/lib/containers/report.py
@@ -5,26 +5,34 @@ from dftimewolf.lib.containers import interface
 
 class Report(interface.AttributeContainer):
   """Analysis report attribute container.
+
   Attributes:
     module_name (str): name of the module that generated the report.
     text (str): report text.
+    text_format (str): format of text in the report. Must be either 'plaintext'
+      or 'markdown'
     attributes (list): attribute list, dicts must contain 'name',
       'type', 'values' keys.
   """
   CONTAINER_TYPE = 'report'
 
-  def __init__(self, module_name, text, attributes=None):
+  def __init__(
+      self, module_name, text, text_format='plaintext', attributes=None):
     """Initializes the analysis report.
+
     Args:
       module_name (str): name of the analysis plugin that generated
           the report.
       text (str): report text.
+      text_format (str): format of text in the report. Must be either
+        'plaintext' or 'markdown'.
       attributes (list): attribute list of dicts that must contain 'name',
         'type', 'values' keys.
     """
     super(Report, self).__init__()
     self.module_name = module_name
     self.text = text
+    self.text_format = text_format
     if attributes is None:
       self.attributes = []
     else:

--- a/dftimewolf/lib/processors/turbinia.py
+++ b/dftimewolf/lib/processors/turbinia.py
@@ -163,23 +163,9 @@ class TurbiniaProcessor(module.BaseModule):
       self.state.AddError(exception, critical=True)
       return
 
-    # Turbinia run complete, build a human-readable message of results.
-    message = 'Completed {0:d} Turbinia tasks\n'.format(len(task_data))
-    for task in task_data:
-      message += '{0!s} ({1!s}): {2!s}\n'.format(
-          task.get('name'),
-          task.get('id'),
-          task.get('status', 'No task status'))
-      # saved_paths may be set to None
-      for path in task.get('saved_paths') or []:
-        if path.endswith('worker-log.txt'):
-          continue
-        if path.endswith('{0!s}.log'.format(task.get('id'))):
-          continue
-        if path.startswith('/'):
-          continue
-        message += '  {0:s}\n'.format(path)
-    print(message)
+    message = self.client.format_task_status(**request_dict, full_report=True)
+    short_message = self.client.format_task_status(**request_dict)
+    print(short_message)
 
     # Store the message for consumption by any reporting modules.
     report = containers.Report(

--- a/dftimewolf/lib/processors/turbinia.py
+++ b/dftimewolf/lib/processors/turbinia.py
@@ -182,7 +182,8 @@ class TurbiniaProcessor(module.BaseModule):
     print(message)
 
     # Store the message for consumption by any reporting modules.
-    report = containers.Report(module_name='TurbiniaProcessor', text=message)
+    report = containers.Report(
+        module_name='TurbiniaProcessor', text=message, text_format='markdown')
     self.state.StoreContainer(report)
 
     # This finds all .plaso files in the Turbinia output, and determines if they

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ chardet==3.0.4
 cryptography==2.4.2
 decorator==4.4.0
 future==0.16.0
-git+https://github.com/google/turbinia.git@4da9b772e883c84c41f5714faea50f67a6c878d7#egg=turbinia
+turbinia==20190819
 google-api-core[grpc]==1.14.0
 google-auth==1.6.3
 google-cloud-core==1.0.3

--- a/tests/lib/containers/report.py
+++ b/tests/lib/containers/report.py
@@ -14,7 +14,8 @@ class ReportDataTest(unittest.TestCase):
     """Tests the GetAttributeNames function."""
     attribute_container = containers.Report(module_name='name', text='text')
 
-    expected_attribute_names = ['attributes', 'module_name', 'text']
+    expected_attribute_names = [
+        'attributes', 'module_name', 'text', 'text_format']
 
     attribute_names = sorted(attribute_container.GetAttributeNames())
 


### PR DESCRIPTION
This uses the Turbinia reports instead of the dftimewolf summary, and does a couple other things:
-  Prints out the short version of the report on the command line
- Sets the full report in the Report container for later reporting.
- Adds a `text_format` attribute so we can define this report as markdown. 
- Swaps the version of Turbinia from tomchop's fork to the latest release.