### PR TITLE
Add source attribute to the DataFrame container definition

### DIFF
--- a/dftimewolf/lib/containers/containers.py
+++ b/dftimewolf/lib/containers/containers.py
@@ -325,16 +325,16 @@ class DataFrame(interface.AttributeContainer):
   CONTAINER_TYPE = 'data_frame'
 
   def __init__(
-      self, 
-      data_frame: "pandas.DataFrame", 
-      description: str, 
-      name: str, 
+      self,
+      data_frame: "pandas.DataFrame",
+      description: str,
+      name: str,
       source: Optional[str] = None) -> None:
     super(DataFrame, self).__init__()
     self.data_frame = data_frame
     self.description = description
     self.name = name
-    self.source = source  
+    self.source = source
     
 
 class Host(interface.AttributeContainer):

--- a/dftimewolf/lib/containers/containers.py
+++ b/dftimewolf/lib/containers/containers.py
@@ -335,7 +335,7 @@ class DataFrame(interface.AttributeContainer):
     self.description = description
     self.name = name
     self.source = source
-    
+
 
 class Host(interface.AttributeContainer):
   """Attribute container definition for a host.

--- a/dftimewolf/lib/containers/containers.py
+++ b/dftimewolf/lib/containers/containers.py
@@ -319,17 +319,23 @@ class DataFrame(interface.AttributeContainer):
     data_frame (pandas.DataFrame): DataFrame containing the data.
     description (str): Description of the data in the data frame.
     name (str): Name of the data frame.
+    source (str): The source of the data in the DataFrame.
   """
 
   CONTAINER_TYPE = 'data_frame'
 
   def __init__(
-      self, data_frame: "pandas.DataFrame", description: str, name: str):
+      self, 
+      data_frame: "pandas.DataFrame", 
+      description: str, 
+      name: str, 
+      source: Optional[str] = None) -> None:
     super(DataFrame, self).__init__()
     self.data_frame = data_frame
     self.description = description
     self.name = name
-
+    self.source = source  
+    
 
 class Host(interface.AttributeContainer):
   """Attribute container definition for a host.


### PR DESCRIPTION
Allows for users of the DataFrame container to specify the source of data, which can then be used by modules processing this container.