### PR TITLE
Consolidate GCEDisk and GCEDiskEvidence containers

### DIFF
--- a/dftimewolf/lib/collectors/gce_disk_copy.py
+++ b/dftimewolf/lib/collectors/gce_disk_copy.py
@@ -156,6 +156,8 @@ class GCEDiskCopy(module.ThreadAwareModule):
     Args:
       container: GCEDisk container referencing the disk to copy.
     """
+    if container.project != self.source_project.project_id:
+      self.logger.info(f'Skipping {container.name} not in source project')
     self.logger.info(f'Disk copy of {container.name} started...')
 
     try:
@@ -167,7 +169,7 @@ class GCEDiskCopy(module.ThreadAwareModule):
       self.at_least_one_success = True
       self.logger.success(f'Disk {container.name} successfully copied to '
           f'{new_disk.name}')
-      self.state.StoreContainer(containers.GCEDiskEvidence(
+      self.state.StoreContainer(containers.GCEDisk(
           new_disk.name, self.destination_project.project_id))
     except lcf_errors.ResourceNotFoundError as exception:
       self.logger.error(f'Could not find disk "{container.name}": {exception}')

--- a/dftimewolf/lib/collectors/gce_disk_copy.py
+++ b/dftimewolf/lib/collectors/gce_disk_copy.py
@@ -213,7 +213,7 @@ class GCEDiskCopy(module.ThreadAwareModule):
   def _GetDisksFromInstance(
       self,
       instance_name: str,
-      all_disks: bool) -> List[compute.GoogleComputeDisk]:
+      all_disks: bool) -> List[str]:
     """Gets disks to copy based on an instance name.
 
     Args:
@@ -222,8 +222,7 @@ class GCEDiskCopy(module.ThreadAwareModule):
           False, get only the instance's boot disk.
 
     Returns:
-      list[compute.GoogleComputeDisk]: List of compute.GoogleComputeDisk
-          objects to copy.
+      list[str]: List of disk names to copy.
     """
     try:
       remote_instance = self.source_project.compute.GetInstance(instance_name)

--- a/dftimewolf/lib/containers/containers.py
+++ b/dftimewolf/lib/containers/containers.py
@@ -263,6 +263,7 @@ class GCEDisk(interface.AttributeContainer):
 
   Attributes:
     name (str): The disk name.
+    project (str): The project the disk lives in.
   """
   CONTAINER_TYPE = 'gcedisk'
 
@@ -272,24 +273,6 @@ class GCEDisk(interface.AttributeContainer):
     self.project = project
 
   def __eq__(self, other: GCEDisk) -> bool:
-    """Override __eq__() for this container."""
-    return self.name == other.name and self.project == other.project
-
-class GCEDiskEvidence(interface.AttributeContainer):
-  """Attribute container definition for a GCE Disk that has been copied.
-
-  Attributes:
-    name (str): The disk name.
-    project (str): The project the disk was copied to.
-  """
-  CONTAINER_TYPE = 'gcediskevidence'
-
-  def __init__(self, name: str, project: str) -> None:
-    super(GCEDiskEvidence, self).__init__()
-    self.name = name
-    self.project = project
-
-  def __eq__(self, other: GCEDiskEvidence) -> bool:
     """Override __eq__() for this container."""
     return self.name == other.name and self.project == other.project
 

--- a/dftimewolf/lib/exporters/gce_disk_from_image.py
+++ b/dftimewolf/lib/exporters/gce_disk_from_image.py
@@ -73,7 +73,7 @@ class GCEDiskFromImage(module.ThreadAwareModule):
     disk = project.compute.CreateDiskFromImage(
       src_image = image,
       zone = self.dest_zone)
-    self.state.StoreContainer(containers.GCEDiskEvidence(
+    self.state.StoreContainer(containers.GCEDisk(
         disk.name,
         self.dest_project_name))
 

--- a/dftimewolf/lib/processors/gce_forensics_vm.py
+++ b/dftimewolf/lib/processors/gce_forensics_vm.py
@@ -151,7 +151,7 @@ class GCEForensicsVM(module.BaseModule):
         evidence_disk=None,
         platform='gcp'))
 
-    disks = self.state.GetContainers(containers.GCEDiskEvidence)
+    disks = self.state.GetContainers(containers.GCEDisk)
 
     for d in disks:
       if d.project != self.project.project_id:

--- a/dftimewolf/lib/processors/turbinia_gcp.py
+++ b/dftimewolf/lib/processors/turbinia_gcp.py
@@ -63,7 +63,7 @@ class TurbiniaGCPProcessor(TurbiniaProcessorBase, module.ThreadAwareModule):
       for disk in disk_names.strip().split(','):
         if not disk:
           continue
