### PR TITLE
Introduce runtime names for modules

### DIFF
--- a/dftimewolf/lib/collectors/aws.py
+++ b/dftimewolf/lib/collectors/aws.py
@@ -36,15 +36,16 @@ class AWSCollector(module.BaseModule):
   _ANALYSIS_VM_CONTAINER_ATTRIBUTE_NAME = 'Analysis VM'
   _ANALYSIS_VM_CONTAINER_ATTRIBUTE_TYPE = 'text'
 
-  def __init__(self, state, critical=False):
+  def __init__(self, state, name=None, critical=False):
     """Initializes an Amazon Web Services (AWS) collector.
 
     Args:
       state (DFTimewolfState): recipe state.
+      name (Optional[str]): The module's runtime name.
       critical (Optional[bool]): True if the module is critical, which causes
           the entire recipe to fail if the module encounters an error.
     """
-    super(AWSCollector, self).__init__(state, critical=critical)
+    super(AWSCollector, self).__init__(state, name=name, critical=critical)
     self.remote_profile_name = None
     self.remote_zone = None
     self.source_account = None

--- a/dftimewolf/lib/collectors/filesystem.py
+++ b/dftimewolf/lib/collectors/filesystem.py
@@ -23,7 +23,8 @@ class FilesystemCollector(module.BaseModule):
       critical (Optional[bool]): True if the module is critical, which causes
           the entire recipe to fail if the module encounters an error.
     """
-    super(FilesystemCollector, self).__init__(state, name=name, critical=critical)
+    super(FilesystemCollector, self).__init__(
+        state, name=name, critical=critical)
     self._paths = None
 
   def SetUp(self, paths=None):  # pylint: disable=arguments-differ

--- a/dftimewolf/lib/collectors/filesystem.py
+++ b/dftimewolf/lib/collectors/filesystem.py
@@ -14,15 +14,16 @@ class FilesystemCollector(module.BaseModule):
   output: A list of existing file paths.
   """
 
-  def __init__(self, state, critical=False):
+  def __init__(self, state, name=None, critical=False):
     """Initializes a local file system collector.
 
     Args:
       state (DFTimewolfState): recipe state.
+      name (Optional[str]): The module's runtime name.
       critical (Optional[bool]): True if the module is critical, which causes
           the entire recipe to fail if the module encounters an error.
     """
-    super(FilesystemCollector, self).__init__(state, critical=critical)
+    super(FilesystemCollector, self).__init__(state, name=name, critical=critical)
     self._paths = None
 
   def SetUp(self, paths=None):  # pylint: disable=arguments-differ

--- a/dftimewolf/lib/collectors/gcloud.py
+++ b/dftimewolf/lib/collectors/gcloud.py
@@ -33,15 +33,16 @@ class GoogleCloudCollector(module.BaseModule):
   _ANALYSIS_VM_CONTAINER_ATTRIBUTE_NAME = 'Analysis VM'
   _ANALYSIS_VM_CONTAINER_ATTRIBUTE_TYPE = 'text'
 
-  def __init__(self, state, critical=False):
+  def __init__(self, state, name=None, critical=False):
     """Initializes a Google Cloud Platform (GCP) collector.
 
     Args:
       state (DFTimewolfState): recipe state.
+      name (Optional[str]): The module's runtime name.
       critical (Optional[bool]): True if the module is critical, which causes
           the entire recipe to fail if the module encounters an error.
     """
-    super(GoogleCloudCollector, self).__init__(state, critical=critical)
+    super(GoogleCloudCollector, self).__init__(state, name=name, critical=critical)
     self.analysis_project = None
     self.analysis_vm = None
     self.incident_id = None

