### PR TITLE
Introduce StreamingContainers

### DIFF
--- a/dftimewolf/lib/containers/containers.py
+++ b/dftimewolf/lib/containers/containers.py
@@ -72,22 +72,20 @@ class ThreatIntelligence(interface.AttributeContainer):
   Attributes:
     name (string): name of the threat
     indicator (string): regular expression relevant to a threat
-    path (string): path to the indicator data (e.g. file)
   """
   CONTAINER_TYPE = 'threat_intelligence'
 
-  def __init__(self, name, indicator, path):
+  def __init__(self, name, indicator):
     """Initializes the Threat Intelligence container.
 
     Args:
       name (string): name of the threat
       indicator (string): regular expression relevant to a threat
-      path (string): path to the indicator data (e.g. file)
     """
     super(ThreatIntelligence, self).__init__()
     self.name = name
     self.indicator = indicator
-    self.path = path
+
 
 class TicketAttribute(interface.AttributeContainer):
   """Attribute container definition for generic ticketing system attributes.

--- a/dftimewolf/lib/containers/containers.py
+++ b/dftimewolf/lib/containers/containers.py
@@ -72,20 +72,22 @@ class ThreatIntelligence(interface.AttributeContainer):
   Attributes:
     name (string): name of the threat
     indicator (string): regular expression relevant to a threat
+    path (string): path to the indicator data (e.g. file)
   """
   CONTAINER_TYPE = 'threat_intelligence'
 
-  def __init__(self, name, indicator):
+  def __init__(self, name, indicator, path):
     """Initializes the Threat Intelligence container.
 
     Args:
       name (string): name of the threat
       indicator (string): regular expression relevant to a threat
+      path (string): path to the indicator data (e.g. file)
     """
     super(ThreatIntelligence, self).__init__()
     self.name = name
     self.indicator = indicator
-
+    self.path = path
 
 class TicketAttribute(interface.AttributeContainer):
   """Attribute container definition for generic ticketing system attributes.

--- a/dftimewolf/lib/state.py
+++ b/dftimewolf/lib/state.py
@@ -221,7 +221,7 @@ class DFTimewolfState(object):
       self.streaming_callbacks[container.CONTAINER_TYPE] = []
     self.streaming_callbacks[container.CONTAINER_TYPE].append(target)
 
-  def StoreStreamingContainer(self, container):
+  def StreamContainer(self, container):
     """Streams a container to the callbacks that are registered to handle it.
 
     Args:

--- a/dftimewolf/lib/state.py
+++ b/dftimewolf/lib/state.py
@@ -227,7 +227,6 @@ class DFTimewolfState(object):
     Args:
       container (interface.AttributeContainer): container that will be streamed
           to any registered callbacks.
-
     """
     for container_type, callbacks in self.streaming_callbacks.items():
       if container_type == container.CONTAINER_TYPE:

--- a/dftimewolf/lib/state.py
+++ b/dftimewolf/lib/state.py
@@ -209,7 +209,7 @@ class DFTimewolfState(object):
     """Performs the actual processing for each module in the module pool."""
     self._InvokeModulesInThreads(self._RunModuleThread)
 
-  def RegisterStreamingCallback(self, target, container):
+  def RegisterStreamingCallback(self, target, container_type):
     """Registers a callback for a type of container.
 
     The function to be registered should a single parameter of type
@@ -217,21 +217,21 @@ class DFTimewolfState(object):
 
     Args:
       target (function): function to be called.
-      container (interface.AttributeContainer): container type on which
-          the callback will be called.
+      container_type (type[interface.AttributeContainer]): container type on
+          which the callback will be called.
     """
