### PR TITLE
Dedupe containers in GCEDiskCopy module

### DIFF
--- a/dftimewolf/lib/collectors/gce_disk_copy.py
+++ b/dftimewolf/lib/collectors/gce_disk_copy.py
@@ -139,6 +139,8 @@ class GCEDiskCopy(module.ThreadAwareModule):
             message=f'Instance "{i}" in {self.source_project.project_id} not '
                 'found or insufficient permissions',
             critical=True)
+
+      self.state.DedupeContainers(containers.GCEDisk)
     except HttpError as exception:
       if exception.resp.status == 403:
         self.ModuleError(

--- a/dftimewolf/lib/containers/containers.py
+++ b/dftimewolf/lib/containers/containers.py
@@ -331,6 +331,10 @@ class GCEDisk(interface.AttributeContainer):
     super(GCEDisk, self).__init__()
     self.name = name
 
+  def __eq__(self, other: GCEDisk) -> bool:
+    """Override __eq__() for this container."""
+    return self.name == other.name
+
 class GCEDiskEvidence(interface.AttributeContainer):
   """Attribute container definition for a GCE Disk that has been copied.
 

--- a/dftimewolf/lib/state.py
+++ b/dftimewolf/lib/state.py
@@ -236,18 +236,17 @@ class DFTimewolfState(object):
         self.store[container_class.CONTAINER_TYPE] = []
       return tuple(container_objects)
 
-  def DedupeContainers(self, container_class: Type[T]):
+  def DedupeContainers(self, container_class: Type[T]) -> None:
     """Thread safe deduping of containers of the given type.
 
     This requires the container being deduped to override `__eq__()`.
-    
+
     Args:
       container_class (type): AttributeContainer class to dedupe.
     """
     with self._state_lock:
       deduped = []
-      for c in cast(List[T],
-          self.store.get(container_class.CONTAINER_TYPE, [])):
+      for c in self.store.get(container_class.CONTAINER_TYPE, []):
         if c not in deduped:
           deduped.append(c)
 

--- a/dftimewolf/lib/state.py
+++ b/dftimewolf/lib/state.py
@@ -236,6 +236,23 @@ class DFTimewolfState(object):
         self.store[container_class.CONTAINER_TYPE] = []
       return tuple(container_objects)
 
+  def DedupeContainers(self, container_class: Type[T]):
+    """Thread safe deduping of containers of the given type.
+
+    This requires the container being deduped to override `__eq__()`.
+    
+    Args:
+      container_class (type): AttributeContainer class to dedupe.
+    """
+    with self._state_lock:
+      deduped = []
+      for c in cast(List[T],
+          self.store.get(container_class.CONTAINER_TYPE, [])):
+        if c not in deduped:
+          deduped.append(c)
+
+      self.store[container_class.CONTAINER_TYPE] = deduped
+
   def _SetupModuleThread(self, module_definition: Dict[str, str]) -> None:
     """Calls the module's SetUp() function and sets a threading event for it.
 

--- a/tests/lib/processors/test_data/turbinia.conf
+++ b/tests/lib/processors/test_data/turbinia.conf
@@ -24,6 +24,7 @@ PSQ_TOPIC = 'turbinia-psq-cloud-test'
 PUBSUB_TOPIC = u'test-turbinia-pubsub-topic'
 INSTANCE_ID = PUBSUB_TOPIC
 LOG_FILE = u'/tmp/turbinia.log'
+LOG_DIR = u'/tmp/'
 OUTPUT_DIR = u'/var/tmp'
 TMP_DIR = u'/tmp'
 LOCK_FILE = '%s/turbinia-worker.lock' % OUTPUT_DIR

--- a/tests/lib/state.py
+++ b/tests/lib/state.py
@@ -407,6 +407,8 @@ class StateTest(unittest.TestCase):
     conts = test_state.GetContainers(thread_aware_modules.TestContainer)
 
     self.assertEqual(len(conts), 2)
+    for value in [c.value for c in conts]:
+      self.assertIn(value, ['one', 'two'])
 
 
 if __name__ == '__main__':

--- a/tests/lib/state.py
+++ b/tests/lib/state.py
@@ -396,6 +396,22 @@ class StateTest(unittest.TestCase):
                        'three Processed']
     self.assertEqual(sorted(values), sorted(expected_values))
 
+  def testContainerDedupe(self):
+    """Tests the DFTimewolfState.DedupeContainers method."""
+    test_state = state.DFTimewolfState(config.Config)
+    test_state.command_line_options = {}
+    test_state.StoreContainer(thread_aware_modules.TestContainer('one'))
+    test_state.StoreContainer(thread_aware_modules.TestContainer('one'))
+    test_state.StoreContainer(thread_aware_modules.TestContainer('two'))
+    test_state.DedupeContainers(thread_aware_modules.TestContainer)
+    conts = test_state.GetContainers(thread_aware_modules.TestContainer)
+
+    self.assertEqual(len(conts), 2)
+
+
+
+
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/lib/state.py
+++ b/tests/lib/state.py
@@ -409,9 +409,5 @@ class StateTest(unittest.TestCase):
     self.assertEqual(len(conts), 2)
 
 
-
-
-
-
 if __name__ == '__main__':
   unittest.main()

--- a/tests/test_modules/thread_aware_modules.py
+++ b/tests/test_modules/thread_aware_modules.py
@@ -18,9 +18,9 @@ class TestContainer(interface.AttributeContainer):
   def __init__(self, value: str) -> None:
     super(TestContainer, self).__init__()
     self.value = value
-  
+
   def __eq__(self, other: object) -> bool:
-      return self.value == other.value
+    return self.value == other.value
 
 class TestContainerTwo(interface.AttributeContainer):
   """Test attribute container."""

--- a/tests/test_modules/thread_aware_modules.py
+++ b/tests/test_modules/thread_aware_modules.py
@@ -18,6 +18,9 @@ class TestContainer(interface.AttributeContainer):
   def __init__(self, value: str) -> None:
     super(TestContainer, self).__init__()
     self.value = value
+  
+  def __eq__(self, other: object) -> bool:
+      return self.value == other.value
 
 class TestContainerTwo(interface.AttributeContainer):
   """Test attribute container."""


### PR DESCRIPTION
Create supporting method in DFTimewolfState to dedupe containers of a certain type, and use that in GCEDiskCopy.

This ensures that if multiple GCEDiskCopy modules are run in a single recipe, they don't duplicate their list in PreProcess. 