--- a/dftimewolf/lib/collectors/gcloud.py
+++ b/dftimewolf/lib/collectors/gcloud.py
@@ -42,7 +42,8 @@ class GoogleCloudCollector(module.BaseModule):
       critical (Optional[bool]): True if the module is critical, which causes
           the entire recipe to fail if the module encounters an error.
     """
-    super(GoogleCloudCollector, self).__init__(state, name=name, critical=critical)
+    super(GoogleCloudCollector, self).__init__(
+        state, name=name, critical=critical)
     self.analysis_project = None
     self.analysis_vm = None
     self.incident_id = None

--- a/dftimewolf/lib/collectors/gcp_logging.py
+++ b/dftimewolf/lib/collectors/gcp_logging.py
@@ -31,9 +31,9 @@ logging.entries.ProtobufEntry.to_api_repr = _CustomToAPIRepr
 class GCPLogsCollector(module.BaseModule):
   """Collector for Google Cloud Platform logs."""
 
-  def __init__(self, state):
+  def __init__(self, state, name=None, critical=False):
     """Initializes a GCP logs collector."""
-    super(GCPLogsCollector, self).__init__(state)
+    super(GCPLogsCollector, self).__init__(state, name=name, critical=critical)
     self._filter_expression = None
     self._project_name = None
 

--- a/dftimewolf/lib/collectors/grr_base.py
+++ b/dftimewolf/lib/collectors/grr_base.py
@@ -21,15 +21,16 @@ class GRRBaseModule(module.BaseModule):
 
   _CHECK_APPROVAL_INTERVAL_SEC = 10
 
-  def __init__(self, state, critical=False):
+  def __init__(self, state, name=None, critical=False):
     """Initializes a GRR hunt or flow module.
 
     Args:
       state (DFTimewolfState): recipe state.
+      name (Optional[str]): The module's runtime name.
       critical (Optional[bool]): True if the module is critical, which causes
           the entire recipe to fail if the module encounters an error.
     """
-    super(GRRBaseModule, self).__init__(state, critical=critical)
+    super(GRRBaseModule, self).__init__(state, name=name, critical=critical)
     self.reason = None
     self.grr_api = None
     self.approvers = None

--- a/dftimewolf/lib/collectors/grr_hosts.py
+++ b/dftimewolf/lib/collectors/grr_hosts.py
@@ -33,15 +33,16 @@ class GRRFlow(GRRBaseModule):  # pylint: disable=abstract-method
 
   _CLIENT_ID_REGEX = re.compile(r'^c\.[0-9a-f]{16}$', re.IGNORECASE)
 
-  def __init__(self, state, critical=False):
+  def __init__(self, state, name=None, critical=False):
     """Initializes a GRR flow module.
 
     Args:
       state (DFTimewolfState): recipe state.
+      name (Optional[str]): The module's runtime name.
       critical (Optional[bool]): True if the module is critical, which causes
           the entire recipe to fail if the module encounters an error.
     """
-    super(GRRFlow, self).__init__(state, critical=critical)
+    super(GRRFlow, self).__init__(state, name=name, critical=critical)
     self.keepalive = False
     self._skipped_flows = []
     self.skip_offline_clients = False
@@ -310,8 +311,9 @@ class GRRArtifactCollector(GRRFlow):
       'Windows': _DEFAULT_ARTIFACTS_WINDOWS
   }
 
-  def __init__(self, state):
-    super(GRRArtifactCollector, self).__init__(state)
+  def __init__(self, state, name=None, critical=False):
+    super(GRRArtifactCollector, self).__init__(
+        state, name=name, critical=critical)
     self._clients = []
     self.artifacts = []
     self.extra_artifacts = []
@@ -441,8 +443,8 @@ class GRRFileCollector(GRRFlow):
               'stat': flows_pb2.FileFinderAction.STAT,
              }
 
-  def __init__(self, state):
-    super(GRRFileCollector, self).__init__(state)
+  def __init__(self, state, name=None, critical=False):
+    super(GRRFileCollector, self).__init__(state, name=name, critical=critical)
     self._clients = []
     self.files = []
     self.hostnames = None
@@ -545,8 +547,8 @@ class GRRFlowCollector(GRRFlow):
     host (str): Target of GRR collection.
   """
 
-  def __init__(self, state):
-    super(GRRFlowCollector, self).__init__(state)
+  def __init__(self, state, name=None, critical=False):
+    super(GRRFlowCollector, self).__init__(state, name=name, critical=critical)
     self.client_id = None
     self.flow_id = None
     self.host = None
@@ -603,13 +605,15 @@ class GRRFlowCollector(GRRFlow):
 
 class GRRTimelineCollector(GRRFlow):
   """Timeline collector for GRR flows.
+
   Attributes:
     root_path (str): root path.
     hostnames (list[str]): FDQNs of the GRR client hosts.
   """
 
-  def __init__(self, state):
-    super(GRRTimelineCollector, self).__init__(state)
+  def __init__(self, state, name=None, critical=False):
+    super(GRRTimelineCollector, self).__init__(
+        state, name=name, critical=critical)
     self._clients = []
     self.root_path = None
     self.hostnames = None

