### PR TITLE
Remove log propagation from child to root

### DIFF
--- a/dftimewolf/cli/dftimewolf_recipes.py
+++ b/dftimewolf/cli/dftimewolf_recipes.py
@@ -329,6 +329,7 @@ def SetupLogging() -> None:
   console_handler = logging.StreamHandler(stream=sys.stdout)
   colorize = not bool(os.environ.get('DFTIMEWOLF_NO_RAINBOW'))
   console_handler.setFormatter(logging_utils.WolfFormatter(colorize=colorize))
+  logger.propagate = False
   logger.addHandler(console_handler)
   logger.debug(
       'Logging to stdout and {0:s}'.format(logging_utils.DEFAULT_LOG_FILE))

--- a/dftimewolf/lib/collectors/grr_hosts.py
+++ b/dftimewolf/lib/collectors/grr_hosts.py
@@ -264,7 +264,7 @@ class GRRFlow(GRRBaseModule, module.ThreadAwareModule):
       try:
         status = client.Flow(flow_id).Get().data
       except grr_errors.UnknownError:
-        msg = 'Unable to stat flow {0:s} for host {1:s}'.format(
+        msg = 'Unable to start flow {0:s} for host {1:s}'.format(
             flow_id, client.data.os_info.fqdn.lower())
         self.ModuleError(msg, critical=True)
 

--- a/dftimewolf/lib/collectors/grr_hosts.py
+++ b/dftimewolf/lib/collectors/grr_hosts.py
@@ -264,8 +264,8 @@ class GRRFlow(GRRBaseModule, module.ThreadAwareModule):
       try:
         status = client.Flow(flow_id).Get().data
       except grr_errors.UnknownError:
-        msg = 'Unable to start flow {0:s} for host {1:s}'.format(
-            flow_id, client.data.os_info.fqdn.lower())
+        msg = (f'Unable to start flow {flow_id} for host '
+            f'{client.data.os_info.fqdn.lower()}')
         self.ModuleError(msg, critical=True)
 
       if status.state == flows_pb2.FlowContext.ERROR:

--- a/dftimewolf/lib/module.py
+++ b/dftimewolf/lib/module.py
@@ -52,6 +52,7 @@ class BaseModule(object):
     self.state = state
     self.logger = cast(logging_utils.WolfLogger,
                        logging.getLogger(name=self.name))
+    self.logger.propagate = False
 
     self.SetupLogging()
 

--- a/tests/lib/collectors/grr_hosts.py
+++ b/tests/lib/collectors/grr_hosts.py
@@ -129,7 +129,7 @@ class GRRFlowTests(unittest.TestCase):
   def testAwaitFlowGRRError(self, mock_FlowGet):
     """"Test that an exception is raised if the GRR API raises an error."""
     mock_FlowGet.side_effect = grr_errors.UnknownError
-    error_msg = 'Unable to stat flow F:12345 for host'
+    error_msg = 'Unable to start flow F:12345 for host'
     with six.assertRaisesRegex(self, DFTimewolfError, error_msg):
       self.grr_flow_module._AwaitFlow(mock_grr_hosts.MOCK_CLIENT, "F:12345")
 

--- a/tests/lib/collectors/grr_hosts.py
+++ b/tests/lib/collectors/grr_hosts.py
@@ -497,8 +497,10 @@ class GRRFlowCollectorTest(unittest.TestCase):
         mock_grr_hosts.MOCK_CLIENT_LIST
     mock_list_flows.return_value = [mock_grr_hosts.flow_pb_terminated]
 
-    with self.assertLogs(level='WARNING') as lc:
-      grr_flow_collector = grr_hosts.GRRFlowCollector(self.test_state)
+    grr_flow_collector = grr_hosts.GRRFlowCollector(self.test_state)
+    logger = grr_flow_collector.logger
+
+    with self.assertLogs(logger) as lc:
       grr_flow_collector.SetUp(
           hostnames='C.0000000000000001',
           flow_ids='F:12345,F:23456,F:34567',
@@ -512,8 +514,8 @@ class GRRFlowCollectorTest(unittest.TestCase):
 
       log_messages = [record.getMessage() for record in lc.records]
       # pylint: disable=line-too-long
-      self.assertIn('\x1b[38;5;11mThe following flows were not found: F:23456, F:34567\x1b[0m', log_messages)
-      self.assertIn('\x1b[38;5;11mDid you specify a child flow instead of a parent?\x1b[0m', log_messages)
+      self.assertIn('The following flows were not found: F:23456, F:34567', log_messages)
+      self.assertIn('Did you specify a child flow instead of a parent?', log_messages)
       # pylint: enable=line-too-long
 
   @mock.patch('grr_api_client.client.Client.ListFlows')
@@ -563,8 +565,10 @@ class GRRFlowCollectorTest(unittest.TestCase):
     mock_list_flows.return_value = [mock_grr_hosts.flow_pb_terminated]
     mock_DLFiles.return_value = None
 
-    with self.assertLogs(level='WARNING') as lc:
-      grr_flow_collector = grr_hosts.GRRFlowCollector(self.test_state)
+    grr_flow_collector = grr_hosts.GRRFlowCollector(self.test_state)
+    logger = grr_flow_collector.logger
+
+    with self.assertLogs(logger) as lc:
       grr_flow_collector.SetUp(
           hostnames='C.0000000000000001',
           flow_ids='F:12345',
@@ -584,7 +588,7 @@ class GRRFlowCollectorTest(unittest.TestCase):
 
       log_messages = [record.getMessage() for record in lc.records]
       # pylint: disable=line-too-long
-      self.assertIn('[MainThread] \x1b[38;5;11mNo flow data collected for C.0000000000000001:F:12345\x1b[0m', log_messages)
+      self.assertIn('No flow data collected for C.0000000000000001:F:12345', log_messages)
       # pylint: enable=line-too-long
 
 

--- a/tests/lib/collectors/grr_hosts.py
+++ b/tests/lib/collectors/grr_hosts.py
@@ -498,9 +498,8 @@ class GRRFlowCollectorTest(unittest.TestCase):
     mock_list_flows.return_value = [mock_grr_hosts.flow_pb_terminated]
 
     grr_flow_collector = grr_hosts.GRRFlowCollector(self.test_state)
-    logger = grr_flow_collector.logger
 
-    with self.assertLogs(logger) as lc:
+    with self.assertLogs(grr_flow_collector.logger) as lc:
       grr_flow_collector.SetUp(
           hostnames='C.0000000000000001',
           flow_ids='F:12345,F:23456,F:34567',
@@ -566,9 +565,8 @@ class GRRFlowCollectorTest(unittest.TestCase):
     mock_DLFiles.return_value = None
 
     grr_flow_collector = grr_hosts.GRRFlowCollector(self.test_state)
-    logger = grr_flow_collector.logger
 
-    with self.assertLogs(logger) as lc:
+    with self.assertLogs(grr_flow_collector.logger) as lc:
       grr_flow_collector.SetUp(
           hostnames='C.0000000000000001',
           flow_ids='F:12345',


### PR DESCRIPTION
This removes duplicate log entries when some modules are used:

Before:
```
[2022-03-07 03:37:45,074] [dftimewolf          ] INFO     Running module: LocalFilesystemCopy
[2022-03-07 03:37:45,074] [LocalFilesystemCopy ] INFO     <path> -> /tmp/dftimewolf_local_fs0t8tq4ta
2022-03-07 03:37:45 [INFO] <path> -> /tmp/dftimewolf_local_fs0t8tq4ta
[2022-03-07 03:37:45,079] [LocalFilesystemCopy ] SUCCESS  <path> was compressed into /tmp/dftimewolf_local_fs0t8tq4ta/<output>.tgz
2022-03-07 03:37:45 [SUCCESS] <path> was compressed into /tmp/dftimewolf_local_fs0t8tq4ta/<output>.tgz
[2022-03-07 03:37:45,079] [dftimewolf          ] INFO     Module LocalFilesystemCopy finished execution

```

After:
```
[2022-03-07 03:42:41,743] [dftimewolf          ] INFO     Running module: LocalFilesystemCopy
[2022-03-07 03:42:41,743] [LocalFilesystemCopy ] INFO     <path> -> /tmp/dftimewolf_local_fs76lmm6m2
[2022-03-07 03:42:41,748] [LocalFilesystemCopy ] SUCCESS  <path> was compressed into /tmp/dftimewolf_local_fs76lmm6m2/<output>.tgz
[2022-03-07 03:42:41,748] [dftimewolf          ] INFO     Module LocalFilesystemCopy finished execution
```