### PR TITLE
Check target instance exists before launching analysis VM

### DIFF
--- a/dftimewolf/lib/collectors/gcloud.py
+++ b/dftimewolf/lib/collectors/gcloud.py
@@ -3,6 +3,7 @@
 
 from google.auth.exceptions import DefaultCredentialsError, RefreshError
 from googleapiclient.errors import HttpError
+from libcloudforensics.errors import ResourceNotFoundError
 from libcloudforensics.providers.gcp.internal import project as gcp_project
 from libcloudforensics.providers.gcp import forensics as gcp_forensics
 
@@ -159,6 +160,16 @@ class GoogleCloudCollector(module.BaseModule):
             name=self._ANALYSIS_VM_CONTAINER_ATTRIBUTE_NAME,
             type_=self._ANALYSIS_VM_CONTAINER_ATTRIBUTE_TYPE,
             value=analysis_vm_name))
+
+    try:
+      if self.remote_instance_name:
+        self.remote_project.compute.GetInstance(self.remote_instance_name)
+    except ResourceNotFoundError as exception:
+      self.ModuleError(
+        message='Instance "{0:s}" not found or insufficient permissions'.format(
+          self.remote_instance_name),
+        critical=True)
+      return
 
     try:
       # TODO: Make creating an analysis VM optional

--- a/dftimewolf/lib/collectors/gcloud.py
+++ b/dftimewolf/lib/collectors/gcloud.py
@@ -161,15 +161,15 @@ class GoogleCloudCollector(module.BaseModule):
             type_=self._ANALYSIS_VM_CONTAINER_ATTRIBUTE_TYPE,
             value=analysis_vm_name))
 
-#    try:
-#      if self.remote_instance_name:
-#        self.remote_project.compute.GetInstance(self.remote_instance_name)
-#    except ResourceNotFoundError as exception:
-#      self.ModuleError(
-#        message='Instance "{0:s}" not found or insufficient permissions'.format(
-#          self.remote_instance_name),
-#        critical=True)
-#      return
+    try:
+      if self.remote_instance_name:
+        self.remote_project.compute.GetInstance(self.remote_instance_name)
+    except ResourceNotFoundError as exception:
+      self.ModuleError(
+        message='Instance "{0:s}" not found or insufficient permissions'.format(
+          self.remote_instance_name),
+        critical=True)
+      return
 
     try:
       # TODO: Make creating an analysis VM optional

--- a/dftimewolf/lib/collectors/gcloud.py
+++ b/dftimewolf/lib/collectors/gcloud.py
@@ -3,7 +3,7 @@
 
 from google.auth.exceptions import DefaultCredentialsError, RefreshError
 from googleapiclient.errors import HttpError
-from libcloudforensics.errors import ResourceNotFoundError
+#from libcloudforensics.errors import ResourceNotFoundError
 from libcloudforensics.providers.gcp.internal import project as gcp_project
 from libcloudforensics.providers.gcp import forensics as gcp_forensics
 
@@ -161,15 +161,15 @@ class GoogleCloudCollector(module.BaseModule):
             type_=self._ANALYSIS_VM_CONTAINER_ATTRIBUTE_TYPE,
             value=analysis_vm_name))
 
-    try:
-      if self.remote_instance_name:
-        self.remote_project.compute.GetInstance(self.remote_instance_name)
-    except ResourceNotFoundError as exception:
-      self.ModuleError(
-        message='Instance "{0:s}" not found or insufficient permissions'.format(
-          self.remote_instance_name),
-        critical=True)
-      return
+#    try:
+#      if self.remote_instance_name:
+#        self.remote_project.compute.GetInstance(self.remote_instance_name)
+#    except ResourceNotFoundError as exception:
+#      self.ModuleError(
+#        message='Instance "{0:s}" not found or insufficient permissions'.format(
+#          self.remote_instance_name),
+#        critical=True)
+#      return
 
     try:
       # TODO: Make creating an analysis VM optional

--- a/dftimewolf/lib/collectors/gcloud.py
+++ b/dftimewolf/lib/collectors/gcloud.py
@@ -3,7 +3,7 @@
 
 from google.auth.exceptions import DefaultCredentialsError, RefreshError
 from googleapiclient.errors import HttpError
-#from libcloudforensics.errors import ResourceNotFoundError
+from libcloudforensics.errors import ResourceNotFoundError
 from libcloudforensics.providers.gcp.internal import project as gcp_project
 from libcloudforensics.providers.gcp import forensics as gcp_forensics
 

--- a/dftimewolf/lib/collectors/gcloud.py
+++ b/dftimewolf/lib/collectors/gcloud.py
@@ -164,7 +164,14 @@ class GoogleCloudCollector(module.BaseModule):
     try:
       if self.remote_instance_name:
         self.remote_project.compute.GetInstance(self.remote_instance_name)
+    except ResourceNotFoundError as exception:
+      self.ModuleError(
+        message='Instance "{0:s}" not found or insufficient permissions'.format(
+          self.remote_instance_name),
+        critical=True)
+      return
 
