### PR TITLE
Removed Pre&PostSetup from ThreadAwareModule

### DIFF
--- a/dftimewolf/lib/collectors/aws_snapshot_s3_copy.py
+++ b/dftimewolf/lib/collectors/aws_snapshot_s3_copy.py
@@ -202,11 +202,5 @@ class AWSSnapshotS3CopyCollector(module.ThreadAwareModule):
   def GetThreadPoolSize(self) -> int:
     return 10
 
-  def PreSetUp(self) -> None:
-    pass
-
-  def PostSetUp(self) -> None:
-    pass
-
 
 modules_manager.ModulesManager.RegisterModule(AWSSnapshotS3CopyCollector)

--- a/dftimewolf/lib/collectors/grr_hosts.py
+++ b/dftimewolf/lib/collectors/grr_hosts.py
@@ -510,12 +510,6 @@ class GRRArtifactCollector(GRRFlow):
         )
         self.state.StoreContainer(cont)
 
-  def PreSetup(self) -> None:
-    """Not implemented."""
-
-  def PostSetup(self) -> None:
-    """Not implemented."""
-
   def PreProcess(self) -> None:
     """Not implemented."""
 
@@ -635,12 +629,6 @@ class GRRFileCollector(GRRFlow):
         )
         self.state.StoreContainer(cont)
 
-  def PreSetup(self) -> None:
-    """Not implemented."""
-
-  def PostSetup(self) -> None:
-    """Not implemented."""
-
   def PreProcess(self) -> None:
     """Check that we're actually doing something, and it's not a no-op."""
     if not self.files:
@@ -741,12 +729,6 @@ class GRRFlowCollector(GRRFlow):
           path=collected_flow_data
       )
       self.state.StoreContainer(cont)
-
-  def PreSetup(self) -> None:
-    """Not implemented."""
-
-  def PostSetup(self) -> None:
-    """Not implemented."""
 
   def PreProcess(self) -> None:
     """Not implemented."""
@@ -883,12 +865,6 @@ class GRRTimelineCollector(GRRFlow):
 
     return output_file_path
 
-  def PreSetup(self) -> None:
-    """Not implemented."""
-
-  def PostSetup(self) -> None:
-    """Not implemented."""
-
   def PreProcess(self) -> None:
     """Not implemented."""
 
@@ -902,7 +878,7 @@ class GRRTimelineCollector(GRRFlow):
 
 
 modules_manager.ModulesManager.RegisterModules([
-    GRRArtifactCollector, # type: ignore
-    GRRFileCollector, # type: ignore
-    GRRFlowCollector, # type: ignore
-    GRRTimelineCollector]) # type: ignore
+    GRRArtifactCollector,
+    GRRFileCollector,
+    GRRFlowCollector,
+    GRRTimelineCollector])

--- a/dftimewolf/lib/exporters/gce_disk_from_image.py
+++ b/dftimewolf/lib/exporters/gce_disk_from_image.py
@@ -84,12 +84,6 @@ class GCEDiskFromImage(module.ThreadAwareModule):
   def GetThreadPoolSize(self) -> int:
     return 10
 
-  def PreSetUp(self) -> None:
-    pass
-
-  def PostSetUp(self) -> None:
-    pass
-
   def PreProcess(self) -> None:
     pass
 

--- a/dftimewolf/lib/exporters/gcs_to_gce_image.py
+++ b/dftimewolf/lib/exporters/gcs_to_gce_image.py
@@ -322,11 +322,5 @@ class GCSToGCEImage(module.ThreadAwareModule):
   def GetThreadPoolSize(self) -> int:
     return 10
 
-  def PreSetUp(self) -> None:
-    pass
-
-  def PostSetUp(self) -> None:
-    pass
-
 
 modules_manager.ModulesManager.RegisterModule(GCSToGCEImage)

--- a/dftimewolf/lib/exporters/s3_to_gcs.py
+++ b/dftimewolf/lib/exporters/s3_to_gcs.py
@@ -166,12 +166,6 @@ class S3ToGCSCopy(module.ThreadAwareModule):
     # limit is 100 per 100 seconds, or 1000/day.
     return 30
 
