### PR TITLE
Filter for meeting_id delimiter

### DIFF
--- a/data/recipes/workspace_meet_ts.json
+++ b/data/recipes/workspace_meet_ts.json
@@ -33,7 +33,7 @@
     }
   ],
   "args": [
-    ["meeting_id", "ID for the Meeting to look up.", null],
+    ["meeting_id", "ID for the Meeting to look up. (Without the '-' delimiter)", null],
     ["--start_time", "Start time (yyyy-mm-ddTHH:MM:SSZ).", null],
     ["--end_time", "End time (yyyy-mm-ddTHH:MM:SSZ).", null],
     ["--incident_id", "Incident ID (used for Timesketch description).", null],

--- a/dftimewolf/lib/collectors/workspace_audit.py
+++ b/dftimewolf/lib/collectors/workspace_audit.py
@@ -126,6 +126,15 @@ class WorkspaceAuditCollector(module.BaseModule):
           for.
       end_time (Optional[str]): End of the time period to return results for.
     """
+
+    # Omit '-' delimiter from the filter_expression (meeting_id) for
+    # the meet application
+    if application_name == 'meet':
+      if '-' in filter_expression:
+        filter_expression = filter_expression.replace('-', '')
+        self.logger.info(
+            'Found \'-\' delimiter in the meeting_id and removed it!')
+
     self._credentials = self._GetCredentials()
     self._application_name = application_name
     self._filter_expression = filter_expression

--- a/dftimewolf/lib/collectors/workspace_audit.py
+++ b/dftimewolf/lib/collectors/workspace_audit.py
@@ -129,11 +129,10 @@ class WorkspaceAuditCollector(module.BaseModule):
 
     # Omit '-' delimiter from the filter_expression (meeting_id) for
     # the meet application
-    if application_name == 'meet':
-      if '-' in filter_expression:
-        filter_expression = filter_expression.replace('-', '')
-        self.logger.info(
-            'Found \'-\' delimiter in the meeting_id and removed it!')
+    if application_name == 'meet' and '-' in filter_expression:
+      filter_expression = filter_expression.replace('-', '')
+      self.logger.info(
+        "Found '-' delimiter in the meeting_id and removed it!")
 
     self._credentials = self._GetCredentials()
     self._application_name = application_name

--- a/docs/recipe-list.md
+++ b/docs/recipe-list.md
@@ -662,7 +662,7 @@ Collects specific files from one or more GRR hosts.
 
 **Details:**
 
-Collects specific files from one or more GRR hosts. Files can be a glob pattern (e.g. `/tmp/*.so`) and support GRR variable interpolation (e.g. `%%users.localappdata%%/Directory/`) 
+Collects specific files from one or more GRR hosts. Files can be a glob pattern (e.g. `/tmp/*.so`) and support GRR variable interpolation (e.g. `%%users.localappdata%%/Directory/`)
 
 **CLI parameters:**
 
@@ -1238,7 +1238,7 @@ Collects Google Workspace audit records for a Google Meet and adds them to Times
 
 Parameter|Default value|Description
 ---------|-------------|-----------
-`meeting_id`|`None`|ID for the Meeting to look up.
+`meeting_id`|`None`|ID for the Meeting to look up. (Without the '-' delimiter)
 `--start_time`|`None`|Start time (yyyy-mm-ddTHH:MM:SSZ).
 `--end_time`|`None`|End time (yyyy-mm-ddTHH:MM:SSZ).
 `--incident_id`|`None`|Incident ID (used for Timesketch description).


### PR DESCRIPTION
Added a filter that removes the '-' delimiters form the meeting_id when used with the workspace_meet_ts recipe. Additionally I added the info to use the meeting_id without delimiters to the documentations and help as well. 