### PR TITLE
Remove log propagation from child to root

### DIFF
--- a/dftimewolf/cli/dftimewolf_recipes.py
+++ b/dftimewolf/cli/dftimewolf_recipes.py
@@ -321,6 +321,7 @@ def SetupLogging() -> None:
   # We want all DEBUG messages and above.
   # TODO(tomchop): Consider making this a parameter in the future.
   logger.setLevel(logging.DEBUG)
+  logger.propagate = False
 
   # File handler needs go be added first because it doesn't format messages
   # with color

--- a/dftimewolf/lib/module.py
+++ b/dftimewolf/lib/module.py
@@ -53,6 +53,7 @@ class BaseModule(object):
     self.state = state
     self.logger = cast(logging_utils.WolfLogger,
                        logging.getLogger(name=self.name))
+    self.logger.propagate = False
     self.SetupLogging()
 
   def SetupLogging(self, threaded: bool = False) -> None:
@@ -67,8 +68,7 @@ class BaseModule(object):
 
     console_handler = logging.StreamHandler()
     formatter = logging_utils.WolfFormatter(
-        random_color=True,
-        threaded=threaded)
+        random_color=True)
     console_handler.setFormatter(formatter)
 
     self.logger.addHandler(console_handler)


### PR DESCRIPTION
This removes duplicate log entries when some modules are used:

Before:
```
[2022-03-07 03:37:45,074] [dftimewolf          ] INFO     Running module: LocalFilesystemCopy
[2022-03-07 03:37:45,074] [LocalFilesystemCopy ] INFO     <path> -> /tmp/dftimewolf_local_fs0t8tq4ta
2022-03-07 03:37:45 [INFO] <path> -> /tmp/dftimewolf_local_fs0t8tq4ta
[2022-03-07 03:37:45,079] [LocalFilesystemCopy ] SUCCESS  <path> was compressed into /tmp/dftimewolf_local_fs0t8tq4ta/<output>.tgz
2022-03-07 03:37:45 [SUCCESS] <path> was compressed into /tmp/dftimewolf_local_fs0t8tq4ta/<output>.tgz
[2022-03-07 03:37:45,079] [dftimewolf          ] INFO     Module LocalFilesystemCopy finished execution
```

After:
```
[2022-03-07 03:42:41,743] [dftimewolf          ] INFO     Running module: LocalFilesystemCopy
[2022-03-07 03:42:41,743] [LocalFilesystemCopy ] INFO     <path> -> /tmp/dftimewolf_local_fs76lmm6m2
[2022-03-07 03:42:41,748] [LocalFilesystemCopy ] SUCCESS  <path> was compressed into /tmp/dftimewolf_local_fs76lmm6m2/<output>.tgz
[2022-03-07 03:42:41,748] [dftimewolf          ] INFO     Module LocalFilesystemCopy finished execution
```