### PR TITLE
Fix bug in removing lines that start with # and '-i'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def ParseRequirements(filename):
   with open(filename) as requirements:
 
     for line in requirements.readlines():
-      if not (line.startswith('#') or line.startswith('-i') or not line):
+      if line.startswith('#') or line.startswith('-i') or not line:
         # Skip lines starting with '#' and '-i https://pypi.org/simple'
         continue
       reqs.append(line)


### PR DESCRIPTION
Error #381 still persists when trying to install.

In line 22 of setup.py there seems to be a logic bug when skipping lines in the requirements file - it does the opposite to what was intended.