### PR TITLE
Introduces Preflight CleanUp functions

### DIFF
--- a/dftimewolf/cli/dftimewolf_recipes.py
+++ b/dftimewolf/cli/dftimewolf_recipes.py
@@ -229,6 +229,9 @@ class DFTimewolfTool(object):
     self._state.SetupModules()
     logger.info('Modules successfully set up!')
 
+  def CleanUpPreflights(self):
+    """Calls the preflight's CleanUp functions."""
+    self._state.CleanUpPreflights()
 
 def SignalHandler(*unused_argvs):
   """Catches Ctrl + C to exit cleanly."""
@@ -307,6 +310,8 @@ def Main():
 
   # TODO: log errors if this fails.
   tool.RunModules()
+
+  tool.CleanUpPreflights()
 
   return True
 

--- a/dftimewolf/lib/module.py
+++ b/dftimewolf/lib/module.py
@@ -121,3 +121,7 @@ class PreflightModule(BaseModule):
   @abc.abstractmethod
   def SetUp(self, *args, **kwargs):
     """Sets up necessary module configuration options."""
+
+  @abc.abstractmethod
+  def CleanUp(self):
+    """Carries out optional cleanup actions at the end of the recipe run."""

--- a/dftimewolf/lib/state.py
+++ b/dftimewolf/lib/state.py
@@ -264,6 +264,16 @@ class DFTimewolfState(object):
       finally:
         self.CheckErrors(is_global=True)
 
+  def CleanUpPreflights(self):
+    """Executes any cleanup actions defined in preflight modules."""
+    for preflight_definition in self.recipe.get('preflights', []):
+      preflight_name = preflight_definition['name']
+      preflight = self._module_pool[preflight_name]
+      try:
+        preflight.CleanUp()
+      finally:
+        self.CheckErrors(is_global=True)
+
   def InstantiateModule(self, module_name):
     """Instantiates an arbitrary dfTimewolf module.
 

--- a/tests/lib/state.py
+++ b/tests/lib/state.py
@@ -92,6 +92,15 @@ class StateTest(unittest.TestCase):
     mock_setup.assert_called_with()
     mock_process.assert_called_with()
 
+  @mock.patch('tests.test_modules.modules.DummyPreflightModule.CleanUp')
+  def testCleanupPreflightModules(self, mock_cleanup):
+    """Tests that preflight's process function is called correctly."""
+    test_state = state.DFTimewolfState(config.Config)
+    test_state.command_line_options = {}
+    test_state.LoadRecipe(test_recipe.contents)
+    test_state.CleanUpPreflights()
+    mock_cleanup.assert_called_with()
+
   @mock.patch('tests.test_modules.modules.DummyModule2.SetUp')
   @mock.patch('tests.test_modules.modules.DummyModule1.SetUp')
   def testSetupModules(self, mock_setup1, mock_setup2):

--- a/tests/test_modules/modules.py
+++ b/tests/test_modules/modules.py
@@ -55,3 +55,7 @@ class DummyPreflightModule(module.PreflightModule):
   def Process(self):
     """Dummy Process function."""
     print(self.name + ' Process!')
+
+  def CleanUp(self):
+    """Dummy cleanup function."""
+    print(self.name + 'CleanUp!')


### PR DESCRIPTION
These are called at the end of the *recipe* (after calling all the module's `Process()` functions), to clean-up any artifacts left behind by preflights