### PR TITLE
Adjust logging query

### DIFF
--- a/data/recipes/gcp_logging_gce_instance_ts.json
+++ b/data/recipes/gcp_logging_gce_instance_ts.json
@@ -14,7 +14,7 @@
         "name": "GCPLogsCollector",
         "args": {
             "project_name": "@project_name",
-            "filter_expression": "logName=projects/@project_name/logs/cloudaudit.googleapis.com%2Factivity operation.producer=\"compute.googleapis.com\" resource.instance_id=\"@instance_id\""
+            "filter_expression": "logName=projects/@project_name/logs/cloudaudit.googleapis.com%2Factivity operation.producer=\"compute.googleapis.com\" resource.labels.instance_id=\"@instance_id\""
         }
     }, {
         "wants": ["GCPLogsCollector"],


### PR DESCRIPTION
Instance IDs now require going through `labels`

https://cloud.google.com/logging/docs/view/advanced-queries#right-log-entries