### PR TITLE
Set ES version for Timesketch e2e tests

### DIFF
--- a/config/linux/jenkins_dftimewolf_install.sh
+++ b/config/linux/jenkins_dftimewolf_install.sh
@@ -78,6 +78,7 @@ if [[ "$*" =~ "include-timesketch" ]]; then
     # Start the Timesketch server container.
      export TIMESKETCH_USER="your_username"
      export TIMESKETCH_PASSWORD="your_password"
+     export ELASTICSEARCH_VERSION=7.6.2
      git clone https://github.com/google/timesketch.git
      cd timesketch
      cd docker


### PR DESCRIPTION
Add required env variable to tell Docker what version of ES to run.