-    if container.CONTAINER_TYPE not in self.streaming_callbacks:
-      self.streaming_callbacks[container.CONTAINER_TYPE] = []
-    self.streaming_callbacks[container.CONTAINER_TYPE].append(target)
+    if container_type not in self.streaming_callbacks:
+      self.streaming_callbacks[container_type] = []
+    self.streaming_callbacks[container_type].append(target)
 
   def StreamContainer(self, container):
     """Streams a container to the callbacks that are registered to handle it.
 
     Args:
-      container (interface.AttributeContainer): container that will be streamed
-          to any registered callbacks.
+      container (interface.AttributeContainer): container instance that will be
+          streamed to any registered callbacks.
     """
-    for callback in self.streaming_callbacks.get(container.CONTAINER_TYPE, []):
+    for callback in self.streaming_callbacks.get(type(container), []):
       callback(container)
 
   def AddError(self, error, critical=False):

--- a/dftimewolf/lib/state.py
+++ b/dftimewolf/lib/state.py
@@ -231,10 +231,8 @@ class DFTimewolfState(object):
       container (interface.AttributeContainer): container that will be streamed
           to any registered callbacks.
     """
-    for container_type, callbacks in self.streaming_callbacks.items():
-      if container_type == container.CONTAINER_TYPE:
-        for callback in callbacks:
-          callback(container)
+    for callback in self.streaming_callbacks.get(container.CONTAINER_TYPE, []):
+      callback(container)
 
   def AddError(self, error, critical=False):
     """Adds an error to the state.

--- a/dftimewolf/lib/state.py
+++ b/dftimewolf/lib/state.py
@@ -212,6 +212,9 @@ class DFTimewolfState(object):
   def RegisterStreamingCallback(self, target, container):
     """Registers a callback for a type of container.
 
+    The function to be registered should a single parameter of type
+    interface.AttributeContainer.
+
     Args:
       target (function): function to be called.
       container (interface.AttributeContainer): container type on which

--- a/dftimewolf/lib/state.py
+++ b/dftimewolf/lib/state.py
@@ -47,6 +47,7 @@ class DFTimewolfState(object):
     self.output = []
     self.recipe = None
     self.store = {}
+    self.streaming_callbacks = {}
 
   def _InvokeModulesInThreads(self, callback):
     """Invokes the callback function on all the modules in separate threads.
@@ -207,6 +208,31 @@ class DFTimewolfState(object):
   def RunModules(self):
     """Performs the actual processing for each module in the module pool."""
     self._InvokeModulesInThreads(self._RunModuleThread)
