### PR TITLE
Bug fix: set evidence object when calling Turbinia create_request()

### DIFF
--- a/dftimewolf/lib/processors/turbinia_base.py
+++ b/dftimewolf/lib/processors/turbinia_base.py
@@ -208,7 +208,7 @@ class TurbiniaProcessorBase(object):
     request = self.client.create_request(
         requester=getpass.getuser(), recipe=recipe)
     request.evidence.append(evidence_)
-    
+
     request_dict = {
         'instance': self.instance,
         'project': self.project,

--- a/dftimewolf/lib/processors/turbinia_base.py
+++ b/dftimewolf/lib/processors/turbinia_base.py
@@ -206,7 +206,7 @@ class TurbiniaProcessorBase(object):
           yara_rules=yara_text)
 
     request = self.client.create_request(
-        requester=getpass.getuser(), recipe=recipe)
+        evidence_=evidence_, requester=getpass.getuser(), recipe=recipe)
 
     request_dict = {
         'instance': self.instance,

--- a/dftimewolf/lib/processors/turbinia_base.py
+++ b/dftimewolf/lib/processors/turbinia_base.py
@@ -206,8 +206,9 @@ class TurbiniaProcessorBase(object):
           yara_rules=yara_text)
 
     request = self.client.create_request(
-        evidence_=evidence_, requester=getpass.getuser(), recipe=recipe)
-
+        requester=getpass.getuser(), recipe=recipe)
+    request.evidence.append(evidence_)
+    
     request_dict = {
         'instance': self.instance,
         'project': self.project,


### PR DESCRIPTION
This is a bugfix. The Turbinia evidence object was not properly set in the call to Turbinia client's create_request() method.