--- a/dftimewolf/lib/collectors/grr_hunt.py
+++ b/dftimewolf/lib/collectors/grr_hunt.py
@@ -65,7 +65,8 @@ class GRRHuntArtifactCollector(GRRHunt):
       critical (Optional[bool]): True if the module is critical, which causes
           the entire recipe to fail if the module encounters an error.
     """
-    super(GRRHuntArtifactCollector, self).__init__(state, name=name, critical=critical)
+    super(GRRHuntArtifactCollector, self).__init__(
+        state, name=name, critical=critical)
     self.artifacts = None
     self.use_tsk = None
     self.hunt = None
@@ -131,7 +132,8 @@ class GRRHuntFileCollector(GRRHunt):
       critical (Optional[bool]): True if the module is critical, which causes
           the entire recipe to fail if the module encounters an error.
     """
-    super(GRRHuntFileCollector, self).__init__(state, name=name, critical=critical)
+    super(GRRHuntFileCollector, self).__init__(
+        state, name=name, critical=critical)
     self.file_path_list = None
 
   # pylint: disable=arguments-differ

--- a/dftimewolf/lib/collectors/grr_hunt.py
+++ b/dftimewolf/lib/collectors/grr_hunt.py
@@ -56,15 +56,16 @@ class GRRHuntArtifactCollector(GRRHunt):
         system artifacts.
   """
 
-  def __init__(self, state, critical=False):
+  def __init__(self, state, name=None, critical=False):
     """Initializes a GRR artifact collector hunt.
 
     Args:
       state (DFTimewolfState): recipe state.
+      name (Optional[str]): The module's runtime name.
       critical (Optional[bool]): True if the module is critical, which causes
           the entire recipe to fail if the module encounters an error.
     """
-    super(GRRHuntArtifactCollector, self).__init__(state, critical=critical)
+    super(GRRHuntArtifactCollector, self).__init__(state, name=name, critical=critical)
     self.artifacts = None
     self.use_tsk = None
     self.hunt = None
@@ -121,15 +122,16 @@ class GRRHuntFileCollector(GRRHunt):
     file_path_list: comma-separated list of file paths.
   """
 
-  def __init__(self, state, critical=False):
+  def __init__(self, state, name=None, critical=False):
     """Initializes a GRR file collector hunt.
 
     Args:
       state (DFTimewolfState): recipe state.
+      name (Optional[str]): The module's runtime name.
       critical (Optional[bool]): True if the module is critical, which causes
           the entire recipe to fail if the module encounters an error.
     """
-    super(GRRHuntFileCollector, self).__init__(state, critical=critical)
+    super(GRRHuntFileCollector, self).__init__(state, name=name, critical=critical)
     self.file_path_list = None
 
   # pylint: disable=arguments-differ
@@ -183,15 +185,16 @@ class GRRHuntDownloader(GRRHunt):
     approvers (str): comma-separated GRR approval recipients.
   """
 
-  def __init__(self, state, critical=False):
+  def __init__(self, state, name=None, critical=False):
     """Initializes a GRR hunt results downloader.
 
     Args:
       state (DFTimewolfState): recipe state.
+      name (Optional[str]): The module's runtime name.
       critical (Optional[bool]): True if the module is critical, which causes
           the entire recipe to fail if the module encounters an error.
     """
-    super(GRRHuntDownloader, self).__init__(state, critical=critical)
+    super(GRRHuntDownloader, self).__init__(state, name=name, critical=critical)
     self.hunt_id = None
     self.output_path = None
 

--- a/dftimewolf/lib/enhancers/timesketch.py
+++ b/dftimewolf/lib/enhancers/timesketch.py
@@ -31,7 +31,8 @@ class TimesketchEnhancer(module.BaseModule):
   _REPORT_NAME = 'TimesketchEnhancer'
 
   def __init__(self, state, name=None, critical=False):
-    super(TimesketchEnhancer, self).__init__(state, name=name, critical=critical)
+    super(TimesketchEnhancer, self).__init__(
+        state, name=name, critical=critical)
     self.timesketch_api = None
 
     self._aggregations_to_skip = []

--- a/dftimewolf/lib/enhancers/timesketch.py
+++ b/dftimewolf/lib/enhancers/timesketch.py
@@ -30,8 +30,8 @@ class TimesketchEnhancer(module.BaseModule):
   # Name given to all report containers.
   _REPORT_NAME = 'TimesketchEnhancer'
 
-  def __init__(self, state):
-    super(TimesketchEnhancer, self).__init__(state)
+  def __init__(self, state, name=None, critical=False):
+    super(TimesketchEnhancer, self).__init__(state, name=name, critical=critical)
     self.timesketch_api = None
 
     self._aggregations_to_skip = []

--- a/dftimewolf/lib/exporters/gce_disk_export.py
+++ b/dftimewolf/lib/exporters/gce_disk_export.py
@@ -36,7 +36,8 @@ class GoogleCloudDiskExport(module.BaseModule):
       critical (Optional[bool]): True if the module is critical, which causes
           the entire recipe to fail if the module encounters an error.
     """