+    try:
       # TODO: Make creating an analysis VM optional
       # pylint: disable=too-many-function-args
       # pylint: disable=redundant-keyword-arg
@@ -180,11 +187,6 @@ class GoogleCloudCollector(module.BaseModule):
       self.analysis_vm.AddLabels(self._gcp_label)
       self.analysis_vm.GetBootDisk().AddLabels(self._gcp_label)
 
-    except ResourceNotFoundError as exception:
-      self.ModuleError(
-        message='Instance "{0:s}" not found or insufficient permissions'.format(
-          self.remote_instance_name),
-        critical=True)
     except (RefreshError,
             DefaultCredentialsError) as exception:
       msg = ('Something is wrong with your Application Default Credentials. '

--- a/dftimewolf/lib/collectors/gcloud.py
+++ b/dftimewolf/lib/collectors/gcloud.py
@@ -164,14 +164,7 @@ class GoogleCloudCollector(module.BaseModule):
     try:
       if self.remote_instance_name:
         self.remote_project.compute.GetInstance(self.remote_instance_name)
-    except ResourceNotFoundError as exception:
-      self.ModuleError(
-        message='Instance "{0:s}" not found or insufficient permissions'.format(
-          self.remote_instance_name),
-        critical=True)
-      return
 
-    try:
       # TODO: Make creating an analysis VM optional
       # pylint: disable=too-many-function-args
       # pylint: disable=redundant-keyword-arg
@@ -187,6 +180,11 @@ class GoogleCloudCollector(module.BaseModule):
       self.analysis_vm.AddLabels(self._gcp_label)
       self.analysis_vm.GetBootDisk().AddLabels(self._gcp_label)
 
+    except ResourceNotFoundError as exception:
+      self.ModuleError(
+        message='Instance "{0:s}" not found or insufficient permissions'.format(
+          self.remote_instance_name),
+        critical=True)
     except (RefreshError,
             DefaultCredentialsError) as exception:
       msg = ('Something is wrong with your Application Default Credentials. '

--- a/tests/lib/collectors/gcloud.py
+++ b/tests/lib/collectors/gcloud.py
@@ -54,6 +54,7 @@ class GoogleCloudCollectorTest(unittest.TestCase):
   @mock.patch('libcloudforensics.providers.gcp.internal.compute_base_resource.GoogleComputeBaseResource.AddLabels')
   @mock.patch('libcloudforensics.providers.gcp.internal.compute_base_resource.GoogleComputeBaseResource')
   @mock.patch('libcloudforensics.providers.gcp.forensics.StartAnalysisVm')
+  @mock.patch('libcloudforensics.providers.gcp.internal.compute.GoogleCloudCompute.GetInstance')
   def testSetUp(self,
                 mock_StartAnalysisVm,
                 mock_GoogleComputeBaseResource,
@@ -103,6 +104,7 @@ class GoogleCloudCollectorTest(unittest.TestCase):
   @mock.patch('libcloudforensics.providers.gcp.forensics.CreateDiskCopy')
   @mock.patch('dftimewolf.lib.collectors.gcloud.GoogleCloudCollector._FindDisksToCopy')
   @mock.patch('libcloudforensics.providers.gcp.internal.compute.GoogleComputeInstance.AttachDisk')
+  @mock.patch('libcloudforensics.providers.gcp.internal.compute.GoogleCloudCompute.GetInstance')
   def testProcess(self,
                   unused_MockAttachDisk,
                   mock_FindDisks,

--- a/tests/lib/collectors/gcloud.py
+++ b/tests/lib/collectors/gcloud.py
@@ -63,7 +63,7 @@ class GoogleCloudCollectorTest(unittest.TestCase):
     """Tests that the collector can be initialized."""
     test_state = state.DFTimewolfState(config.Config)
     mock_StartAnalysisVm.return_value = (mock_GoogleComputeBaseResource, None)
-    mock_TargetInstance.return_value = FAKE_INSTANCE
+    mock_GetInstance.return_value = FAKE_INSTANCE
 
     gcloud_collector = gcloud.GoogleCloudCollector(test_state)
     gcloud_collector.SetUp(
@@ -119,7 +119,7 @@ class GoogleCloudCollectorTest(unittest.TestCase):
     mock_StartAnalysisVm.return_value = (FAKE_ANALYSIS_VM, None)
     mock_FindDisks.return_value = [FAKE_DISK]
     mock_CreateDiskCopy.return_value = FAKE_DISK_COPY
-    mock_TargetInstance.return_value = FAKE_INSTANCE
+    mock_GetInstance.return_value = FAKE_INSTANCE
     FAKE_ANALYSIS_VM.AddLabels = mock_AddLabels
     FAKE_ANALYSIS_VM.GetBootDisk = mock_GetBootDisk
     FAKE_DISK_COPY.AddLabels = mock_AddLabels

--- a/tests/lib/collectors/gcloud.py
+++ b/tests/lib/collectors/gcloud.py
@@ -51,14 +51,15 @@ class GoogleCloudCollectorTest(unittest.TestCase):
     self.assertIsNotNone(gcloud_collector)
 
   # pylint: disable=invalid-name,line-too-long
+  @mock.patch('libcloudforensics.providers.gcp.internal.compute.GoogleCloudCompute.GetInstance')
   @mock.patch('libcloudforensics.providers.gcp.internal.compute_base_resource.GoogleComputeBaseResource.AddLabels')
   @mock.patch('libcloudforensics.providers.gcp.internal.compute_base_resource.GoogleComputeBaseResource')
   @mock.patch('libcloudforensics.providers.gcp.forensics.StartAnalysisVm')
-  @mock.patch('libcloudforensics.providers.gcp.internal.compute.GoogleCloudCompute.GetInstance')
   def testSetUp(self,
                 mock_StartAnalysisVm,
                 mock_GoogleComputeBaseResource,
-                mock_AddLabels):
+                mock_AddLabels,
+                mock_TargetInstance):
     """Tests that the collector can be initialized."""
     test_state = state.DFTimewolfState(config.Config)
     mock_StartAnalysisVm.return_value = (mock_GoogleComputeBaseResource, None)
@@ -98,20 +99,21 @@ class GoogleCloudCollectorTest(unittest.TestCase):
         [mock.call({'incident_id': 'fake_incident_id'})])
 
   # pylint: disable=line-too-long
+  @mock.patch('libcloudforensics.providers.gcp.internal.compute.GoogleCloudCompute.GetInstance')
   @mock.patch('libcloudforensics.providers.gcp.internal.compute.GoogleComputeInstance.GetBootDisk')
   @mock.patch('libcloudforensics.providers.gcp.internal.compute_base_resource.GoogleComputeBaseResource.AddLabels')
   @mock.patch('libcloudforensics.providers.gcp.forensics.StartAnalysisVm')
   @mock.patch('libcloudforensics.providers.gcp.forensics.CreateDiskCopy')
   @mock.patch('dftimewolf.lib.collectors.gcloud.GoogleCloudCollector._FindDisksToCopy')
   @mock.patch('libcloudforensics.providers.gcp.internal.compute.GoogleComputeInstance.AttachDisk')
-  @mock.patch('libcloudforensics.providers.gcp.internal.compute.GoogleCloudCompute.GetInstance')
   def testProcess(self,
                   unused_MockAttachDisk,
                   mock_FindDisks,
                   mock_CreateDiskCopy,
                   mock_StartAnalysisVm,
                   mock_AddLabels,
-                  mock_GetBootDisk):
+                  mock_GetBootDisk,
+                  mock_TargetInstance):
     """Tests the collector's Process() function."""
     mock_StartAnalysisVm.return_value = (FAKE_ANALYSIS_VM, None)
     mock_FindDisks.return_value = [FAKE_DISK]

--- a/tests/lib/collectors/gcloud.py
+++ b/tests/lib/collectors/gcloud.py
@@ -59,7 +59,7 @@ class GoogleCloudCollectorTest(unittest.TestCase):
                 mock_StartAnalysisVm,
                 mock_GoogleComputeBaseResource,
                 mock_AddLabels,
-                mock_TargetInstance):
+                mock_GetInstance):
     """Tests that the collector can be initialized."""
     test_state = state.DFTimewolfState(config.Config)
     mock_StartAnalysisVm.return_value = (mock_GoogleComputeBaseResource, None)
