### PR TITLE
Add github action to deploy docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,7 +3,9 @@ name: Build documentation pages
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  push
+  push:
+    branches:
+      - main
 
 jobs:
   build:
@@ -18,5 +20,5 @@ jobs:
       - name: Build doc
         run: mkdocs build
       - name: Publish doc to GitHub pages
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.event_name == 'push' && github.push.branches == 'main' }}
         run: mkdocs gh-deploy --force

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,6 +3,7 @@ name: Build documentation pages
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  push
 
 jobs:
   build:
@@ -12,5 +13,10 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - run: pip install mkdocs
-      - run: mkdocs build
+      - name: Install mkdocs
+        run: pip install mkdocs
+      - name: Build doc
+        run: mkdocs build
+      - name: Publish doc to GitHub pages
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        run: mkdocs gh-deploy --force


### PR DESCRIPTION
`mkdocs gh-deploy --force` will build the documentation in the repo root (/) on the `gh-pages` branch.