### PR TITLE
Added delay between GCE launch and evidence disk attachment

### DIFF
--- a/dftimewolf/lib/processors/gce_forensics_vm.py
+++ b/dftimewolf/lib/processors/gce_forensics_vm.py
@@ -154,7 +154,8 @@ class GCEForensicsVM(module.BaseModule):
 
     disks = self.state.GetContainers(containers.GCEDisk)
 
-    # Sleep until status is RUNNING before attaching disks. Possible status values:
+    # Sleep until status is RUNNING before attaching disks. Possible status
+    # values:
     # https://cloud.google.com/compute/docs/reference/rest/v1/instances/get
     if disks and self.analysis_vm.GetPowerState() != 'RUNNING':
       self.logger.info('Pausing 10 seconds to allow OS to boot before attaching'

--- a/dftimewolf/lib/processors/gce_forensics_vm.py
+++ b/dftimewolf/lib/processors/gce_forensics_vm.py
@@ -154,10 +154,12 @@ class GCEForensicsVM(module.BaseModule):
 
     disks = self.state.GetContainers(containers.GCEDisk)
 
-    if disks:
-      self.logger.info('Pausing 30 seconds to allow OS to boot before attaching'
+    # Sleep until status is RUNNING before attaching disks. Possible status values:
+    # https://cloud.google.com/compute/docs/reference/rest/v1/instances/get
+    if disks and self.analysis_vm.GetPowerState() != 'RUNNING':
+      self.logger.info('Pausing 10 seconds to allow OS to boot before attaching'
           ' evidence disks')
-      time.sleep(30)
+      time.sleep(10)
 
     for d in disks:
       if d.project != self.project.project_id:

--- a/dftimewolf/lib/processors/gce_forensics_vm.py
+++ b/dftimewolf/lib/processors/gce_forensics_vm.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Creates an analysis VM and attaches GCP disks to it for analysis."""
 
+import time
 from typing import List, Optional, Dict
 
 from libcloudforensics import errors as lcf_errors
@@ -152,6 +153,11 @@ class GCEForensicsVM(module.BaseModule):
         platform='gcp'))
 
     disks = self.state.GetContainers(containers.GCEDisk)
+
+    if disks:
+      self.logger.info('Pausing 30 seconds to allow OS to boot before attaching'
+          ' evidence disks')
+      time.sleep(30)
 
     for d in disks:
       if d.project != self.project.project_id:

--- a/tests/lib/processors/gce_forensics_vm.py
+++ b/tests/lib/processors/gce_forensics_vm.py
@@ -65,14 +65,20 @@ class GCEForensicsVMTest(unittest.TestCase):
   @mock.patch('libcloudforensics.providers.gcp.internal.compute_base_resource.GoogleComputeBaseResource.AddLabels')
   @mock.patch('libcloudforensics.providers.gcp.forensics.StartAnalysisVm')
   @mock.patch('libcloudforensics.providers.gcp.internal.compute.GoogleComputeInstance.AttachDisk')
+  @mock.patch('libcloudforensics.providers.gcp.internal.compute.GoogleComputeInstance.GetPowerState')
+  @mock.patch('time.sleep')
   # pylint: enable=line-too-long
   def testProcess(self,
+                  mock_sleep,
+                  mock_GetPowerState,
                   mock_AttachDisk,
                   mock_StartAnalysisVm,
                   mock_AddLabels,
                   mock_GetBootDisk,
                   mock_DiskInit):
     """Tests the collector's Process() function."""
+    mock_sleep.return_value = None
+    mock_GetPowerState.return_value = 'RUNNING'
     mock_StartAnalysisVm.return_value = (FAKE_ANALYSIS_VM, None)
     FAKE_ANALYSIS_VM.AddLabels = mock_AddLabels
     FAKE_ANALYSIS_VM.GetBootDisk = mock_GetBootDisk


### PR DESCRIPTION
If an evidence disk is attached too close to instance launch, and the evidence disk is a boot disk from the copied VM, the VM can fail to pick the correct disk to launch from, since both disks are equally correct, as far as the VM is concerned. Adding a delay to attaching evidence disks will ensure that the correct disk is booted from. 