### PR TITLE
TurbiniaGCP - Ignore disks in other projects

### DIFF
--- a/dftimewolf/lib/processors/turbinia_gcp.py
+++ b/dftimewolf/lib/processors/turbinia_gcp.py
@@ -93,6 +93,8 @@ class TurbiniaGCPProcessor(TurbiniaProcessorBase, module.ThreadAwareModule):
   def Process(self, disk_container: containers.GCEDiskEvidence) -> None:
     """Process a GCE Disk with Turbinia."""
     if disk_container.project != self.project:
+      self.logger.info(f'Found disk "{disk_container.name}" but skipping as it '
+          f'is in a different project "{disk_container.project}".')
       return
 
     log_file_path = os.path.join(

--- a/dftimewolf/lib/processors/turbinia_gcp.py
+++ b/dftimewolf/lib/processors/turbinia_gcp.py
@@ -92,6 +92,9 @@ class TurbiniaGCPProcessor(TurbiniaProcessorBase, module.ThreadAwareModule):
   # pylint: disable=arguments-renamed
   def Process(self, disk_container: containers.GCEDiskEvidence) -> None:
     """Process a GCE Disk with Turbinia."""
+    if disk_container.project != self.project:
+      return
+
     log_file_path = os.path.join(
         self._output_path, f'{disk_container.name}-turbinia.log')
 

--- a/tests/lib/processors/turbinia_gcp.py
+++ b/tests/lib/processors/turbinia_gcp.py
@@ -353,6 +353,7 @@ class TurbiniaGCPProcessorTest(unittest.TestCase):
     file_containers = test_state.GetContainers(containers.File)
     self.assertEqual(len(file_containers), 0)
 
+    # pylint: disable=no-member
     mock_GoogleCloudDisk.assert_not_called()
     turbinia_processor.client.send_request.assert_not_called()
 

--- a/tests/lib/processors/turbinia_gcp.py
+++ b/tests/lib/processors/turbinia_gcp.py
@@ -316,6 +316,46 @@ class TurbiniaGCPProcessorTest(unittest.TestCase):
     self.assertEqual(file_containers[0].path, '/fake/data.plaso')
     self.assertEqual(file_containers[1].path, '/fake/data2.plaso')
 
+  @mock.patch('turbinia.evidence.GoogleCloudDisk')
+  @mock.patch('turbinia.client.get_turbinia_client')
+  # pylint: disable=invalid-name
+  def testProcessCrossProject(self,
+                              _mock_TurbiniaClient,
+                              mock_GoogleCloudDisk):
+    """Tests that process does nothing if the disks are in another project."""
+    test_state = state.DFTimewolfState(config.Config)
+    test_state.StoreContainer(containers.GCEDiskEvidence(
+        name='disk-1', project='another-project'))
+    turbinia_processor = turbinia_gcp.TurbiniaGCPProcessor(test_state)
+    turbinia_processor.SetUp(
+        turbinia_config_file=None,
+        project='turbinia-project',
+        turbinia_zone='europe-west1',
+        sketch_id=4567,
+        run_all_jobs=False)
+
+    turbinia_processor.client.get_task_data.return_value = [{
+        'saved_paths': [
+            '/fake/data.plaso',
+            '/fake/data2.plaso',
+            '/another/random/file.txt',
+            'gs://BinaryExtractorTask.tar.gz',
+        ]
+    }]
+
+    turbinia_processor.PreProcess()
+    in_containers = test_state.GetContainers(
+        turbinia_processor.GetThreadOnContainerType())
+    for c in in_containers:
+      turbinia_processor.Process(c)
+    turbinia_processor.PostProcess()
+
+    file_containers = test_state.GetContainers(containers.File)
+    self.assertEqual(len(file_containers), 0)
+
+    mock_GoogleCloudDisk.assert_not_called()
+    turbinia_processor.client.send_request.assert_not_called()
+
   @mock.patch('turbinia.output_manager.GCSOutputWriter')
   # pylint: disable=invalid-name
   def testDownloadFilesFromGCS(self, mock_GCSOutputWriter):

--- a/tests/lib/processors/turbinia_gcp.py
+++ b/tests/lib/processors/turbinia_gcp.py
@@ -334,15 +334,6 @@ class TurbiniaGCPProcessorTest(unittest.TestCase):
         sketch_id=4567,
         run_all_jobs=False)
 
-    turbinia_processor.client.get_task_data.return_value = [{
-        'saved_paths': [
-            '/fake/data.plaso',
-            '/fake/data2.plaso',
-            '/another/random/file.txt',
-            'gs://BinaryExtractorTask.tar.gz',
-        ]
-    }]
-
     turbinia_processor.PreProcess()
     in_containers = test_state.GetContainers(
         turbinia_processor.GetThreadOnContainerType())


### PR DESCRIPTION
Currently the TurbiniaGCPProcessor module doesn't consider the project in the GCEDiskEvidence container, meaning it may attempt to process disks in other projects. This change corrects that behaviour. 