-    super(GoogleCloudDiskExport, self).__init__(state, name=name, critical=critical)
+    super(GoogleCloudDiskExport, self).__init__(
+        state, name=name, critical=critical)
     self.analysis_project = None
     self.source_project = None
     self.source_disk = None

--- a/dftimewolf/lib/exporters/gce_disk_export.py
+++ b/dftimewolf/lib/exporters/gce_disk_export.py
@@ -27,15 +27,16 @@ class GoogleCloudDiskExport(module.BaseModule):
     _image_name (str): Intermediary image to export.
   """
 
-  def __init__(self, state, critical=False):
+  def __init__(self, state, name=None, critical=False):
     """Initializes a Google Cloud Platform (GCP) Disk Export.
 
     Args:
       state (DFTimewolfState): recipe state.
+      name (Optional[str]): The module's runtime name.
       critical (Optional[bool]): True if the module is critical, which causes
           the entire recipe to fail if the module encounters an error.
     """
-    super(GoogleCloudDiskExport, self).__init__(state, critical=critical)
+    super(GoogleCloudDiskExport, self).__init__(state, name=name, critical=critical)
     self.analysis_project = None
     self.source_project = None
     self.source_disk = None

--- a/dftimewolf/lib/exporters/local_filesystem.py
+++ b/dftimewolf/lib/exporters/local_filesystem.py
@@ -19,7 +19,8 @@ class LocalFilesystemCopy(module.BaseModule):
 
   def __init__(self, state, name=None, critical=False):
     """Initializes a local file system exporter module."""
-    super(LocalFilesystemCopy, self).__init__(state, name=name, critical=critical)
+    super(LocalFilesystemCopy, self).__init__(
+        state, name=name, critical=critical)
     self._target_directory = None
 
   def SetUp(self, target_directory=None):  # pylint: disable=arguments-differ

--- a/dftimewolf/lib/exporters/local_filesystem.py
+++ b/dftimewolf/lib/exporters/local_filesystem.py
@@ -17,9 +17,9 @@ class LocalFilesystemCopy(module.BaseModule):
   output: The directory in which the files have been copied.
   """
 
-  def __init__(self, state):
+  def __init__(self, state, name=None, critical=False):
     """Initializes a local file system exporter module."""
-    super(LocalFilesystemCopy, self).__init__(state)
+    super(LocalFilesystemCopy, self).__init__(state, name=name, critical=critical)
     self._target_directory = None
 
   def SetUp(self, target_directory=None):  # pylint: disable=arguments-differ

