### PR TITLE
Set stdout as default output stream for logging.StreamHandler

### DIFF
--- a/dftimewolf/cli/dftimewolf_recipes.py
+++ b/dftimewolf/cli/dftimewolf_recipes.py
@@ -306,7 +306,7 @@ def SetupLogging() -> None:
 
   # Add a silent default stream handler, this is automatically set
   # when other libraries call logging.info() or similar methods.
-  root_handler = logging.StreamHandler()
+  root_handler = logging.StreamHandler(stream=sys.stdout)
   root_handler.addFilter(lambda x: False)
   root_log.addHandler(root_handler)
 
@@ -323,7 +323,7 @@ def SetupLogging() -> None:
   file_handler.setFormatter(logging_utils.WolfFormatter(colorize=False))
   logger.addHandler(file_handler)
 
-  console_handler = logging.StreamHandler()
+  console_handler = logging.StreamHandler(stream=sys.stdout)
   colorize = not bool(os.environ.get('DFTIMEWOLF_NO_RAINBOW'))
   console_handler.setFormatter(logging_utils.WolfFormatter(colorize=colorize))
   logger.addHandler(console_handler)


### PR DESCRIPTION
Not setting stream= parameter means the StreamHandler uses stderr, per https://docs.python.org/3/library/logging.handlers.html#logging.StreamHandler