### PR TITLE
Add thread name to logging for thread aware modules

### DIFF
--- a/dftimewolf/lib/logging_utils.py
+++ b/dftimewolf/lib/logging_utils.py
@@ -42,6 +42,9 @@ BOLD = '\u001b[1m'  # Bold / bright modifier
 LOG_FORMAT = (
     '[%(asctime)s] [{0:s}{color:s}%(name)-20s{1:s}] %(levelname)-8s'
     ' %(message)s')
+LOG_FORMAT_WITH_THREAD = (
+    '[%(asctime)s] [{0:s}{color:s}%(name)-20s{1:s}] [%(threadName)s] '
+    '%(levelname)-8s %(message)s')
 
 LEVEL_COLOR_MAP = {
     'WARNING': YELLOW,
@@ -70,6 +73,7 @@ class WolfFormatter(logging.Formatter):
       self,
       colorize: bool = True,
       random_color: bool = False,
+      threaded: bool = False,
       **kwargs: Any) -> None:
     """Initializes the WolfFormatter object.
 
@@ -78,13 +82,14 @@ class WolfFormatter(logging.Formatter):
       random_color (bool): If True, will colorize the module name with a random
           color picked from COLOR_SEQS.
     """
+    format = LOG_FORMAT_WITH_THREAD if threaded else LOG_FORMAT
     self.colorize = colorize
-    kwargs['fmt'] = LOG_FORMAT.format('', '', color='')
+    kwargs['fmt'] = format.format('', '', color='')
     if self.colorize:
       color = ''
       if random_color:
         color = random.choice(COLOR_SEQS)
-      kwargs['fmt'] = LOG_FORMAT.format(BOLD, RESET_SEQ, color=color)
+      kwargs['fmt'] = format.format(BOLD, RESET_SEQ, color=color)
     super(WolfFormatter, self).__init__(**kwargs)
 
   def format(self, record: LogRecord) -> str:

--- a/dftimewolf/lib/logging_utils.py
+++ b/dftimewolf/lib/logging_utils.py
@@ -44,9 +44,6 @@ BOLD = '\u001b[1m'  # Bold / bright modifier
 LOG_FORMAT = (
     '[%(asctime)s] [{0:s}{color:s}%(name)-20s{1:s}] %(levelname)-8s'
     ' %(message)s')
