### PR TITLE
Fix GCP recipe.

### DIFF
--- a/data/recipes/gcp_forensics.json
+++ b/data/recipes/gcp_forensics.json
@@ -15,8 +15,8 @@
           "all_disks": "@all_disks",
           "boot_disk_size": "@boot_disk_size",
           "cpu_cores": 16,
-          "image_project": "ubuntu-1804-lts",
-          "image_family": "ubuntu-os-cloud"
+          "image_project": "ubuntu-os-cloud",
+          "image_family": "ubuntu-1804-lts"
       }
   }],
   "args": [


### PR DESCRIPTION
The image project and image family in the current GCP recipe is inverted, causing the recipe to fail with the following error message:

```
$: dftimewolf gcp_forensics --instance instance_name --analysis_project_name project_name other_project_name incident_id

$: googleapiclient.errors.HttpError: <HttpError 404 when requesting https://compute.googleapis.com/compute/v1/projects/ubuntu-1804-lts/global/images/family/ubuntu-os-cloud?alt=json returned "The resource 'projects/ubuntu-1804-lts' was not found">
```

See https://cloud.google.com/compute/docs/images

Signed-off-by: Theo Giovanna <gtheo@google.com>