### PR TITLE
GRRFlowCollector - Error handling improvements

### DIFF
--- a/dftimewolf/lib/collectors/grr_hosts.py
+++ b/dftimewolf/lib/collectors/grr_hosts.py
@@ -897,7 +897,7 @@ class GRRFlowCollector(GRRFlow):
             found_flows.append(f)
 
     missing_flows = sorted([f for f in flows if f not in found_flows])
-    if len(missing_flows) != 0:
+    if missing_flows:
       self.logger.warning('The following flows were not found: '
           f'{", ".join(missing_flows)}')
       self.logger.warning('Did you specify a child flow instead of a parent?')

--- a/dftimewolf/lib/collectors/grr_hosts.py
+++ b/dftimewolf/lib/collectors/grr_hosts.py
@@ -922,6 +922,9 @@ class GRRFlowCollector(GRRFlow):
           path=collected_flow_data
       )
       self.state.StoreContainer(cont)
+    else:
+      self.logger.warning('No flow data collected for '
+          f'{container.hostname}:{container.flow_id}')
 
   def PreProcess(self) -> None:
     """Check that we're actually about to collect anything."""

--- a/dftimewolf/lib/collectors/grr_hosts.py
+++ b/dftimewolf/lib/collectors/grr_hosts.py
@@ -917,7 +917,7 @@ class GRRFlowCollector(GRRFlow):
 
   def PreProcess(self) -> None:
     """Check that we're actually about to collect anything."""
-    if len(self.state.GetContainers(containers.GrrFlow)) == 0:
+    if len(self.state.GetContainers(self.GetThreadOnContainerType())) == 0:
       self.logger.error('No flows found for collection.')
       self.logger.error('Did you specify a child flow instead of a parent?')
       self.ModuleError('No flows found for collection.', critical=True)

--- a/dftimewolf/lib/collectors/grr_hosts.py
+++ b/dftimewolf/lib/collectors/grr_hosts.py
@@ -916,7 +916,11 @@ class GRRFlowCollector(GRRFlow):
       self.state.StoreContainer(cont)
 
   def PreProcess(self) -> None:
-    """Not implemented."""
+    """Check that we're actually about to collect anything."""
+    if len(self.state.GetContainers(containers.GrrFlow)) == 0:
+      self.logger.error('No flows found for collection.')
+      self.logger.error('Did you specify a child flow instead of a parent?')
+      self.ModuleError('No flows found for collection.', critical=True)
 
   def PostProcess(self) -> None:
     # TODO(ramoj) check if this should be per client in process
@@ -924,7 +928,7 @@ class GRRFlowCollector(GRRFlow):
     self._CheckSkippedFlows()
 
   def GetThreadOnContainerType(self) -> Type[interface.AttributeContainer]:
-    """This module works on host containers."""
+    """This module works on GrrFlow containers."""
     return containers.GrrFlow
 
 

--- a/dftimewolf/lib/exporters/scp_ex.py
+++ b/dftimewolf/lib/exporters/scp_ex.py
@@ -101,7 +101,8 @@ class SCPExporter(module.BaseModule):
       self._paths = [fspath.path for fspath in fspaths]
 
     if not self._paths:
-      self.ModuleError('No paths specified to SCP module.', critical=True)
+      self.ModuleError(
+          'No files found for copying with SCP module.', critical=True)
 
     self._CreateDestinationDirectory(remote=self._upload)
 

--- a/tests/lib/collectors/grr_hosts.py
+++ b/tests/lib/collectors/grr_hosts.py
@@ -509,7 +509,8 @@ class GRRFlowCollectorTest(unittest.TestCase):
         skip_offline_clients=False,
     )
 
-    self.test_state.GetContainers(containers.GrrFlow, True)  # Clear the containers to test correct failure on no containers being found.
+    # Clear the containers to test correct failure on no containers being found.
+    self.test_state.GetContainers(containers.GrrFlow, True)
 
     with self.assertRaises(errors.DFTimewolfError) as error:
       grr_flow_collector.PreProcess()

--- a/tests/lib/collectors/grr_hosts.py
+++ b/tests/lib/collectors/grr_hosts.py
@@ -551,7 +551,7 @@ class GRRFlowCollectorTest(unittest.TestCase):
   @mock.patch('dftimewolf.lib.collectors.grr_hosts.GRRFlow._DownloadFiles')
   @mock.patch('dftimewolf.lib.collectors.grr_hosts.GRRFlow._AwaitFlow')
   def testProcessNoFlowData(self,
-      _, 
+      _,
       mock_DLFiles,
       mock_InitHttp,
       mock_list_flows):


### PR DESCRIPTION
Updated GRRFlowCollector to raise an error when no flows are found. This can occur if the user specifies a child flow rather than a parent flow, which is no longer supported.

In SetUp, each flow that is not found will be noted as a warning:

```
[2022-03-02 02:51:37,686] [GRRFlowCollector    ] WARNING  The following flows were not found: F:23456, F:34567
[2022-03-02 02:51:37,687] [GRRFlowCollector    ] WARNING  Did you specify a child flow instead of a parent?
```

 In PreProcess, if no flows are found at all, an error is raised. SetUp doesn't error in the event the containers are coming from a previous module.

```
[2022-03-02 02:55:50,353] [GRRFlowCollector    ] CRITICAL No flows found for collection.
```

In Process, if a flow has no data collected:

```
[2022-03-02 03:08:47,585] [GRRFlowCollector    ] WARNING  [MainThread] No flow data collected for C.0000000000000001:F:12345
```