### PR TITLE
fix: CreateDisk call passing the proper parameters

### DIFF
--- a/dftimewolf/lib/collectors/gcloud.py
+++ b/dftimewolf/lib/collectors/gcloud.py
@@ -59,7 +59,6 @@ class GoogleCloudCollector(module.BaseModule):
       new_disk = gcp_forensics.CreateDiskCopy(
           self.remote_project.project_id,
           self.analysis_project.project_id,
-          None,
           self.analysis_project.default_zone,
           disk_name=disk.name)
       self.logger.info('Disk {0:s} successfully copied to {1:s}'.format(

--- a/tests/lib/collectors/gcloud.py
+++ b/tests/lib/collectors/gcloud.py
@@ -135,7 +135,6 @@ class GoogleCloudCollectorTest(unittest.TestCase):
     mock_CreateDiskCopy.assert_called_with(
         'test-target-project-name',
         'test-analysis-project-name',
-        None,
         FAKE_DISK.zone,
         disk_name=FAKE_DISK.name)
     forensics_vms = test_state.GetContainers(containers.ForensicsVM)


### PR DESCRIPTION
At some point in time, `instance_name` and `zone` were flipped in libcloudofrensics, making this brittle as `None` was being passed as the zone name. This made that disks could be created in other zones and failed to attach to the original analysis VM.