### PR TITLE
Fixed sketch-id error message

### DIFF
--- a/dftimewolf/lib/exporters/timesketch.py
+++ b/dftimewolf/lib/exporters/timesketch.py
@@ -86,7 +86,7 @@ class TimesketchExporter(module.BaseModule):
       sketch = self.timesketch_api.get_sketch(self.sketch_id)
       if 'write' not in sketch.my_acl:
         self.ModuleError(
-            'No write access to sketch ID {0:d}, aborting'.format(sketch_id),
+            'No write access to sketch ID {0:d}, aborting'.format(self.sketch_id),
             critical=True)
       self.state.AddToCache('timesketch_sketch', sketch)
       self.sketch_id = sketch.id

--- a/dftimewolf/lib/exporters/timesketch.py
+++ b/dftimewolf/lib/exporters/timesketch.py
@@ -86,8 +86,8 @@ class TimesketchExporter(module.BaseModule):
       sketch = self.timesketch_api.get_sketch(self.sketch_id)
       if 'write' not in sketch.my_acl:
         self.ModuleError(
-            'No write access to sketch ID {0:d}, aborting'.format(self.sketch_id),
-            critical=True)
+            'No write access to sketch ID {0:d}, aborting'.format(
+            self.sketch_id), critical=True)
       self.state.AddToCache('timesketch_sketch', sketch)
       self.sketch_id = sketch.id
 


### PR DESCRIPTION
The Error message references sketch_id (str) instead of the correct self.sketch_id (int). Because of that the following error is thrown when reaching the original line 89:
ValueError: Unknown format code 'd' for object of type 'str'

The fix uses self.sketch_id, which has already been converted to an int in line 71.