### PR TITLE
Hosts in GRR modules are attribute containers instead of strings

### DIFF
--- a/data/recipes/grr_artifact_grep.json
+++ b/data/recipes/grr_artifact_grep.json
@@ -6,7 +6,7 @@
         "wants": [],
         "name": "GRRArtifactCollector",
         "args": {
-            "hosts": "@hosts",
+            "hostnames": "@hostnames",
             "reason": "@reason",
             "grr_server_url": "@grr_server_url",
             "grr_username": "@grr_username",
@@ -26,7 +26,7 @@
         }
     }],
     "args": [
-        ["hosts", "Comma-separated list of hosts to process", null],
+        ["hostnames", "Comma-separated list of hostnames or GRR client IDs to process", null],
         ["reason", "Reason for collection", null],
         ["--artifacts", "Comma-separated list of artifacts to fetch (override default artifacts)", null],
         ["--extra_artifacts", "Comma-separated list of artifacts to append to the default artifact list", null],

--- a/data/recipes/grr_artifact_ts.json
+++ b/data/recipes/grr_artifact_ts.json
@@ -6,7 +6,7 @@
         "wants": [],
         "name": "GRRArtifactCollector",
         "args": {
-            "hosts": "@hosts",
+            "hostnames": "@hostnames",
             "reason": "@reason",
             "grr_server_url": "@grr_server_url",
             "grr_username": "@grr_username",
@@ -35,7 +35,7 @@
         }
     }],
     "args": [
-        ["hosts", "Comma-separated list of hosts to process", null],
+        ["hostnames", "Comma-separated list of hostnames or GRR client IDs to process", null],
         ["reason", "Reason for collection", null],
         ["--artifacts", "Comma-separated list of artifacts to fetch (override default artifacts)", null],
         ["--extra_artifacts", "Comma-separated list of artifacts to append to the default artifact list", null],

--- a/data/recipes/grr_files_collect.json
+++ b/data/recipes/grr_files_collect.json
@@ -6,7 +6,7 @@
         "wants": [],
         "name": "GRRFileCollector",
         "args": {
-            "hosts": "@hosts",
+            "hostnames": "@hostnames",
             "reason": "@reason",
             "grr_server_url": "@grr_server_url",
             "grr_username": "@grr_username",
@@ -26,7 +26,7 @@
         }
     }],
     "args": [
-        ["hosts", "Comma-separated list of hosts to process", null],
+        ["hostnames", "Comma-separated list of hostnames or GRR client IDs to process", null],
         ["reason", "Reason for collection", null],
         ["files", "Comma-separated list of files to fetch (supports GRR variable interpolation)", null],
         ["directory", "Directory in which to export files.", null],

--- a/data/recipes/grr_flow_collect.json
+++ b/data/recipes/grr_flow_collect.json
@@ -6,7 +6,7 @@
         "wants": [],
         "name": "GRRFlowCollector",
         "args": {
-            "host": "@host",
+            "hostname": "@hostname",
             "flow_id": "@flow_id",
             "reason": "@reason",
             "grr_server_url": "@grr_server_url",
@@ -24,7 +24,7 @@
         }
     }],
     "args": [
-        ["host", "Hostname to collect the flow from", null],
+        ["hostname", "Hostname to collect the flow from", null],
         ["flow_id", "Flow ID to download", null],
         ["reason", "Reason for collection", null],
         ["directory", "Directory in which to export files.", null],

--- a/data/recipes/grr_timeline_ts.json
+++ b/data/recipes/grr_timeline_ts.json
@@ -7,7 +7,7 @@
     "wants": [],
     "name": "GRRTimelineCollector",
     "args": {
-      "hosts": "@hosts",
+      "hostnames": "@hostnames",
       "root_path": "@root_path",
       "reason": "incident_id: @reason",
       "timeline_format": "1",
@@ -39,7 +39,7 @@
     }
   }],
   "args": [
-    ["hosts", "Hosts to process", null],
+    ["hostnames", "Comma-separated list of hostnames or GRR client IDs to process", null],
     ["root_path", "Root path for timeline generation", "/"],
     ["reason", "Reason for collection", null],
     ["--skip_offline_clients", "Whether to skip clients that are offline", false],

--- a/dftimewolf/lib/collectors/grr_hosts.py
+++ b/dftimewolf/lib/collectors/grr_hosts.py
@@ -330,7 +330,7 @@ class GRRArtifactCollector(GRRFlow):
   Attributes:
     artifacts (list[str]): artifact definition names.
     extra_artifacts (list[str]): extra artifact definition names.
-    hostnames (list[containers.Host]): Hosts to collect artifacts from.
+    hosts (list[containers.Host]): Hosts to collect artifacts from.
     use_tsk (bool): True if GRR should use Sleuthkit (TSK) to collect file
         system artifacts.
   """
@@ -367,18 +367,18 @@ class GRRArtifactCollector(GRRFlow):
     self._clients = []
     self.artifacts = []
     self.extra_artifacts = []
-    self.hostnames = []
+    self.hosts = []
     self.use_tsk = False
 
   # pylint: disable=arguments-differ,too-many-arguments
   def SetUp(self,
-            hosts, artifacts, extra_artifacts, use_tsk,
+            hostnames, artifacts, extra_artifacts, use_tsk,
             reason, grr_server_url, grr_username, grr_password, approvers=None,
             verify=True, skip_offline_clients=False):
     """Initializes a GRR artifact collector.
 
     Args:
-      hosts (str): comma-separated hostnames to launch the flow on.
+      hostnames (str): comma-separated hostnames to launch the flow on.
       artifacts (str): comma-separated artifact definition names.
       extra_artifacts (str): comma-separated extra artifact definition names.
       use_tsk (bool): True if GRR should use Sleuthkit (TSK) to collect file
@@ -404,11 +404,11 @@ class GRRArtifactCollector(GRRFlow):
       self.extra_artifacts = [item.strip() for item
                               in extra_artifacts.strip().split(',')]
 
-    for item in hosts.strip().split(','):
+    for item in hostnames.strip().split(','):
       hostname = item.strip()
       if hostname:
         host = containers.Host(hostname=hostname)
-        self.hostnames.append(host)
+        self.hosts.append(host)
 
     self.use_tsk = use_tsk
 
@@ -474,10 +474,10 @@ class GRRArtifactCollector(GRRFlow):
     Raises:
       DFTimewolfError: if no artifacts specified nor resolved by platform.
     """
-    self.hostnames.extend(self.state.GetContainers(containers.Host))
+    self.hosts.extend(self.state.GetContainers(containers.Host))
 
     threads = []
-    for client in self._FindClients([host.hostname for host in self.hostnames]):
+    for client in self._FindClients([host.hostname for host in self.hosts]):
       thread = threading.Thread(target=self._ProcessThread, args=(client, ))
       threads.append(thread)
       thread.start()
@@ -491,7 +491,7 @@ class GRRFileCollector(GRRFlow):
 
   Attributes:
     files (list[str]): file paths.
-    hostnames (list[containers.Host]): Hosts to collect artifacts from.
+    hosts (list[containers.Host]): Hosts to collect artifacts from.
     use_tsk (bool): True if GRR should use Sleuthkit (TSK) to collect files.
     action (FileFinderAction): Enum denoting action to take.
   """
@@ -504,19 +504,19 @@ class GRRFileCollector(GRRFlow):
     super(GRRFileCollector, self).__init__(state, name=name, critical=critical)
     self._clients = []
     self.files = []
-    self.hostnames = []
+    self.hosts = []
     self.use_tsk = False
     self.action = None
 
   # pylint: disable=arguments-differ,too-many-arguments
   def SetUp(self,
-            hosts, files, use_tsk,
+            hostnames, files, use_tsk,
             reason, grr_server_url, grr_username, grr_password, approvers=None,
             verify=True, skip_offline_clients=False, action='download'):
     """Initializes a GRR file collector.
 
     Args:
-      hosts (str): comma-separated hostnames to launch the flow on.
+      hostnames (str): comma-separated hostnames to launch the flow on.
       files (str): comma-separated file paths.
       use_tsk (bool): True if GRR should use Sleuthkit (TSK) to collect files.
       reason (str): justification for GRR access.
@@ -538,11 +538,11 @@ class GRRFileCollector(GRRFlow):
     if files is not None:
       self.files = [item.strip() for item in files.strip().split(',')]
 
-    for item in hosts.strip().split(','):
+    for item in hostnames.strip().split(','):
       hostname = item.strip()
       if hostname:
         host = containers.Host(hostname=hostname)
-        self.hostnames.append(host)
+        self.hosts.append(host)
 
     self.use_tsk = use_tsk
 
@@ -589,10 +589,10 @@ class GRRFileCollector(GRRFlow):
     Raises:
       DFTimewolfError: if no files specified.
     """
-    self.hostnames.extend(self.state.GetContainers(containers.Host))
+    self.hosts.extend(self.state.GetContainers(containers.Host))
 
     threads = []
-    for client in self._FindClients([host.hostname for host in self.hostnames]):
+    for client in self._FindClients([host.hostname for host in self.hosts]):
       thread = threading.Thread(target=self._ProcessThread, args=(client, ))
       threads.append(thread)
       thread.start()
@@ -619,13 +619,13 @@ class GRRFlowCollector(GRRFlow):
 
   # pylint: disable=arguments-differ
   def SetUp(self,
-            host, flow_id,
+            hostname, flow_id,
             reason, grr_server_url, grr_username, grr_password, approvers=None,
             verify=True, skip_offline_clients=False):
     """Initializes a GRR flow collector.
 
     Args:
-      host (containers.Host): Host to gather the flow from.
+      hostname (str): Hostname to gather the flow from.
       flow_id (str): GRR identifier of the flow to retrieve.
       reason (str): justification for GRR access.
       grr_server_url (str): GRR server URL.
@@ -643,7 +643,7 @@ class GRRFlowCollector(GRRFlow):
         skip_offline_clients=skip_offline_clients)
 
     self.flow_id = flow_id
-    self.host = containers.Host(hostname=host)
+    self.host = containers.Host(hostname=hostname)
 
   def Process(self):
     """Downloads the results of a GRR collection flow.
@@ -672,7 +672,7 @@ class GRRTimelineCollector(GRRFlow):
 
   Attributes:
     root_path (str): root path.
-    hostnames (list[containers.Host]): Hosts to collect artifacts from.
+    hosts (list[containers.Host]): Hosts to collect artifacts from.
   """
 
   def __init__(self, state, name=None, critical=False):
@@ -680,19 +680,19 @@ class GRRTimelineCollector(GRRFlow):
         state, name=name, critical=critical)
     self._clients = []
     self.root_path = None
-    self.hostnames = []
+    self.hosts = []
     self._timeline_format = None
 
   # We're overriding the behavior of GRRFlow's SetUp function to include new
   # parameters.
   # pylint: disable=arguments-differ,too-many-arguments
   def SetUp(self,
-            hosts, root_path,
+            hostnames, root_path,
             reason, timeline_format, grr_server_url, grr_username, grr_password,
             approvers=None, verify=True, skip_offline_clients=False):
     """Initializes a GRR timeline collector.
     Args:
-      hosts (str): comma-separated hostnames to launch the flow on.
+      hostnames (str): comma-separated hostnames to launch the flow on.
       root_path (str): path to start the recursive timeline.
       reason (str): justification for GRR access.
       timeline_format (str): Timeline format (1 is BODY, 2 is RAW).
@@ -713,11 +713,11 @@ class GRRTimelineCollector(GRRFlow):
     if root_path is not None:
       self.root_path = root_path.strip()
 
-    for item in hosts.strip().split(','):
+    for item in hostnames.strip().split(','):
       hostname = item.strip()
       if hostname:
         host = containers.Host(hostname=hostname)
-        self.hostnames.append(host)
+        self.hosts.append(host)
 
     self._timeline_format = int(timeline_format)
     self.root_path = root_path.encode()
@@ -756,10 +756,10 @@ class GRRTimelineCollector(GRRFlow):
     Raises:
       DFTimewolfError: if no files specified.
     """
-    self.hostnames.extend(self.state.GetContainers(containers.Host))
+    self.hosts.extend(self.state.GetContainers(containers.Host))
 
     threads = []
-    for client in self._FindClients([host.hostname for host in self.hostnames]):
+    for client in self._FindClients([host.hostname for host in self.hosts]):
       thread = threading.Thread(target=self._ProcessThread, args=(client, ))
       threads.append(thread)
       thread.start()

--- a/dftimewolf/lib/containers/containers.py
+++ b/dftimewolf/lib/containers/containers.py
@@ -223,3 +223,19 @@ class DataFrame(interface.AttributeContainer):
     self.data_frame = data_frame
     self.description = description
     self.name = name
+
+
+class Host(interface.AttributeContainer):
+  """Attribute container definition for a host.
+
+  Attributes:
+    hostname (str): The host's hostname.
+    platform (str): The host's platform. One of {win, linux, macos, unknown}.
+  """
+
+  CONTAINER_TYPE = 'host'
+
+  def __init__(self, hostname, platform='unkown'):
+    super(Host, self).__init__()
+    self.hostname = hostname
+    self.platform = platform

--- a/dftimewolf/lib/containers/containers.py
+++ b/dftimewolf/lib/containers/containers.py
@@ -235,7 +235,7 @@ class Host(interface.AttributeContainer):
 
   CONTAINER_TYPE = 'host'
 
-  def __init__(self, hostname, platform='unkown'):
+  def __init__(self, hostname, platform='unknown'):
     super(Host, self).__init__()
     self.hostname = hostname
     self.platform = platform

--- a/tests/lib/collectors/grr_hosts.py
+++ b/tests/lib/collectors/grr_hosts.py
@@ -200,8 +200,8 @@ class GRRArtifactCollectorTest(unittest.TestCase):
     self.assertEqual(self.grr_artifact_collector.artifacts, [])
     self.assertEqual(
         self.grr_artifact_collector.extra_artifacts, [])
-    self.assertEqual(self.grr_artifact_collector.hostnames,
-                     ['C.0000000000000001'])
+    self.assertEqual(self.grr_artifact_collector.hostnames[0].hostname,
+                     'C.0000000000000001')
     self.assertTrue(self.grr_artifact_collector.use_tsk)
 
   @mock.patch('grr_api_client.api.InitHttp')
@@ -268,6 +268,41 @@ class GRRArtifactCollectorTest(unittest.TestCase):
     self.assertEqual(result.name, 'tomchop')
     self.assertEqual(result.path, '/tmp/tmpRandom/tomchop')
 
+  @mock.patch('grr_api_client.api.InitHttp')
+  @mock.patch('dftimewolf.lib.collectors.grr_hosts.GRRFlow._AwaitFlow')
+  @mock.patch('dftimewolf.lib.collectors.grr_hosts.GRRFlow._DownloadFiles')
+  @mock.patch('dftimewolf.lib.collectors.grr_hosts.GRRFlow._LaunchFlow')
+  @mock.patch('dftimewolf.lib.collectors.grr_hosts.GRRFlow._FindClients')
+  def testProcessFromContainers(self,
+                                mock_FindClients,
+                                unused_LaunchFlow,
+                                unused_DownloadFiles,
+                                unused_AwaitFlow,
+                                mock_InitHttp):
+    """Tests that processing works when only containers are passed."""
+    mock_InitHttp.return_value = self.mock_grr_api
+    self.grr_artifact_collector.hostnames = []
+    self.grr_artifact_collector.SetUp(
+        hosts='',
+        artifacts='RandomArtifact',
+        extra_artifacts='AnotherArtifact',
+        use_tsk=True,
+        reason='Random reason',
+        grr_server_url='http://fake/endpoint',
+        grr_username='user',
+        grr_password='password',
+        approvers='approver1,approver2',
+        verify=False,
+        skip_offline_clients=False
+    )
+    self.test_state.StoreContainer(containers.Host(hostname='container.host'))
+
+    self.grr_artifact_collector.Process()
+    mock_FindClients.assert_called_with(['container.host'])
+
+
+
+
 class GRRFileCollectorTest(unittest.TestCase):
   """Tests for the GRR file collector."""
 
@@ -293,8 +328,8 @@ class GRRFileCollectorTest(unittest.TestCase):
   def testInitialization(self):
     """Tests that the collector can be initialized."""
     self.assertIsNotNone(self.grr_file_collector)
-    self.assertEqual(self.grr_file_collector.hostnames,
-                     ['C.0000000000000001'])
+    self.assertEqual(self.grr_file_collector.hostnames[0].hostname,
+                     'C.0000000000000001')
     self.assertEqual(self.grr_file_collector.files, ['/etc/passwd'])
 
   @mock.patch('dftimewolf.lib.collectors.grr_hosts.GRRFlow._AwaitFlow')
@@ -320,6 +355,37 @@ class GRRFileCollectorTest(unittest.TestCase):
     result = results[0]
     self.assertEqual(result.name, 'tomchop')
     self.assertEqual(result.path, '/tmp/something')
+
+  @mock.patch('grr_api_client.api.InitHttp')
+  @mock.patch('dftimewolf.lib.collectors.grr_hosts.GRRFlow._AwaitFlow')
+  @mock.patch('dftimewolf.lib.collectors.grr_hosts.GRRFlow._DownloadFiles')
+  @mock.patch('dftimewolf.lib.collectors.grr_hosts.GRRFlow._LaunchFlow')
+  @mock.patch('dftimewolf.lib.collectors.grr_hosts.GRRFlow._FindClients')
+  def testProcessFromContainers(self,
+                                mock_FindClients,
+                                unused_LaunchFlow,
+                                unused_DownloadFiles,
+                                unused_AwaitFlow,
+                                mock_InitHttp):
+    """Tests that processing works when only containers are passed."""
+    mock_InitHttp.return_value = self.mock_grr_api
+    self.grr_file_collector.hostnames = []
+    self.grr_file_collector.SetUp(
+        hosts='',
+        files='/etc/passwd',
+        use_tsk=True,
+        reason='random reason',
+        grr_server_url='http://fake/endpoint',
+        grr_username='admin',
+        grr_password='admin',
+        approvers='approver1,approver2',
+        skip_offline_clients=False,
+        action='stat',
+    )
+    self.test_state.StoreContainer(containers.Host(hostname='container.host'))
+
+    self.grr_file_collector.Process()
+    mock_FindClients.assert_called_with(['container.host'])
 
 
 class GRRFlowCollector(unittest.TestCase):
@@ -384,8 +450,8 @@ class GRRTimelineCollector(unittest.TestCase):
   def testInitialization(self):
     """Tests that the collector can be initialized."""
     self.assertIsNotNone(self.grr_timeline_collector)
-    self.assertEqual(self.grr_timeline_collector.hostnames,
-                     ['C.0000000000000001'])
+    self.assertEqual(self.grr_timeline_collector.hostnames[0].hostname,
+                     'C.0000000000000001')
     self.assertEqual(self.grr_timeline_collector.root_path, b'/')
     self.assertEqual(self.grr_timeline_collector._timeline_format, 1)
 
@@ -410,6 +476,38 @@ class GRRTimelineCollector(unittest.TestCase):
     result = results[0]
     self.assertEqual(result.name, 'tomchop')
     self.assertEqual(result.path, '/tmp/something')
+
+  @mock.patch('grr_api_client.api.InitHttp')
+  @mock.patch('dftimewolf.lib.collectors.grr_hosts.GRRFlow._AwaitFlow')
+  @mock.patch('dftimewolf.lib.collectors.grr_hosts.GRRFlow._DownloadFiles')
+  @mock.patch('dftimewolf.lib.collectors.grr_hosts.GRRFlow._LaunchFlow')
+  @mock.patch('dftimewolf.lib.collectors.grr_hosts.GRRFlow._FindClients')
+  def testProcessFromContainers(self,
+                                mock_FindClients,
+                                unused_LaunchFlow,
+                                unused_DownloadFiles,
+                                unused_AwaitFlow,
+                                mock_InitHttp):
+    """Tests that processing works when only containers are passed."""
+    mock_InitHttp.return_value = self.mock_grr_api
+    self.grr_timeline_collector.hostnames = []
+    self.grr_timeline_collector.SetUp(
+        hosts='',
+        root_path='/',
+        reason='random reason',
+        timeline_format='1',
+        grr_server_url='http://fake/endpoint',
+        grr_username='admin',
+        grr_password='admin',
+        approvers='approver1,approver2',
+        skip_offline_clients=False,
+    )
+    self.test_state.StoreContainer(containers.Host(hostname='container.host'))
+
+    self.grr_timeline_collector.Process()
+    mock_FindClients.assert_called_with(['container.host'])
+
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/lib/collectors/grr_hosts.py
+++ b/tests/lib/collectors/grr_hosts.py
@@ -178,7 +178,7 @@ class GRRArtifactCollectorTest(unittest.TestCase):
     self.grr_artifact_collector = grr_hosts.GRRArtifactCollector(
         self.test_state)
     self.grr_artifact_collector.SetUp(
-        hosts='C.0000000000000001',
+        hostnames='C.0000000000000001',
         artifacts=None,
         extra_artifacts=None,
         use_tsk=True,
@@ -200,7 +200,7 @@ class GRRArtifactCollectorTest(unittest.TestCase):
     self.assertEqual(self.grr_artifact_collector.artifacts, [])
     self.assertEqual(
         self.grr_artifact_collector.extra_artifacts, [])
-    self.assertEqual(self.grr_artifact_collector.hostnames[0].hostname,
+    self.assertEqual(self.grr_artifact_collector.hosts[0].hostname,
                      'C.0000000000000001')
     self.assertTrue(self.grr_artifact_collector.use_tsk)
 
@@ -224,7 +224,7 @@ class GRRArtifactCollectorTest(unittest.TestCase):
     self.grr_artifact_collector = grr_hosts.GRRArtifactCollector(
         self.test_state)
     self.grr_artifact_collector.SetUp(
-        hosts='C.0000000000000001',
+        hostnames='C.0000000000000001',
         artifacts='RandomArtifact',
         extra_artifacts='AnotherArtifact',
         use_tsk=True,
@@ -281,9 +281,10 @@ class GRRArtifactCollectorTest(unittest.TestCase):
                                 mock_InitHttp):
     """Tests that processing works when only containers are passed."""
     mock_InitHttp.return_value = self.mock_grr_api
-    self.grr_artifact_collector.hostnames = []
+    self.grr_artifact_collector = grr_hosts.GRRArtifactCollector(
+        self.test_state)
     self.grr_artifact_collector.SetUp(
-        hosts='',
+        hostnames='',
         artifacts='RandomArtifact',
         extra_artifacts='AnotherArtifact',
         use_tsk=True,
@@ -313,7 +314,7 @@ class GRRFileCollectorTest(unittest.TestCase):
     self.test_state = state.DFTimewolfState(config.Config)
     self.grr_file_collector = grr_hosts.GRRFileCollector(self.test_state)
     self.grr_file_collector.SetUp(
-        hosts='C.0000000000000001',
+        hostnames='C.0000000000000001',
         files='/etc/passwd',
         use_tsk=True,
         reason='random reason',
@@ -328,7 +329,7 @@ class GRRFileCollectorTest(unittest.TestCase):
   def testInitialization(self):
     """Tests that the collector can be initialized."""
     self.assertIsNotNone(self.grr_file_collector)
-    self.assertEqual(self.grr_file_collector.hostnames[0].hostname,
+    self.assertEqual(self.grr_file_collector.hosts[0].hostname,
                      'C.0000000000000001')
     self.assertEqual(self.grr_file_collector.files, ['/etc/passwd'])
 
@@ -369,9 +370,10 @@ class GRRFileCollectorTest(unittest.TestCase):
                                 mock_InitHttp):
     """Tests that processing works when only containers are passed."""
     mock_InitHttp.return_value = self.mock_grr_api
-    self.grr_file_collector.hostnames = []
+    self.grr_file_collector = grr_hosts.GRRFileCollector(
+        self.test_state)
     self.grr_file_collector.SetUp(
-        hosts='',
+        hostnames='',
         files='/etc/passwd',
         use_tsk=True,
         reason='random reason',
@@ -398,7 +400,7 @@ class GRRFlowCollector(unittest.TestCase):
     self.test_state = state.DFTimewolfState(config.Config)
     self.grr_flow_collector = grr_hosts.GRRFlowCollector(self.test_state)
     self.grr_flow_collector.SetUp(
-        host='C.0000000000000001',
+        hostname='C.0000000000000001',
         flow_id='F:12345',
         reason='random reason',
         grr_server_url='http://fake/endpoint',
@@ -436,7 +438,7 @@ class GRRTimelineCollector(unittest.TestCase):
     self.grr_timeline_collector = grr_hosts.GRRTimelineCollector(
         self.test_state)
     self.grr_timeline_collector.SetUp(
-        hosts='C.0000000000000001',
+        hostnames='C.0000000000000001',
         root_path='/',
         reason='random reason',
         timeline_format='1',
@@ -450,7 +452,7 @@ class GRRTimelineCollector(unittest.TestCase):
   def testInitialization(self):
     """Tests that the collector can be initialized."""
     self.assertIsNotNone(self.grr_timeline_collector)
-    self.assertEqual(self.grr_timeline_collector.hostnames[0].hostname,
+    self.assertEqual(self.grr_timeline_collector.hosts[0].hostname,
                      'C.0000000000000001')
     self.assertEqual(self.grr_timeline_collector.root_path, b'/')
     self.assertEqual(self.grr_timeline_collector._timeline_format, 1)
@@ -490,9 +492,10 @@ class GRRTimelineCollector(unittest.TestCase):
                                 mock_InitHttp):
     """Tests that processing works when only containers are passed."""
     mock_InitHttp.return_value = self.mock_grr_api
-    self.grr_timeline_collector.hostnames = []
+    self.grr_timeline_collector = grr_hosts.GRRTimelineCollector(
+        self.test_state)
     self.grr_timeline_collector.SetUp(
-        hosts='',
+        hostnames='',
         root_path='/',
         reason='random reason',
         timeline_format='1',


### PR DESCRIPTION
This PR changes the way GRR modules deal with hosts. Instead of strings, they now manipulate `containers.Host` attribute containers. This makes it possible for other modules (e.g. "user2host") to generate containers for the GRR modules to work on.