--- a/dftimewolf/lib/exporters/scp_ex.py
+++ b/dftimewolf/lib/exporters/scp_ex.py
@@ -23,8 +23,8 @@ class SCPExporter(module.BaseModule):
     _id_file (str): Identity file to use.
   """
 
-  def __init__(self, state):
-    super(SCPExporter, self).__init__(state)
+  def __init__(self, state, name=None, critical=False):
+    super(SCPExporter, self).__init__(state, name=name, critical=critical)
     self._paths = None
     self._user = None
     self._hostname = None

--- a/dftimewolf/lib/exporters/timesketch.py
+++ b/dftimewolf/lib/exporters/timesketch.py
@@ -28,8 +28,8 @@ class TimesketchExporter(module.BaseModule):
   # The name of a ticket attribute that contains the URL to a sketch.
   _SKETCH_ATTRIBUTE_NAME = 'Timesketch URL'
 
-  def __init__(self, state):
-    super(TimesketchExporter, self).__init__(state)
+  def __init__(self, state, name=None, critical=False):
+    super(TimesketchExporter, self).__init__(state, name=name, critical=critical)
     self.incident_id = None
     self.sketch_id = None
     self.timesketch_api = None

--- a/dftimewolf/lib/exporters/timesketch.py
+++ b/dftimewolf/lib/exporters/timesketch.py
@@ -29,7 +29,8 @@ class TimesketchExporter(module.BaseModule):
   _SKETCH_ATTRIBUTE_NAME = 'Timesketch URL'
 
   def __init__(self, state, name=None, critical=False):
-    super(TimesketchExporter, self).__init__(state, name=name, critical=critical)
+    super(TimesketchExporter, self).__init__(
+        state, name=name, critical=critical)
     self.incident_id = None
     self.sketch_id = None
     self.timesketch_api = None

--- a/dftimewolf/lib/module.py
+++ b/dftimewolf/lib/module.py
@@ -29,7 +29,6 @@ class BaseModule(object):
 
     Args:
       state (DFTimewolfState): recipe state.
-      name (Optional[str]): The module's runtime name.
       name (Optional[str]): A unique name for a specific instance of the module
           class. If not provided, will default to the module's class name.
       critical (Optional[bool]): True if the module is critical, which causes

--- a/dftimewolf/lib/module.py
+++ b/dftimewolf/lib/module.py
@@ -19,6 +19,8 @@ class BaseModule(object):
     critical (bool): True if this module is critical to the execution of
         the recipe. If set to True, and the module fails to properly run,
         the recipe will be aborted.
+    name (str): A unique name for a specific instance of the module
+          class. If not provided, will default to the module's class name.
     state (DFTimewolfState): recipe state.
   """
 
@@ -33,7 +35,7 @@ class BaseModule(object):
           the entire recipe to fail if the module encounters an error.
     """
     super(BaseModule, self).__init__()
-    self.name = name if name else self.__class__.name
+    self.name = name if name else self.__class__.__name__
     self.critical = critical
     self.state = state
     self.SetupLogging()
@@ -55,11 +57,6 @@ class BaseModule(object):
     console_handler.setFormatter(formatter)
 
     self.logger.addHandler(console_handler)
-
-  @property
-  def name(self):
-    """Returns the name for this module."""
-    return self.name
 
   def CleanUp(self):
     """Cleans up module output to prepare it for the next module."""

--- a/dftimewolf/lib/module.py
+++ b/dftimewolf/lib/module.py
@@ -22,22 +22,25 @@ class BaseModule(object):
     state (DFTimewolfState): recipe state.
   """
 
-  def __init__(self, state, critical=False):
+  def __init__(self, state, name=None, critical=False):
     """Initialize a module.
 
     Args:
       state (DFTimewolfState): recipe state.
+      name (Optional[str]): A unique name for a specific instance of the module
+          class. If not provided, will default to the module's class name.
       critical (Optional[bool]): True if the module is critical, which causes
           the entire recipe to fail if the module encounters an error.
     """
     super(BaseModule, self).__init__()
+    self.name = name if name else self.__class__.name
     self.critical = critical
     self.state = state
     self.SetupLogging()
 
   def SetupLogging(self):
     """Sets up stream and file logging for a specific module."""
