### PR TITLE
Move Turbinia recipe variables

### DIFF
--- a/dftimewolf/lib/processors/turbinia_gcp.py
+++ b/dftimewolf/lib/processors/turbinia_gcp.py
@@ -191,9 +191,9 @@ class TurbiniaProcessorBase(module.BaseModule):
     request = TurbiniaRequest(requester=getpass.getuser())
     request.evidence.append(evidence_)
     if self.sketch_id:
-      request.recipe['sketch_id'] = self.sketch_id
+      request.recipe['globals']['sketch_id'] = self.sketch_id
     if not self.run_all_jobs:
-      request.recipe['jobs_denylist'] = [
+      request.recipe['globals']['jobs_denylist'] = [
           'StringsJob', 'BinaryExtractorJob', 'BulkExtractorJob', 'PhotorecJob']
 
     threatintel = self.state.GetContainers(containers.ThreatIntelligence)
@@ -202,7 +202,7 @@ class TurbiniaProcessorBase(module.BaseModule):
           'Sending {0:d} threatintel to Turbinia GrepWorkers...'.format(
               len(threatintel)))
       indicators = [item.indicator for item in threatintel]
-      request.recipe['filter_patterns'] = indicators
+      request.recipe['globals']['filter_patterns'] = indicators
 
     request_dict = {
         'instance': self.instance,

--- a/tests/lib/processors/turbinia_gcp.py
+++ b/tests/lib/processors/turbinia_gcp.py
@@ -178,9 +178,9 @@ class TurbiniaProcessorTest(unittest.TestCase):
     # pylint: disable=no-member
     turbinia_processor.client.send_request.assert_called()
     request = turbinia_processor.client.send_request.call_args[0][0]
-    self.assertEqual(request.recipe['sketch_id'], 4567)
+    self.assertEqual(request.recipe['globals']['sketch_id'], 4567)
     self.assertListEqual(
-        request.recipe['jobs_denylist'],
+        request.recipe['globals']['jobs_denylist'],
         ['StringsJob', 'BinaryExtractorJob', 'BulkExtractorJob', 'PhotorecJob'])
     turbinia_processor.client.get_task_data.assert_called()
     # pylint: disable=protected-access


### PR DESCRIPTION
This is to match the recipe structure in the new release of Turbinia.