### PR TITLE
Added in recipe for new GCE forensics modules

### DIFF
--- a/data/recipes/gcp_forensics_new.json
+++ b/data/recipes/gcp_forensics_new.json
@@ -1,0 +1,64 @@
+{
+  "name": "gcp_forensics_new",
+  "short_description": "Copies disk from a GCP project to an analysis VM. Uses the new modules.",
+  "description": "Copies a persistent disk from a GCP project to another, creates an analysis VM (with a startup script containing installation instructions for basic forensics tooling) in the destination project, and attaches the copied GCP persistent disk to it.",
+  "preflights": [{
+    "wants": [],
+    "name": "GCPTokenCheck",
+    "runtime_name": "GCPTokenCheck-analysis",
+    "args": {
+        "project_name": "@analysis_project_name"
+    }
+  },
+  {
+    "wants": [],
+    "name": "GCPTokenCheck",
+    "runtime_name": "GCPTokenCheck-source",
+    "args": {
+        "project_name": "@source_project_name"
+    }
+  }],
+  "modules": [
+    {
+      "wants": [],
+      "name": "GCEDiskCopy",
+      "args": {
+        "destination_project_name": "@analysis_project_name",
+        "source_project_name": "@source_project_name",
+        "destination_zone": "@zone",
+        "remote_instance_names": "@instances",
+        "disk_names": "@disks",
+        "all_disks": "@all_disks",
+        "stop_instances": "@stop_instances"
+      }
+    }, {
+      "wants": ["GCEDiskCopy"],
+      "name": "GCEForensicsVM",
+      "args": {
+        "project_name": "@analysis_project_name",
+        "incident_id": "@incident_id",
+        "zone": "@zone",
+        "boot_disk_size": "@boot_disk_size",
+        "boot_disk_type": "@boot_disk_type",
+        "cpu_cores": "@cpu_cores",
+        "image_project": "ubuntu-os-cloud",
+        "image_family": "ubuntu-1804-lts",
+        "create_analysis_vm": "@create_analysis_vm"
+      }
+    }
+  ],
+  "args": [
+      ["source_project_name", "Name of the project containing the instance / disks to copy.", null],
+      ["analysis_project_name", "Name of the project where the analysis VM will be created and disks copied to.", null],
+      ["--incident_id", "Incident ID to label the VM with.", null],
+      ["--instances", "Name of the instance to analyze.", null],
+      ["--disks", "Comma-separated list of disks to copy from the source GCP project (if `instance` not provided).", null],
+      ["--all_disks", "Copy all disks in the designated instance. Overrides `disk_names` if specified.", false],
+      ["--stop_instances", "Stop the designated instance after copying disks.", false],
+      ["--create_analysis_vm", "Create an analysis VM in the destination project.", true],
+      ["--cpu_cores", "Number of CPU cores of the analysis VM.", 4],
+      ["--boot_disk_size", "The size of the analysis VM boot disk (in GB).", 50.0],
+      ["--boot_disk_type", "Disk type to use [pd-standard, pd-ssd].", "pd-standard"],
+      ["--zone", "The GCP zone where the Analysis VM and copied disks will be created.", "us-central1-f"]
+  ]
+}


### PR DESCRIPTION
Adding in a temp recipe for the new GCE forensics modules. This recipe will exist along side the original while updates are made to E2E testing pipelines for easier rolling back of said tests if something breaks. Eventually, this recipe will replace `gcp_forensics.json`