-        self.state.StoreContainer(containers.GCEDiskEvidence(
+        self.state.StoreContainer(containers.GCEDisk(
             name=disk,
             project=project))
 
@@ -85,13 +85,13 @@ class TurbiniaGCPProcessor(TurbiniaProcessorBase, module.ThreadAwareModule):
     for container in vm_containers:
       if container.evidence_disk and container.evidence_disk.name:
         self.state.StoreContainer(
-            containers.GCEDiskEvidence(
+            containers.GCEDisk(
                 name=container.evidence_disk.name,
                 project=self.project))
-    self.state.DedupeContainers(containers.GCEDiskEvidence)
+    self.state.DedupeContainers(containers.GCEDisk)
 
   # pylint: disable=arguments-renamed
-  def Process(self, disk_container: containers.GCEDiskEvidence) -> None:
+  def Process(self, disk_container: containers.GCEDisk) -> None:
     """Process a GCE Disk with Turbinia."""
     if disk_container.project != self.project:
       self.logger.info(f'Found disk "{disk_container.name}" but skipping as it '
@@ -175,7 +175,7 @@ class TurbiniaGCPProcessor(TurbiniaProcessorBase, module.ThreadAwareModule):
 
   @staticmethod
   def GetThreadOnContainerType() -> Type[interface.AttributeContainer]:
-    return containers.GCEDiskEvidence
+    return containers.GCEDisk
 
   def GetThreadPoolSize(self) -> int:
     return self.parallel_count

--- a/tests/e2e/aws_disk_forensics.py
+++ b/tests/e2e/aws_disk_forensics.py
@@ -199,12 +199,12 @@ class AWSToGCPForensicsEndToEndTest(unittest.TestCase):
     self.assertGreaterEqual(
         len(self.test_state.GetContainers(containers.AWSVolume)), 1)
     self.assertEqual(len(self.test_state.GetContainers(containers.AWSVolume)),
-        len(self.test_state.GetContainers(containers.GCEDiskEvidence)))
+        len(self.test_state.GetContainers(containers.GCEDisk)))
 
     real_gce_disk_names = list(
         compute.GoogleCloudCompute(self.gcp_project_id).Disks().keys())
 
-    for d in self.test_state.GetContainers(containers.GCEDiskEvidence):
+    for d in self.test_state.GetContainers(containers.GCEDisk):
       self.assertIn(d.name, real_gce_disk_names)
       real_disk = compute.GoogleComputeDisk(
           self.gcp_project_id, self.gcp_zone, d.name)
@@ -215,7 +215,7 @@ class AWSToGCPForensicsEndToEndTest(unittest.TestCase):
     """Clean up after the test."""
     log.warning("Cleaning up after test...")
     # All of the following artefacts are created: AWSSnapshot, AWSS3Object,
-    # GCSObject, GCEImage, GCEDiskEvidence
+    # GCSObject, GCEImage, GCEDisk
     for c in self.test_state.GetContainers(containers.AWSSnapshot):
       self._removeAWSSnapshot(c.id)
     for c in self.test_state.GetContainers(containers.AWSS3Object):
@@ -224,8 +224,8 @@ class AWSToGCPForensicsEndToEndTest(unittest.TestCase):
       self._removeGCSObject(c.path)
     for c in self.test_state.GetContainers(containers.GCEImage):
       self._removeGCEImage(c.name)
-    for c in self.test_state.GetContainers(containers.GCEDiskEvidence):
-      self._removeGCEDiskEvidence(c.name)
+    for c in self.test_state.GetContainers(containers.GCEDisk):
+      self._removeGCEDisk(c.name)
 
   def _removeAWSSnapshot(self, snap_id: str):
     """Deletes an AWS EBS Snapshot with ID `id`."""
@@ -264,7 +264,7 @@ class AWSToGCPForensicsEndToEndTest(unittest.TestCase):
     except Exception as error:  # pylint: disable=broad-except
       log.error(f'Failed to delete GCE Image {name}: {str(error)}')
 
-  def _removeGCEDiskEvidence(self, name: str):
+  def _removeGCEDisk(self, name: str):
     """Remove the disk with name `name`."""
     log.warning(f'Deleting GCE Disk {name}')
     try:

--- a/tests/e2e/gcp_disk_forensics.py
+++ b/tests/e2e/gcp_disk_forensics.py
@@ -190,7 +190,7 @@ class GCEForensicsEndToEndTest(unittest.TestCase):
     # Check the disks are attached as expected
     actual_disks = compute.GoogleComputeInstance(
       self.project_id, self.zone, for_vm.name).ListDisks().keys()
-    expected_disks = self.test_state.GetContainers(containers.GCEDiskEvidence)
+    expected_disks = self.test_state.GetContainers(containers.GCEDisk)
 
     # Length should differ by 1 for the boot disk
     self.assertEqual(len(actual_disks), len(expected_disks) + 1)
@@ -235,7 +235,7 @@ class GCEForensicsEndToEndTest(unittest.TestCase):
     # Check the disks are attached as expected
     actual_disks = compute.GoogleComputeInstance(
       self.project_id, self.zone, for_vm.name).ListDisks().keys()
-    expected_disks = self.test_state.GetContainers(containers.GCEDiskEvidence)
+    expected_disks = self.test_state.GetContainers(containers.GCEDisk)
 
     # Length should differ by 1 for the boot disk
     self.assertEqual(len(actual_disks), len(expected_disks) + 1)

--- a/tests/lib/collectors/gce_disk_copy.py
+++ b/tests/lib/collectors/gce_disk_copy.py
@@ -349,7 +349,7 @@ class GCEDiskCopyTest(unittest.TestCase):
     FAKE_INSTANCE.Stop = mock.MagicMock()
 
     collector.PreProcess()
-    conts = test_state.GetContainers(collector.GetThreadOnContainerType())
+    conts = test_state.GetContainers(collector.GetThreadOnContainerType(), True)
     for d in conts:
       collector.Process(d)  # pytype: disable=wrong-arg-types
       # GetContainers returns the abstract base class type, but process is
@@ -364,7 +364,6 @@ class GCEDiskCopyTest(unittest.TestCase):
     FAKE_INSTANCE.Stop.assert_called_once()
 
     out_disks = test_state.GetContainers(containers.GCEDisk)
-    print(out_disks)
     out_disk_names = [d.name for d in out_disks]
     expected_disk_names = ['disk1-copy', 'disk2-copy']
     self.assertEqual(out_disk_names, expected_disk_names)
@@ -373,7 +372,6 @@ class GCEDiskCopyTest(unittest.TestCase):
 
     # Do it again, but we don't want to stop the instance this time.
     # First, clear the containers
-    test_state.GetContainers(containers.GCEDisk, True)
     test_state.GetContainers(containers.GCEDisk, True)
     mock_CreateDiskCopy.side_effect = FAKE_DISK_COPY
     collector = gce_disk_copy.GCEDiskCopy(test_state)
@@ -389,7 +387,7 @@ class GCEDiskCopyTest(unittest.TestCase):
     FAKE_INSTANCE.Stop = mock.MagicMock()
 
     collector.PreProcess()
-    conts = test_state.GetContainers(collector.GetThreadOnContainerType())
+    conts = test_state.GetContainers(collector.GetThreadOnContainerType(), True)
     for d in conts:
       collector.Process(d)  # pytype: disable=wrong-arg-types
       # GetContainers returns the abstract base class type, but process is

--- a/tests/lib/collectors/gce_disk_copy.py
+++ b/tests/lib/collectors/gce_disk_copy.py
@@ -363,8 +363,9 @@ class GCEDiskCopyTest(unittest.TestCase):
 
     FAKE_INSTANCE.Stop.assert_called_once()
 
-    out_disks = test_state.GetContainers(containers.GCEDiskEvidence)
-    out_disk_names = sorted([d.name for d in out_disks])
+    out_disks = test_state.GetContainers(containers.GCEDisk)
+    print(out_disks)
+    out_disk_names = [d.name for d in out_disks]
     expected_disk_names = ['disk1-copy', 'disk2-copy']
     self.assertEqual(out_disk_names, expected_disk_names)
     for d in out_disks:
@@ -373,7 +374,7 @@ class GCEDiskCopyTest(unittest.TestCase):
     # Do it again, but we don't want to stop the instance this time.
     # First, clear the containers
     test_state.GetContainers(containers.GCEDisk, True)
-    test_state.GetContainers(containers.GCEDiskEvidence, True)
+    test_state.GetContainers(containers.GCEDisk, True)
     mock_CreateDiskCopy.side_effect = FAKE_DISK_COPY
     collector = gce_disk_copy.GCEDiskCopy(test_state)
     collector.SetUp(
@@ -401,7 +402,7 @@ class GCEDiskCopyTest(unittest.TestCase):
     collector.PostProcess()
 
     FAKE_INSTANCE.Stop.assert_not_called()
-    out_disks = test_state.GetContainers(containers.GCEDiskEvidence)
+    out_disks = test_state.GetContainers(containers.GCEDisk)
     out_disk_names = sorted([d.name for d in out_disks])
     expected_disk_names = ['disk1-copy', 'disk2-copy']
     self.assertEqual(out_disk_names, expected_disk_names)

--- a/tests/lib/exporters/gce_disk_from_image.py
+++ b/tests/lib/exporters/gce_disk_from_image.py
@@ -84,7 +84,7 @@ class GCEDiskFromImageTest(unittest.TestCase):
     exporter.PostProcess()
 
     actual_output = [c.name for \
-        c in test_state.GetContainers(containers.GCEDiskEvidence)]
+        c in test_state.GetContainers(containers.GCEDisk)]
 
     self.assertEqual(sorted(actual_output), sorted([
       'fake-disk-one',
@@ -116,7 +116,7 @@ class GCEDiskFromImageTest(unittest.TestCase):
     exporter.PostProcess()
 
     actual_output = [c.name for \
-        c in test_state.GetContainers(containers.GCEDiskEvidence)]
+        c in test_state.GetContainers(containers.GCEDisk)]
 
     self.assertEqual(sorted(actual_output), sorted([
       'fake-disk-one',

--- a/tests/lib/processors/gce_forensics_vm.py
+++ b/tests/lib/processors/gce_forensics_vm.py
@@ -86,11 +86,11 @@ class GCEForensicsVMTest(unittest.TestCase):
     mock_DiskInit.side_effect = [disk1, disk2, disk3]
 
     test_state = state.DFTimewolfState(config.Config)
-    test_state.StoreContainer(containers.GCEDiskEvidence(
+    test_state.StoreContainer(containers.GCEDisk(
         'test-disk-1', 'test-analysis-project-name'))
-    test_state.StoreContainer(containers.GCEDiskEvidence(
+    test_state.StoreContainer(containers.GCEDisk(
         'test-disk-2', 'test-analysis-project-name'))
-    test_state.StoreContainer(containers.GCEDiskEvidence(
+    test_state.StoreContainer(containers.GCEDisk(
         'test-disk-3', 'test-analysis-project-name'))
 
     processor = GCEForensicsVM(test_state)
@@ -131,7 +131,7 @@ class GCEForensicsVMTest(unittest.TestCase):
       mock.call(disk3),
     ])
 
-    actual_disks = test_state.GetContainers(containers.GCEDiskEvidence)
+    actual_disks = test_state.GetContainers(containers.GCEDisk)
     actual_disk_names = [d.name for d in actual_disks]
 
     self.assertEqual(3, len(actual_disks))

--- a/tests/lib/processors/turbinia_gcp.py
+++ b/tests/lib/processors/turbinia_gcp.py
@@ -257,7 +257,7 @@ class TurbiniaGCPProcessorTest(unittest.TestCase):
       containers.YaraRule(
         name='dummy_yara', rule_text="rule dummy { condition: false }")
     )
-    test_state.StoreContainer(containers.GCEDiskEvidence(
+    test_state.StoreContainer(containers.GCEDisk(
         name='disk-1', project='turbinia-project'))
     turbinia_processor = turbinia_gcp.TurbiniaGCPProcessor(test_state)
     turbinia_processor.SetUp(
@@ -351,7 +351,7 @@ class TurbiniaGCPProcessorTest(unittest.TestCase):
                               mock_GoogleCloudDisk):
     """Tests that process does nothing if the disks are in another project."""
     test_state = state.DFTimewolfState(config.Config)
-    test_state.StoreContainer(containers.GCEDiskEvidence(
+    test_state.StoreContainer(containers.GCEDisk(
         name='disk-1', project='another-project'))
     turbinia_processor = turbinia_gcp.TurbiniaGCPProcessor(test_state)
     turbinia_processor.SetUp(
@@ -438,7 +438,7 @@ class TurbiniaGCPProcessorTest(unittest.TestCase):
     turbinia_processor.client.create_request.return_value = turbinia_message.TurbiniaRequest()
     turbinia_processor.PreProcess()
 
-    out_containers = test_state.GetContainers(containers.GCEDiskEvidence)
+    out_containers = test_state.GetContainers(containers.GCEDisk)
 
     self.assertEqual(len(out_containers), 1)
     self.assertEqual(out_containers[0].name, 'disk-1')


### PR DESCRIPTION
The two containers represent the same object, and so removed GCEDiskEvidence and replaced all usages of it with GCEDisk. 