-    self.logger = logging.getLogger(name=self.__class__.__name__)
+    self.logger = logging.getLogger(name=self.name)
     self.logger.setLevel(logging.DEBUG)
 
     file_handler = handlers.RotatingFileHandler(
@@ -55,8 +58,8 @@ class BaseModule(object):
 
   @property
   def name(self):
-    """Returns the class name for this module."""
-    return self.__class__.__name__
+    """Returns the name for this module."""
+    return self.name
 
   def CleanUp(self):
     """Cleans up module output to prepare it for the next module."""

--- a/dftimewolf/lib/module.py
+++ b/dftimewolf/lib/module.py
@@ -29,6 +29,7 @@ class BaseModule(object):
 
     Args:
       state (DFTimewolfState): recipe state.
+      name (Optional[str]): The module's runtime name.
       name (Optional[str]): A unique name for a specific instance of the module
           class. If not provided, will default to the module's class name.
       critical (Optional[bool]): True if the module is critical, which causes

--- a/dftimewolf/lib/modules/manager.py
+++ b/dftimewolf/lib/modules/manager.py
@@ -30,7 +30,7 @@ class ModulesManager(object):
 
   @classmethod
   def GetModuleByName(cls, name):
-    """Retrieves a specific by its name.
+    """Retrieves a specific module by its name.
 
     Args:
       name (str): name of the module.

--- a/dftimewolf/lib/processors/gcp_logging_timesketch.py
+++ b/dftimewolf/lib/processors/gcp_logging_timesketch.py
@@ -18,7 +18,8 @@ class GCPLoggingTimesketch(BaseModule):
     # No configuration required.
 
   def __init__(self, state, name=None, critical=False):
-    super(GCPLoggingTimesketch, self).__init__(state, name=name, critical=critical)
+    super(GCPLoggingTimesketch, self).__init__(
+        state, name=name, critical=critical)
 
   def _ProcessLogLine(self, log_line, query, project_name):
     """Processes a single JSON formatted Google Clod Platform log line.

--- a/dftimewolf/lib/processors/gcp_logging_timesketch.py
+++ b/dftimewolf/lib/processors/gcp_logging_timesketch.py
@@ -17,8 +17,8 @@ class GCPLoggingTimesketch(BaseModule):
     """Sets up necessary module configuration options."""
     # No configuration required.
 
-  def __init__(self, state):
-    super(GCPLoggingTimesketch, self).__init__(state)
+  def __init__(self, state, name=None, critical=False):
+    super(GCPLoggingTimesketch, self).__init__(state, name=name, critical=critical)
 
   def _ProcessLogLine(self, log_line, query, project_name):
     """Processes a single JSON formatted Google Clod Platform log line.

--- a/dftimewolf/lib/processors/grepper.py
+++ b/dftimewolf/lib/processors/grepper.py
@@ -20,8 +20,8 @@ class GrepperSearch(module.BaseModule):
   output: filepath and keyword match, to stdout (final_output).
   """
 
-  def __init__(self, state):
-    super(GrepperSearch, self).__init__(state)
+  def __init__(self, state, name=None, critical=False):
+    super(GrepperSearch, self).__init__(state, name=name, critical=critical)
     self._keywords = None
     self._output_path = None
     self._final_output = None

--- a/dftimewolf/lib/processors/localplaso.py
+++ b/dftimewolf/lib/processors/localplaso.py
@@ -17,8 +17,8 @@ class LocalPlasoProcessor(module.BaseModule):
   output: The path to the resulting Plaso storage file.
   """
 
-  def __init__(self, state):
-    super(LocalPlasoProcessor, self).__init__(state)
+  def __init__(self, state, name=None, critical=False):
+    super(LocalPlasoProcessor, self).__init__(state, name=name, critical=critical)
     self._timezone = None
     self._output_path = None
     self._plaso_path = None

--- a/dftimewolf/lib/processors/localplaso.py
+++ b/dftimewolf/lib/processors/localplaso.py
@@ -18,7 +18,8 @@ class LocalPlasoProcessor(module.BaseModule):
   """
 
   def __init__(self, state, name=None, critical=False):
-    super(LocalPlasoProcessor, self).__init__(state, name=name, critical=critical)
+    super(LocalPlasoProcessor, self).__init__(
+        state, name=name, critical=critical)
     self._timezone = None
     self._output_path = None
     self._plaso_path = None

--- a/dftimewolf/lib/processors/turbinia.py
+++ b/dftimewolf/lib/processors/turbinia.py
@@ -31,15 +31,16 @@ class TurbiniaProcessor(module.BaseModule):
     turbinia_zone (str): GCP zone in which the Turbinia server is running.
   """
 
-  def __init__(self, state, critical=False):
+  def __init__(self, state, name=None, critical=False):
     """Initializes a Turbinia Google Cloud (GCP) disks processor.
 
     Args:
       state (DFTimewolfState): recipe state.
+      name (Optional[str]): The module's runtime name.
       critical (Optional[bool]): True if the module is critical, which causes
           the entire recipe to fail if the module encounters an error.
     """
-    super(TurbiniaProcessor, self).__init__(state, critical=critical)
+    super(TurbiniaProcessor, self).__init__(state, name=name, critical=critical)
     self._output_path = None
     self.client = None
     self.disk_name = None

--- a/dftimewolf/lib/state.py
+++ b/dftimewolf/lib/state.py
@@ -93,7 +93,10 @@ class DFTimewolfState(object):
         raise errors.RecipeParseError(
             'Recipe uses unknown module: {0:s}'.format(module_name))
 
-      self._module_pool[module_name] = module_class(self)
+      runtime_name = module_definition.get('runtime_name')
+      if not runtime_name:
+        runtime_name = module_name
+      self._module_pool[runtime_name] = module_class(self, name=runtime_name)
 
   def AddToCache(self, name, value):
     """Thread-safe method to add data to the state's cache.

--- a/tests/lib/state.py
+++ b/tests/lib/state.py
@@ -103,6 +103,21 @@ class StateTest(unittest.TestCase):
     mock_setup1.assert_called_with()
     mock_setup2.assert_called_with()
 
+  @mock.patch('tests.test_modules.modules.DummyModule2.SetUp')
+  @mock.patch('tests.test_modules.modules.DummyModule1.SetUp')
+  def testSetupNamedModules(self, mock_setup1, mock_setup2):
+    """Tests that module's setup functions are correctly called."""
+    test_state = state.DFTimewolfState(config.Config)
+    test_state.command_line_options = {}
+    test_state.LoadRecipe(test_recipe.named_modules_contents)
+    test_state.SetupModules()
+    self.assertEqual(
+      mock_setup1.call_args_list,
+      [mock.call(runtime_value='1-1'), mock.call(runtime_value='1-2')])
+    self.assertEqual(
+      mock_setup2.call_args_list,
+      [mock.call(runtime_value='2-1'), mock.call(runtime_value='2-2')])
+
   @mock.patch('tests.test_modules.modules.DummyModule2.Process')
   @mock.patch('tests.test_modules.modules.DummyModule1.Process')
   def testProcessModules(self, mock_process1, mock_process2):
@@ -114,6 +129,23 @@ class StateTest(unittest.TestCase):
     test_state.RunModules()
     mock_process1.assert_called_with()
     mock_process2.assert_called_with()
+
+  @mock.patch('tests.test_modules.modules.DummyModule2.Process')
+  @mock.patch('tests.test_modules.modules.DummyModule1.Process')
+  def testProcessNamedModules(self, mock_process1, mock_process2):
+    """Tests that modules' process functions are correctly called."""
+    test_state = state.DFTimewolfState(config.Config)
+    test_state.command_line_options = {}
+    test_state.LoadRecipe(test_recipe.named_modules_contents)
+    test_state.SetupModules()
+    test_state.RunModules()
+    # pylint: disable=protected-access
+    self.assertIn('DummyModule1', test_state._threading_event_per_module)
+    self.assertIn('DummyModule2', test_state._threading_event_per_module)
+    self.assertIn('DummyModule1-2', test_state._threading_event_per_module)
+    self.assertIn('DummyModule2-2', test_state._threading_event_per_module)
+    self.assertEqual(mock_process1.call_count, 2)
+    self.assertEqual(mock_process2.call_count, 2)
 
   @mock.patch('tests.test_modules.modules.DummyModule2.Process')
   @mock.patch('tests.test_modules.modules.DummyModule1.Process')

--- a/tests/lib/state.py
+++ b/tests/lib/state.py
@@ -50,6 +50,18 @@ class StateTest(unittest.TestCase):
     self.assertIn('DummyPreflightModule', test_state._module_pool)
     self.assertEqual(len(test_state._module_pool), 3)
 
+  def testLoadRecipeWithRuntimeNames(self):
+    """Tests that a recipe can be loaded correctly."""
+    test_state = state.DFTimewolfState(config.Config)
+    test_state.LoadRecipe(test_recipe.named_modules_contents)
+    # pylint: disable=protected-access
+    self.assertIn('DummyModule1', test_state._module_pool)
+    self.assertIn('DummyModule2', test_state._module_pool)
+    self.assertIn('DummyModule1-2', test_state._module_pool)
+    self.assertIn('DummyModule2-2', test_state._module_pool)
+    self.assertIn('DummyPreflightModule', test_state._module_pool)
+    self.assertEqual(len(test_state._module_pool), 5)
+
   def testStoreContainer(self):
     """Tests that containers are stored correctly."""
     test_state = state.DFTimewolfState(config.Config)

--- a/tests/test_modules/modules.py
+++ b/tests/test_modules/modules.py
@@ -8,8 +8,8 @@ from dftimewolf.lib.containers import containers
 class DummyModule1(module.BaseModule):
   """This is a dummy module."""
 
-  def __init__(self, state):
-    super(DummyModule1, self).__init__(state)
+  def __init__(self, state, name=None):
+    super(DummyModule1, self).__init__(state, name)
 
   def SetUp(self):  # pylint: disable=arguments-differ
     """Dummy setup function."""
@@ -27,8 +27,8 @@ class DummyModule1(module.BaseModule):
 class DummyModule2(module.BaseModule):
   """This is a dummy module."""
 
-  def __init__(self, state):
-    super(DummyModule2, self).__init__(state)
+  def __init__(self, state, name=None):
+    super(DummyModule2, self).__init__(state, name)
 
   def SetUp(self):  # pylint: disable=arguments-differ
     """Dummy setup function."""
@@ -41,8 +41,8 @@ class DummyModule2(module.BaseModule):
 class DummyPreflightModule(module.PreflightModule):
   """Dummy preflight module."""
 
-  def __init__(self, state):
-    super(DummyPreflightModule, self).__init__(state)
+  def __init__(self, state, name=None):
+    super(DummyPreflightModule, self).__init__(state, name)
 
   def SetUp(self, args):  # pylint: disable=arguments-differ
     """Dummy Process function."""

--- a/tests/test_modules/modules.py
+++ b/tests/test_modules/modules.py
@@ -9,10 +9,12 @@ class DummyModule1(module.BaseModule):
   """This is a dummy module."""
 
   def __init__(self, state, name=None):
+    self.runtime_value = None
     super(DummyModule1, self).__init__(state, name)
 
-  def SetUp(self):  # pylint: disable=arguments-differ
+  def SetUp(self, runtime_value=None):  # pylint: disable=arguments-differ
     """Dummy setup function."""
+    self.runtime_value = runtime_value
     print(self.name + ' Setup!')
     self.state.RegisterStreamingCallback(self.Callback, containers.Report)
 
@@ -28,10 +30,12 @@ class DummyModule2(module.BaseModule):
   """This is a dummy module."""
 
   def __init__(self, state, name=None):
+    self.runtime_value = None
     super(DummyModule2, self).__init__(state, name)
 
-  def SetUp(self):  # pylint: disable=arguments-differ
+  def SetUp(self, runtime_value=None):  # pylint: disable=arguments-differ
     """Dummy setup function."""
+    self.runtime_value = runtime_value
     print(self.name + ' Setup!')
 
   def Process(self):

--- a/tests/test_modules/test_recipe.py
+++ b/tests/test_modules/test_recipe.py
@@ -29,21 +29,29 @@ named_modules_contents = {
     'modules': [{
         'wants': [],
         'name': 'DummyModule1',
-        'args': {},
+        'args': {
+            'runtime_value': '1-1'
+        },
     }, {
         'wants': ['DummyModule1'],
         'name': 'DummyModule2',
-        'args': {},
+        'args': {
+            'runtime_value': '2-1'
+        },
     }, {
         'wants': ['DummyModule2'],
         'name': 'DummyModule1',
         'runtime_name': 'DummyModule1-2',
-        'args': {},
+        'args': {
+            'runtime_value': '1-2'
+        },
     }, {
         'wants': ['DummyModule1-2'],
         'name': 'DummyModule2',
         'runtime_name': 'DummyModule2-2',
-        'args': {},
+        'args': {
+            'runtime_value': '2-2'
+        },
     }]
 }
 

--- a/tests/test_modules/test_recipe.py
+++ b/tests/test_modules/test_recipe.py
@@ -19,4 +19,32 @@ contents = {
     }]
 }
 
+named_modules_contents = {
+    'name':
+        'dummy_recipe',
+    'short_description': 'Nothing to see here.',
+    'preflights': [{
+        'name': 'DummyPreflightModule'
+    }],
+    'modules': [{
+        'wants': [],
+        'name': 'DummyModule1',
+        'args': {},
+    }, {
+        'wants': ['DummyModule1'],
+        'name': 'DummyModule2',
+        'args': {},
+    }, {
+        'wants': ['DummyModule2'],
+        'name': 'DummyModule1',
+        'runtime_name': 'DummyModule1-2',
+        'args': {},
+    }, {
+        'wants': ['DummyModule1-2'],
+        'name': 'DummyModule2',
+        'runtime_name': 'DummyModule2-2',
+        'args': {},
+    }]
+}
+
 args = []


### PR DESCRIPTION
Modules can now be identified by their `runtime_name` instead of their class names. This allows to disambiguate modules when there is more than one module of the same type in a recipe.

I didn't find a better variable name than `runtime_name`. WDYT?