-LOG_FORMAT_WITH_THREAD = (
-    '[%(asctime)s] [{0:s}{color:s}%(name)-20s{1:s}] [%(threadName)s] '
-    '%(levelname)-8s %(message)s')
 
 LEVEL_COLOR_MAP = {
     'WARNING': YELLOW,
@@ -109,7 +106,7 @@ class WolfFormatter(logging.Formatter):
       if loglevel_color:
         message = loglevel_color + message + RESET_SEQ
       record.msg = message
-    
+
     if self.threaded:
       stack = [i[3] for i in inspect.stack()]
       if 'Process' in stack:

--- a/dftimewolf/lib/logging_utils.py
+++ b/dftimewolf/lib/logging_utils.py
@@ -108,9 +108,9 @@ class WolfFormatter(logging.Formatter):
       record.msg = message
 
     if self.threaded:
-      stack = [i[3] for i in inspect.stack()]
+      stack = [i.function for i in inspect.stack()]
       if 'Process' in stack:
-        record.msg = "[{0:s}] {1:s}".format(
-            threading.current_thread().getName(),
-            record.getMessage())
+        thread_name = threading.current_thread().getName()
+        message = record.getMessage()
+        record.msg = "[{0:s}] {1:s}".format(thread_name, message)
     return super(WolfFormatter, self).format(record)

--- a/dftimewolf/lib/module.py
+++ b/dftimewolf/lib/module.py
@@ -55,7 +55,7 @@ class BaseModule(object):
 
     self.SetupLogging()
 
-  def SetupLogging(self) -> None:
+  def SetupLogging(self, threaded: bool = False) -> None:
     """Sets up stream and file logging for a specific module."""
     self.logger.setLevel(logging.DEBUG)
 
@@ -67,7 +67,7 @@ class BaseModule(object):
     self.logger.addHandler(file_handler)
 
     console_handler = logging.StreamHandler()
-    formatter = logging_utils.WolfFormatter(random_color=True)
+    formatter = logging_utils.WolfFormatter(random_color=True, threaded=threaded)
     console_handler.setFormatter(formatter)
 
     self.logger.addHandler(console_handler)
@@ -175,6 +175,11 @@ class ThreadAwareModule(BaseModule):
     """
     super(ThreadAwareModule, self).__init__(
         state, name=name, critical=critical)
+
+    # The call to super.__init__ sets up the logger, but we want to change it
+    # for threaded modules.
+    self.logger.handlers.clear()
+    self.SetupLogging(threaded=True)
 
   @abc.abstractmethod
   def PreSetUp(self) -> None:

--- a/dftimewolf/lib/module.py
+++ b/dftimewolf/lib/module.py
@@ -67,7 +67,9 @@ class BaseModule(object):
     self.logger.addHandler(file_handler)
 
     console_handler = logging.StreamHandler()
-    formatter = logging_utils.WolfFormatter(random_color=True, threaded=threaded)
+    formatter = logging_utils.WolfFormatter(
+        random_color=True,
+        threaded=threaded)
     console_handler.setFormatter(formatter)
 
     self.logger.addHandler(console_handler)

--- a/tests/lib/state.py
+++ b/tests/lib/state.py
@@ -259,6 +259,8 @@ class StateTest(unittest.TestCase):
     test_state.SetupModules()
     test_state.RunModules()
 
+    self.assertEqual(len(test_state.errors), 0)
+
     # With no mocks, the first module generates 3 TestContainers, and 1
     # TestContainerTwo. The Test ThreadAwareConsumerModule is threaded on
     # and modifies TestContainer, modifies TestContainerTwo, and generates

--- a/tests/test_modules/thread_aware_modules.py
+++ b/tests/test_modules/thread_aware_modules.py
@@ -74,7 +74,7 @@ class ThreadAwareConsumerModule(module.ThreadAwareModule):
 
   def Process(self, container) -> None:
     """Process"""
-    print(self.name + ' Process!')
+    self.logger.info(self.name + ' Process!')
 
     time.sleep(1)
 
@@ -98,13 +98,13 @@ class ThreadAwareConsumerModule(module.ThreadAwareModule):
     return 2
 
   def PreSetUp(self) -> None:
-    print("ThreadAwareConsumerModule Static Pre Set Up")
+    self.logger.info("ThreadAwareConsumerModule Static Pre Set Up")
 
   def PostSetUp(self) -> None:
-    print("ThreadAwareConsumerModule Static Post Set Up")
+    self.logger.info("ThreadAwareConsumerModule Static Post Set Up")
 
   def PreProcess(self) -> None:
-    print("ThreadAwareConsumerModule Static Pre Process")
+    self.logger.info("ThreadAwareConsumerModule Static Pre Process")
 
   def PostProcess(self) -> None:
-    print("ThreadAwareConsumerModule Static Post Process")
+    self.logger.info("ThreadAwareConsumerModule Static Post Process")

--- a/tests/test_modules/thread_aware_modules.py
+++ b/tests/test_modules/thread_aware_modules.py
@@ -70,11 +70,11 @@ class ThreadAwareConsumerModule(module.ThreadAwareModule):
 
   def SetUp(self): # pylint: disable=arguments-differ
     """SetUp"""
-    print(self.name + ' SetUp!')
+    self.logger.info('{0:s} SetUp!'.format(self.name))
 
   def Process(self, container) -> None:
     """Process"""
-    self.logger.info(self.name + ' Process!')
+    self.logger.info('{0:s} Process!'.format(self.name))
 
     time.sleep(1)
 


### PR DESCRIPTION
Adds the thread name to log messages for logging within a threadawaremodule's Process method. Allows for better identification of log messages when multiple threads are running. 

Sample from unittests:

```
<snip>
[2021-11-08 23:19:54,699] [dftimewolf          ] INFO     Module ContainerGeneratorModule finished execution
[2021-11-08 23:19:54,699] [dftimewolf          ] INFO     Running module: ThreadAwareConsumerModule
[2021-11-08 23:19:54,699] [ThreadAwareConsumerModule] INFO     ThreadAwareConsumerModule Static Pre Process
[2021-11-08 23:19:54,699] [dftimewolf          ] INFO     Running 3 threads, max 2 simultaneous for module ThreadAwareConsumerModule
[2021-11-08 23:19:54,700] [ThreadAwareConsumerModule] INFO     [ThreadPoolExecutor-1_0] ThreadAwareConsumerModule Process!
[2021-11-08 23:19:54,700] [ThreadAwareConsumerModule] INFO     [ThreadPoolExecutor-1_1] ThreadAwareConsumerModule Process!
[2021-11-08 23:19:55,701] [ThreadAwareConsumerModule] INFO     [ThreadPoolExecutor-1_0] ThreadAwareConsumerModule Process!
[2021-11-08 23:19:56,703] [ThreadAwareConsumerModule] INFO     ThreadAwareConsumerModule Static Post Process
[2021-11-08 23:19:56,704] [dftimewolf          ] INFO     Module ThreadAwareConsumerModule finished execution
.[2021-11-08 23:19:56,705] [dftimewolf          ] DEBUG    Loading module ContainerGeneratorModule from tests.test_modules.thread_aware_modules
[2021-11-08 23:19:56,705] [dftimewolf          ] DEBUG    Loading module ThreadAwareConsumerModule from tests.test_modules.thread_aware_modules
[2021-11-08 23:19:56,706] [dftimewolf          ] INFO     Setting up module: ContainerGeneratorModule
<snip>
```

Closes #441