-  def PreSetUp(self) -> None:
-    pass
-
-  def PostSetUp(self) -> None:
-    pass
-
   def PostProcess(self) -> None:
     pass
 

--- a/dftimewolf/lib/exporters/timesketch.py
+++ b/dftimewolf/lib/exporters/timesketch.py
@@ -220,12 +220,6 @@ class TimesketchExporter(module.ThreadAwareModule):
   def GetThreadPoolSize(self) -> int:
     return 5
 
-  def PreSetUp(self) -> None:
-    pass
-
-  def PostSetUp(self) -> None:
-    pass
-
   def PreProcess(self) -> None:
     """Get the sketch, creating it if it doesn't yet exist."""
     if not self.timesketch_api:

--- a/dftimewolf/lib/module.py
+++ b/dftimewolf/lib/module.py
@@ -184,16 +184,6 @@ class ThreadAwareModule(BaseModule):
     self.SetupLogging(threaded=True)
 
   @abc.abstractmethod
-  def PreSetUp(self) -> None:
-    """Carries out optional SetUp actions that only need to be performed once,
-    regardless of the number of class instantiations. Called before SetUp."""
-
-  @abc.abstractmethod
-  def PostSetUp(self) -> None:
-    """Carries out optional SetUp actions that only need to be performed once,
-    regardless of the number of class instantiations. Called after SetUp."""
-
-  @abc.abstractmethod
   def PreProcess(self) -> None:
     """Carries out optional Process actions that only need to be performed
     once, regardless of the number of class instantiations. Called before

--- a/dftimewolf/lib/processors/turbinia_gcp_tam.py
+++ b/dftimewolf/lib/processors/turbinia_gcp_tam.py
@@ -360,12 +360,6 @@ class TurbiniaGCPProcessorThreaded(TurbiniaProcessorThreadedBase):
   def GetThreadPoolSize(self) -> int:
     return 5
 
-  def PreSetUp(self) -> None:
-    pass
-
-  def PostSetUp(self) -> None:
-    pass
-
   def PreProcess(self) -> None:
     pass
 

--- a/dftimewolf/lib/state.py
+++ b/dftimewolf/lib/state.py
@@ -252,11 +252,7 @@ class DFTimewolfState(object):
     module = self._module_pool[runtime_name]
 
     try:
-      if isinstance(module, ThreadAwareModule):
-        module.PreSetUp()
       module.SetUp(**new_args)
-      if isinstance(module, ThreadAwareModule):
-        module.PostSetUp()
     except errors.DFTimewolfError:
       msg = "A critical error occurred in module {0:s}, aborting execution."
       logger.critical(msg.format(module.name))

--- a/tests/lib/state.py
+++ b/tests/lib/state.py
@@ -226,16 +226,12 @@ class StateTest(unittest.TestCase):
 
   # pylint: disable=line-too-long
   @mock.patch('tests.test_modules.thread_aware_modules.ThreadAwareConsumerModule.Process')
-  @mock.patch('tests.test_modules.thread_aware_modules.ThreadAwareConsumerModule.PreSetUp')
-  @mock.patch('tests.test_modules.thread_aware_modules.ThreadAwareConsumerModule.PostSetUp')
   @mock.patch('tests.test_modules.thread_aware_modules.ThreadAwareConsumerModule.PreProcess')
   @mock.patch('tests.test_modules.thread_aware_modules.ThreadAwareConsumerModule.PostProcess')
   # pylint: enable=line-too-long
   def testProcessThreadAwareModule(self,
       mock_post_process,
       mock_pre_process,
-      mock_post_setup,
-      mock_pre_setup,
       mock_threaded_process):
     """Tests the ThreadAwareModules process functions are correctly called."""
     test_state = state.DFTimewolfState(config.Config)
@@ -246,8 +242,6 @@ class StateTest(unittest.TestCase):
     self.assertEqual(mock_threaded_process.call_count, 3)
     self.assertEqual(mock_post_process.call_count, 1)
     self.assertEqual(mock_pre_process.call_count, 1)
-    self.assertEqual(mock_post_setup.call_count, 1)
-    self.assertEqual(mock_pre_setup.call_count, 1)
     self.assertEqual(3,
         len(test_state.GetContainers(thread_aware_modules.TestContainer)))
 
@@ -283,51 +277,6 @@ class StateTest(unittest.TestCase):
     self.assertEqual(sorted(values), sorted(expected_values))
 
   # pylint: disable=line-too-long
-  @mock.patch('tests.test_modules.thread_aware_modules.ThreadAwareConsumerModule.PreSetUp')
-  @mock.patch('tests.test_modules.thread_aware_modules.ThreadAwareConsumerModule.SetUp')
-  @mock.patch('tests.test_modules.thread_aware_modules.ThreadAwareConsumerModule.PostSetUp')
-  # pylint: enable=line-too-long
-  def testThreadAwareModulePreSetUpFailure(self,
-      mock_post_setup,
-      mock_setup,
-      mock_pre_setup):
-    """Tests that if PreSetUp exceptions, SetUp and PostSetUp are not
-    called."""
-    mock_pre_setup.side_effect = \
-        errors.DFTimewolfError('Exception thrown', critical=False)
-
-    test_state = state.DFTimewolfState(config.Config)
-    test_state.command_line_options = {}
-    test_state.LoadRecipe(test_recipe.threaded_no_preflights, TEST_MODULES)
-    test_state.SetupModules()
-
-    self.assertEqual(mock_pre_setup.call_count, 1)
-    self.assertEqual(mock_setup.call_count, 0)
-    self.assertEqual(mock_post_setup.call_count, 0)
-
-  # pylint: disable=line-too-long
-  @mock.patch('tests.test_modules.thread_aware_modules.ThreadAwareConsumerModule.PreSetUp')
-  @mock.patch('tests.test_modules.thread_aware_modules.ThreadAwareConsumerModule.SetUp')
-  @mock.patch('tests.test_modules.thread_aware_modules.ThreadAwareConsumerModule.PostSetUp')
-  # pylint: enable=line-too-long
-  def testThreadAwareModuleSetUpFailure(self,
-      mock_post_setup,
-      mock_setup,
-      mock_pre_setup):
-    """Tests that if SetUp exceptions, PostSetUp is not called."""
-    mock_setup.side_effect = \
-        errors.DFTimewolfError('Exception thrown', critical=False)
-
-    test_state = state.DFTimewolfState(config.Config)
-    test_state.command_line_options = {}
-    test_state.LoadRecipe(test_recipe.threaded_no_preflights, TEST_MODULES)
-    test_state.SetupModules()
-
-    self.assertEqual(mock_pre_setup.call_count, 1)
-    self.assertEqual(mock_setup.call_count, 1)
-    self.assertEqual(mock_post_setup.call_count, 0)
-
-  # pylint: disable=line-too-long
   @mock.patch('tests.test_modules.thread_aware_modules.ThreadAwareConsumerModule.PreProcess')
   @mock.patch('tests.test_modules.thread_aware_modules.ThreadAwareConsumerModule.Process')
   @mock.patch('tests.test_modules.thread_aware_modules.ThreadAwareConsumerModule.PostProcess')
@@ -360,7 +309,7 @@ class StateTest(unittest.TestCase):
       mock_post_process,
       mock_process,
       mock_pre_process):
-    """Tests that if process exceptions, PostProcess is still called."""
+    """Tests that if Process exceptions, PostProcess is still called."""
     mock_process.side_effect = \
         errors.DFTimewolfError('Exception thrown', critical=False)
 

--- a/tests/test_modules/thread_aware_modules.py
+++ b/tests/test_modules/thread_aware_modules.py
@@ -97,12 +97,6 @@ class ThreadAwareConsumerModule(module.ThreadAwareModule):
   def GetThreadPoolSize(self):
     return 2
 
-  def PreSetUp(self) -> None:
-    self.logger.info("ThreadAwareConsumerModule Static Pre Set Up")
-
-  def PostSetUp(self) -> None:
-    self.logger.info("ThreadAwareConsumerModule Static Post Set Up")
-
   def PreProcess(self) -> None:
     self.logger.info("ThreadAwareConsumerModule Static Pre Process")
 


### PR DESCRIPTION
These two methods don't provide any value, and so just create unneeded empty method stubs in TAM implementations.

Closes #500.