### PR TITLE
Added env var for GRPC polling strategy for turbinia

### DIFF
--- a/dftimewolf/lib/processors/turbinia_base.py
+++ b/dftimewolf/lib/processors/turbinia_base.py
@@ -53,7 +53,7 @@ class TurbiniaProcessorBase(object):
     self.parallel_count = 5  # Arbitrary, used by ThreadAwareModule
     self.logger = logger
 
-    os.environ['GRPC_POLL_STRATEGY'] = "poll"
+    os.environ['GRPC_POLL_STRATEGY'] = 'poll'
 
   def _DeterminePaths(
       self,


### PR DESCRIPTION
Fixes error message:

```
E0519 01:04:53.391875361   55777 fork_posix.cc:70]           Fork support is only compatible with the epoll1 and poll polling strategies
```