+
+  def RegisterStreamingCallback(self, target, container):
+    """Registers a callback for a type of container.
+
+    Args:
+      target (function): function to be called.
+      container (interface.AttributeContainer): container type on which
+          the callback will be called.
+    """
+    if container.CONTAINER_TYPE not in self.streaming_callbacks:
+      self.streaming_callbacks[container.CONTAINER_TYPE] = []
+    self.streaming_callbacks[container.CONTAINER_TYPE].append(target)
+
+  def StoreStreamingContainer(self, container):
+    """Streams a container to the callbacks that are registered to handle it.
+
+    Args:
+      container (interface.AttributeContainer): container that will be streamed
+          to any registered callbacks.
+
+    """
+    for container_type, callbacks in self.streaming_callbacks.items():
+      if container_type == container.CONTAINER_TYPE:
+        for callback in callbacks:
+          callback(container)
 
   def AddError(self, error, critical=False):
     """Adds an error to the state.

--- a/tests/lib/state.py
+++ b/tests/lib/state.py
@@ -137,7 +137,7 @@ class StateTest(unittest.TestCase):
     test_state.SetupModules()
     # DummyModule1 has registered a StreamingConsumer
     report = containers.Report(module_name='testing', text='asd')
-    test_state.StoreStreamingContainer(report)
+    test_state.StreamContainer(report)
     mock_callback.assert_called_with(report)
 
   @mock.patch('tests.test_modules.modules.DummyModule1.Callback')
@@ -150,7 +150,7 @@ class StateTest(unittest.TestCase):
     # DummyModule1's registered StreamingConsumer only consumes Reports, not
     # TicketAtttributes
     attributes = containers.TicketAttribute(type_='asd', name='asd', value='asd')
-    test_state.StoreStreamingContainer(attributes)
+    test_state.StreamContainer(attributes)
     mock_callback.assert_not_called()
 
 if __name__ == '__main__':

--- a/tests/lib/state.py
+++ b/tests/lib/state.py
@@ -129,5 +129,29 @@ class StateTest(unittest.TestCase):
     self.assertIn('dfTimewolf Error', msg)
     self.assertTrue(critical)
 
+  @mock.patch('tests.test_modules.modules.DummyModule1.Callback')
+  def testStreamingCallback(self, mock_callback):
+    """Tests that registered callbacks are appropriately called."""
+    test_state = state.DFTimewolfState(config.Config)
+    test_state.LoadRecipe(test_recipe.contents)
+    test_state.SetupModules()
+    # DummyModule1 has registered a StreamingConsumer
+    report = containers.Report(module_name='testing', text='asd')
+    test_state.StoreStreamingContainer(report)
+    mock_callback.assert_called_with(report)
+
+  @mock.patch('tests.test_modules.modules.DummyModule1.Callback')
+  def testStreamingCallbackNotCalled(self, mock_callback):
+    """Tests that registered callbacks are called only on types for which
+    they are registered."""
+    test_state = state.DFTimewolfState(config.Config)
+    test_state.LoadRecipe(test_recipe.contents)
+    test_state.SetupModules()
+    # DummyModule1's registered StreamingConsumer only consumes Reports, not
+    # TicketAtttributes
+    attributes = containers.TicketAttribute(type_='asd', name='asd', value='asd')
+    test_state.StoreStreamingContainer(attributes)
+    mock_callback.assert_not_called()
+
 if __name__ == '__main__':
   unittest.main()

--- a/tests/lib/state.py
+++ b/tests/lib/state.py
@@ -149,7 +149,8 @@ class StateTest(unittest.TestCase):
     test_state.SetupModules()
     # DummyModule1's registered StreamingConsumer only consumes Reports, not
     # TicketAtttributes
-    attributes = containers.TicketAttribute(type_='asd', name='asd', value='asd')
+    attributes = containers.TicketAttribute(
+        type_='asd', name='asd', value='asd')
     test_state.StreamContainer(attributes)
     mock_callback.assert_not_called()
 

--- a/tests/test_modules/modules.py
+++ b/tests/test_modules/modules.py
@@ -21,7 +21,6 @@ class DummyModule1(module.BaseModule):
 
   def Callback(self, container):
     """Dummy callback that we just want to have called"""
-    pass
 
   def Process(self):
     """Dummy Process function."""

--- a/tests/test_modules/modules.py
+++ b/tests/test_modules/modules.py
@@ -4,6 +4,7 @@
 from __future__ import print_function, unicode_literals
 
 from dftimewolf.lib import module
+from dftimewolf.lib.containers import containers
 
 
 class DummyModule1(module.BaseModule):
@@ -16,6 +17,11 @@ class DummyModule1(module.BaseModule):
   def SetUp(self):  # pylint: disable=arguments-differ
     """Dummy setup function."""
     print(self.name + ' Setup!')
+    self.state.RegisterStreamingCallback(self.Callback, containers.Report)
+
+  def Callback(self, container):
+    """Dummy callback that we just want to have called"""
+    pass
 
   def Process(self):
     """Dummy Process function."""


### PR DESCRIPTION
This PR introduces StreamingContainers in dfTimewolf.

Modules register StreamingContainersConsumers by passing a callback and an AttributeContainer class to `RegisterStreamingCallback`. Other modules then call `StreamContainer` with the container of their choice, and all callbacks registered for that container type will be called. 

Containers "streamed" this way are not stored and cannot be recovered later on, unless the callback implements an internal mechanism to preserve them.