### PR TITLE
Cleanup

### DIFF
--- a/dftimewolf/lib/exporters/local_filesystem.py
+++ b/dftimewolf/lib/exporters/local_filesystem.py
@@ -35,11 +35,7 @@ class LocalFilesystemCopy(module.BaseModule):
     if not target_directory:
       self._target_directory = tempfile.mkdtemp()
     elif not os.path.exists(target_directory):
-      try:
-        os.makedirs(target_directory)
-      except OSError as exception:
-        message = 'An unknown error occurred: {0!s}'.format(exception)
-        self.state.AddError(message, critical=True)
+      os.makedirs(target_directory)
 
   def Process(self):
     """Checks whether the paths exists and updates the state accordingly."""

--- a/tests/lib/exporters/local_filesystem.py
+++ b/tests/lib/exporters/local_filesystem.py
@@ -82,8 +82,9 @@ class LocalFileSystemTest(unittest.TestCase):
     mock_makedirs.side_effect = OSError('FAKEERROR')
     test_state = state.DFTimewolfState(config.Config)
     local_filesystem_copy = local_filesystem.LocalFilesystemCopy(test_state)
-    local_filesystem_copy.SetUp(target_directory="/nonexistent")
-    self.assertEqual(test_state.errors[0][1], True)
+    with self.assertRaises(OSError) as exception:
+      local_filesystem_copy.SetUp(target_directory="/nonexistent")
+      self.assertEqual(str(exception), 'FAKEERROR')
 
   @mock.patch('os.makedirs')
   def testSetupManualDir(self, mock_makedirs):


### PR DESCRIPTION
Errors are caught around calls to `SetUp()` and `Process()`, so no need to catch and add them here.