### PR TITLE
use the relase docker image (stable)

### DIFF
--- a/config/linux/jenkins_dftimewolf_install.sh
+++ b/config/linux/jenkins_dftimewolf_install.sh
@@ -64,7 +64,7 @@ if [[ "$*" =~ "include-grr" ]]; then
       -e ADMIN_PASSWORD="admin" \
       --ulimit nofile=1048576:1048576 \
       -p 127.0.0.1:8000:8000 -p 127.0.0.1:8080:8080 \
-      -d grrdocker/grr:latest grr
+      -d grrdocker/grr:release grr
 
     # Wait for GRR to initialize.
     /bin/sleep 120


### PR DESCRIPTION
This fixes some broken e2e tests