@@ -114,7 +114,7 @@ class GoogleCloudCollectorTest(unittest.TestCase):
                   mock_StartAnalysisVm,
                   mock_AddLabels,
                   mock_GetBootDisk,
-                  mock_TargetInstance):
+                  mock_GetInstance):
     """Tests the collector's Process() function."""
     mock_StartAnalysisVm.return_value = (FAKE_ANALYSIS_VM, None)
     mock_FindDisks.return_value = [FAKE_DISK]

--- a/tests/lib/collectors/gcloud.py
+++ b/tests/lib/collectors/gcloud.py
@@ -63,6 +63,7 @@ class GoogleCloudCollectorTest(unittest.TestCase):
     """Tests that the collector can be initialized."""
     test_state = state.DFTimewolfState(config.Config)
     mock_StartAnalysisVm.return_value = (mock_GoogleComputeBaseResource, None)
+    mock_TargetInstance.return_value = FAKE_INSTANCE
 
     gcloud_collector = gcloud.GoogleCloudCollector(test_state)
     gcloud_collector.SetUp(
@@ -118,6 +119,7 @@ class GoogleCloudCollectorTest(unittest.TestCase):
     mock_StartAnalysisVm.return_value = (FAKE_ANALYSIS_VM, None)
     mock_FindDisks.return_value = [FAKE_DISK]
     mock_CreateDiskCopy.return_value = FAKE_DISK_COPY
+    mock_TargetInstance.return_value = FAKE_INSTANCE
     FAKE_ANALYSIS_VM.AddLabels = mock_AddLabels
     FAKE_ANALYSIS_VM.GetBootDisk = mock_GetBootDisk
     FAKE_DISK_COPY.AddLabels = mock_AddLabels


### PR DESCRIPTION
Pretty self explanatory I reckon. By checking that the target is valid before launching the VM, we don't launch the VM on a target error.