### PR TITLE
python3.7 compatibility fix

### DIFF
--- a/dftimewolf/lib/collectors/grr_hosts.py
+++ b/dftimewolf/lib/collectors/grr_hosts.py
@@ -336,7 +336,7 @@ class GRRFlow(GRRBaseModule, module.ThreadAwareModule):
 
     # Unzip archive for processing and remove redundant zip
     fqdn = client.data.os_info.fqdn.lower()
-    client_output_file = os.path.join(self.output_path, fqdn)
+    client_output_file = os.path.join(self.output_path, fqdn, flow_id)
     if not os.path.isdir(client_output_file):
       os.makedirs(client_output_file)
 

--- a/dftimewolf/lib/exporters/local_filesystem.py
+++ b/dftimewolf/lib/exporters/local_filesystem.py
@@ -2,7 +2,9 @@
 """Local file system exporter module."""
 
 import os
+import random
 import shutil
+import string
 import tempfile
 from typing import List, Optional
 
@@ -44,9 +46,9 @@ class LocalFilesystemCopy(module.BaseModule):
     if not target_directory:
       self._target_directory = tempfile.mkdtemp(prefix='dftimewolf_local_fs')
     else:
-      if os.path.exists(target_directory):
-        target_directory = os.path.join(target_directory, 'dftimewolf')
-        os.makedirs(target_directory, exist_ok=True)
+#      if os.path.exists(target_directory):
+#        target_directory = os.path.join(target_directory, 'dftimewolf')
+#        os.makedirs(target_directory, exist_ok=True)
       self._target_directory = target_directory
 
   def Process(self) -> None:
@@ -97,7 +99,11 @@ class LocalFilesystemCopy(module.BaseModule):
     full_paths = []
     if os.path.isdir(source):
       try:
-        shutil.copytree(source, destination_directory, dirs_exist_ok=True)
+        if os.path.exists(destination_directory):
+          destination_directory = "{0:s}/{1:s}".format(
+              destination_directory,
+              ''.join(random.choices(string.ascii_uppercase, k=10)))
+        shutil.copytree(source, destination_directory)
         full_paths.append(destination_directory)
       except shutil.Error as e:
         self.ModuleError(str(e), critical=True)

--- a/dftimewolf/lib/exporters/local_filesystem.py
+++ b/dftimewolf/lib/exporters/local_filesystem.py
@@ -46,9 +46,6 @@ class LocalFilesystemCopy(module.BaseModule):
     if not target_directory:
       self._target_directory = tempfile.mkdtemp(prefix='dftimewolf_local_fs')
     else:
-#      if os.path.exists(target_directory):
-#        target_directory = os.path.join(target_directory, 'dftimewolf')
-#        os.makedirs(target_directory, exist_ok=True)
       self._target_directory = target_directory
 
   def Process(self) -> None:

--- a/tests/lib/collectors/grr_hosts.py
+++ b/tests/lib/collectors/grr_hosts.py
@@ -146,11 +146,11 @@ class GRRFlowTests(unittest.TestCase):
 
     return_value = self.grr_flow_module._DownloadFiles(
         mock_grr_hosts.MOCK_CLIENT, "F:12345")
-    self.assertEqual(return_value, '/tmp/random/tomchop')
+    self.assertEqual(return_value, '/tmp/random/tomchop/F:12345')
     mock_GetFilesArchive.assert_called_once()
     mock_ZipFile.assert_called_once_with('/tmp/random/F:12345.zip')
-    mock_isdir.assert_called_once_with('/tmp/random/tomchop')
-    mock_makedirs.assert_called_once_with('/tmp/random/tomchop')
+    mock_isdir.assert_called_once_with('/tmp/random/tomchop/F:12345')
+    mock_makedirs.assert_called_once_with('/tmp/random/tomchop/F:12345')
     mock_remove.assert_called_once_with('/tmp/random/F:12345.zip')
 
   @mock.patch('os.path.exists')

--- a/tests/lib/exporters/local_filesystem.py
+++ b/tests/lib/exporters/local_filesystem.py
@@ -2,9 +2,7 @@
 # -*- coding: utf-8 -*-
 """Tests the local filesystem exporter."""
 
-import tempfile
 import unittest
-from os.path import exists
 
 import mock
 
@@ -68,30 +66,6 @@ class LocalFileSystemTest(unittest.TestCase):
             '/fake/random'),
     ])
     mock_copy2.assert_called_with('/fake/evidence_file', '/fake/random')
-
-#  def testProcessCopyRealDirs(self):
-#    src = tempfile.mkdtemp()
-#    dst = tempfile.mkdtemp()
-#    fh = tempfile.NamedTemporaryFile(delete=False, dir=src)
-#    fh.write(b'sample data')
-#    fh.close()
-#
-#    test_state = state.DFTimewolfState(config.Config)
-#    test_state.StoreContainer(containers.File(
-#        name='description', path=src))
-#
-#    local_filesystem_copy = local_filesystem.LocalFilesystemCopy(test_state)
-#    local_filesystem_copy.SetUp()
-#    local_filesystem_copy.Process()
-#
-#    final = dst + '/' + fh.name.split('/')[-1]
-#    print('*' * 50)
-#    print("src: " + src)
-#    print("dst: " + dst)
-#    print("fh.name: " + fh.name)
-#    print("final: " + final)
-#    print('*' * 50)
-#    self.assertEqual(exists(final), True)
 
   @mock.patch('dftimewolf.lib.utils.Compress')
   @mock.patch('tempfile.mkdtemp')

--- a/tests/lib/exporters/local_filesystem.py
+++ b/tests/lib/exporters/local_filesystem.py
@@ -2,7 +2,9 @@
 # -*- coding: utf-8 -*-
 """Tests the local filesystem exporter."""
 
+import tempfile
 import unittest
+from os.path import exists
 
 import mock
 
@@ -63,10 +65,33 @@ class LocalFileSystemTest(unittest.TestCase):
 
     mock_copytree.assert_has_calls([
         mock.call('/fake/evidence_directory',
-            '/fake/random',
-            dirs_exist_ok=True),
+            '/fake/random'),
     ])
     mock_copy2.assert_called_with('/fake/evidence_file', '/fake/random')
+
+#  def testProcessCopyRealDirs(self):
+#    src = tempfile.mkdtemp()
+#    dst = tempfile.mkdtemp()
+#    fh = tempfile.NamedTemporaryFile(delete=False, dir=src)
+#    fh.write(b'sample data')
+#    fh.close()
+#
+#    test_state = state.DFTimewolfState(config.Config)
+#    test_state.StoreContainer(containers.File(
+#        name='description', path=src))
+#
+#    local_filesystem_copy = local_filesystem.LocalFilesystemCopy(test_state)
+#    local_filesystem_copy.SetUp()
+#    local_filesystem_copy.Process()
+#
+#    final = dst + '/' + fh.name.split('/')[-1]
+#    print('*' * 50)
+#    print("src: " + src)
+#    print("dst: " + dst)
+#    print("fh.name: " + fh.name)
+#    print("final: " + final)
+#    print('*' * 50)
+#    self.assertEqual(exists(final), True)
 
   @mock.patch('dftimewolf.lib.utils.Compress')
   @mock.patch('tempfile.mkdtemp')


### PR DESCRIPTION
Python 3.7 doesn't support the `dirs_exist_ok` param of `shutil.copytree()` recently added in, this pr fixes that, while keeping the fix for multiple containers attempting to use the `local_filesystem` module to output. 