### PR TITLE
Fixes and enhancements for metawolf

### DIFF
--- a/dftimewolf/metawolf/metawolf.py
+++ b/dftimewolf/metawolf/metawolf.py
@@ -238,8 +238,8 @@ class Metawolf(cmd2.Cmd):
     if what[0] in [SET_ALL, SET_ALL_SC]:
       if not self.recipe:
         self.poutput('Please set a recipe first: `{0:s}`'.format(
-          self.metawolf_output.Color(
-            'set -r[ecipe] recipe_name', output.YELLOW)))
+            self.metawolf_output.Color(
+                'set -r[ecipe] recipe_name', output.YELLOW)))
         return
       for settable in self.session_settables.values():
         if settable.recipe == RECIPE_NAME_IGNORED:
@@ -366,8 +366,8 @@ class Metawolf(cmd2.Cmd):
       return
 
     value = input('Confirm running: {0:s} [yN]? '.format(
-      self.metawolf_output.Color(' '.join(['dftimewolf'] + cmd[1:]),
-                                 output.YELLOW, escape=True))) or 'n'
+        self.metawolf_output.Color(' '.join(['dftimewolf'] + cmd[1:]),
+                                   output.YELLOW, escape=True))) or 'n'
     ans = utils.Str2Bool(str(value))
     while ans not in [False, True]:
       value = input('[yN]? ') or 'n'


### PR DESCRIPTION
- Fix some help texts which displayed the old syntax (e.g. `show output` vs. `show -o[utput]`)
- Display the list of recipe's arguments that were reset to their default value when using the `reload` command
- Escape correctly color codes when prompting the user for inputs
- Allow users to bail early when using `set -a` with `ctrl+d` (e.g. if the recipe has many optional arguments)
- Fix process status when non-dftimewolf errors occur (esp. between restarts of metawolf)
- Remove the `help` command override, because this messes up with cmd2's capabilities (e.g. prevents getting help for a specific command)
- Add a new `send` command, to communicate with the `STDIN` of running processes. This is particularly useful when running recipes that require user inputs during their lifecycle

Signed-off-by: Theo Giovanna <gtheo@google.com>