### PR TITLE
Disable expensive Turbinia jobs by default

### DIFF
--- a/dftimewolf/lib/processors/turbinia.py
+++ b/dftimewolf/lib/processors/turbinia.py
@@ -180,7 +180,8 @@ class TurbiniaProcessor(module.BaseModule):
     if self.sketch_id:
       request.recipe['sketch_id'] = self.sketch_id
     if not self.run_all_jobs:
-      request.recipe['jobs_blacklist'] = ['StringsJob']
+      request.recipe['jobs_blacklist'] = [
+          'StringsJob', 'BinaryExtractorJob', 'BulkExtractorJob', 'PhotorecJob']
 
     # Get threat intelligence data from any modules that have stored some.
     # In this case, observables is a list of containers.ThreatIntelligence

--- a/dftimewolf/lib/processors/turbinia.py
+++ b/dftimewolf/lib/processors/turbinia.py
@@ -180,7 +180,11 @@ class TurbiniaProcessor(module.BaseModule):
     if self.sketch_id:
       request.recipe['sketch_id'] = self.sketch_id
     if not self.run_all_jobs:
+      # TODO(aarontp): Remove once the release with
+      # https://github.com/google/turbinia/pull/554 is live.
       request.recipe['jobs_blacklist'] = [
+          'StringsJob', 'BinaryExtractorJob', 'BulkExtractorJob', 'PhotorecJob']
+      request.recipe['jobs_denylist'] = [
           'StringsJob', 'BinaryExtractorJob', 'BulkExtractorJob', 'PhotorecJob']
 
     # Get threat intelligence data from any modules that have stored some.

--- a/tests/lib/processors/turbinia.py
+++ b/tests/lib/processors/turbinia.py
@@ -159,7 +159,9 @@ class TurbiniaProcessorTest(unittest.TestCase):
     turbinia_processor.client.send_request.assert_called()
     request = turbinia_processor.client.send_request.call_args[0][0]
     self.assertEqual(request.recipe['sketch_id'], 4567)
-    self.assertListEqual(request.recipe['jobs_blacklist'], ['StringsJob'])
+    self.assertListEqual(
+        request.recipe['jobs_blacklist'],
+        ['StringsJob', 'BinaryExtractorJob', 'BulkExtractorJob', 'PhotorecJob'])
     turbinia_processor.client.get_task_data.assert_called()
     # pylint: disable=protected-access
     mock_GCSOutputWriter.assert_any_call(

--- a/tests/lib/processors/turbinia.py
+++ b/tests/lib/processors/turbinia.py
@@ -162,6 +162,9 @@ class TurbiniaProcessorTest(unittest.TestCase):
     self.assertListEqual(
         request.recipe['jobs_blacklist'],
         ['StringsJob', 'BinaryExtractorJob', 'BulkExtractorJob', 'PhotorecJob'])
+    self.assertListEqual(
+        request.recipe['jobs_denylist'],
+        ['StringsJob', 'BinaryExtractorJob', 'BulkExtractorJob', 'PhotorecJob'])
     turbinia_processor.client.get_task_data.assert_called()
     # pylint: disable=protected-access
     mock_GCSOutputWriter.assert_any_call(


### PR DESCRIPTION
This should speed up the runs a bit.   In the next release of Turbinia we should be able to handle this with a recipe.  Also, the flags for this are getting renamed in the next release (https://github.com/google/turbinia/pull/554/), but I'll push another change here before that gets released.