### PR TITLE
Made Grr approval urls visible in curses mode

### DIFF
--- a/dftimewolf/lib/collectors/grr_base.py
+++ b/dftimewolf/lib/collectors/grr_base.py
@@ -23,6 +23,8 @@ class GRRBaseModule(object):
     grr_url: GRR HTTP URL.
     reason (str): justification for GRR access.
     approvers: list of GRR approval recipients.
+    message_callback: Callback method used to notify the operator of approval
+        URLs.
   """
 
   _CHECK_APPROVAL_INTERVAL_SEC = 10
@@ -60,6 +62,8 @@ class GRRBaseModule(object):
       grr_server_url (str): GRR server URL.
       grr_username (str): GRR username.
       grr_password (str): GRR password.
+      message_callback: Callback method used to notify the operator of approval
+          URLs.
       approvers (Optional[str]): comma-separated GRR approval recipients.
       verify (Optional[bool]): True to indicate GRR server's x509 certificate
           should be verified.

--- a/dftimewolf/lib/collectors/grr_base.py
+++ b/dftimewolf/lib/collectors/grr_base.py
@@ -41,6 +41,7 @@ class GRRBaseModule(object):
     self.grr_url = str()
     self.approvers = []  # type: List[str]
     self.output_path = str()
+    self.message_callback: Callable[[str, bool], None] = None  # type: ignore
 
   # pylint: disable=arguments-differ
   def GrrSetUp(
@@ -49,6 +50,7 @@ class GRRBaseModule(object):
       grr_server_url: str,
       grr_username: str,
       grr_password: str,
+      message_callback: Callable[[str, bool], None],
       approvers: Optional[str]=None,
       verify: bool=True) -> None:
     """Initializes a GRR hunt result collector.
@@ -71,6 +73,7 @@ class GRRBaseModule(object):
     self.grr_url = grr_server_url
     self.output_path = tempfile.mkdtemp()
     self.reason = reason
+    self.message_callback = message_callback
 
   # TODO: change object to more specific GRR type information.
   def _WrapGRRRequestWithApproval(
@@ -100,6 +103,7 @@ class GRRBaseModule(object):
     """
     approval_sent = False
     approval_url = None
+    approval_url_shown = False
 
     while True:
       try:
@@ -111,7 +115,11 @@ class GRRBaseModule(object):
         if approval_sent:
           logger.info('Approval not yet granted, waiting {0:d}s'.format(
               self._CHECK_APPROVAL_INTERVAL_SEC))
-          logger.info(approval_url)
+          if not approval_url_shown:
+            self.message_callback(f'Approval needed at: {approval_url}', False)
+            approval_url_shown = True
+          else:
+            logger.info(f'Approval needed at: {approval_url}')
           time.sleep(self._CHECK_APPROVAL_INTERVAL_SEC)
           continue
 
@@ -129,6 +137,5 @@ class GRRBaseModule(object):
                         format(self.grr_url, approval.username,
                                approval.client_id,
                                approval.approval_id))
-        logger.info(
-            '{0!s}: approval request sent to: {1!s} (reason: {2:s})'.format(
-                grr_object, self.approvers, self.reason))
+        logger.info(f'{grr_object}: approval request sent to: '
+            f'{self.approvers} (reason: {self.reason})')

--- a/dftimewolf/lib/collectors/grr_hosts.py
+++ b/dftimewolf/lib/collectors/grr_hosts.py
@@ -85,8 +85,8 @@ class GRRFlow(GRRBaseModule, module.ThreadAwareModule):
     """
     self.skip_offline_clients = skip_offline_clients
     self.GrrSetUp(
-        reason, grr_server_url, grr_username, grr_password,
-        approvers=approvers, verify=verify)
+        reason, grr_server_url, grr_username, grr_password, approvers=approvers,
+        verify=verify, message_callback=self.PublishMessage)
 
   def _SeenLastMonth(self, timestamp: int) -> bool:
     """Take a UTC timestamp and check if it is in the last month.

--- a/dftimewolf/lib/collectors/grr_hunt.py
+++ b/dftimewolf/lib/collectors/grr_hunt.py
@@ -203,8 +203,9 @@ class GRRHuntArtifactCollector(GRRHunt):
           client OS types (win, osx or linux).
       client_labels (str): a comma separated list of client labels.
     """
-    self.GrrSetUp(reason, grr_server_url, grr_username, grr_password,
-        approvers=approvers, verify=verify)
+    self.GrrSetUp(
+        reason, grr_server_url, grr_username, grr_password, approvers=approvers,
+        verify=verify, message_callback=self.PublishMessage)
 
     self.artifacts = [item.strip() for item in artifacts.strip().split(',')]
     if not artifacts:
@@ -289,8 +290,8 @@ class GRRHuntFileCollector(GRRHunt):
       client_labels (str): a comma separated list of client labels.
     """
     self.GrrSetUp(
-        reason, grr_server_url, grr_username, grr_password,
-        approvers=approvers, verify=verify)
+        reason, grr_server_url, grr_username, grr_password, approvers=approvers,
+        verify=verify, message_callback=self.PublishMessage)
     self.file_path_list = [item.strip() for item
                            in file_path_list.strip().split(',')]
     if max_file_size:
@@ -388,12 +389,8 @@ class GRRHuntOsqueryCollector(GRRHunt):
       client_labels (str): a comma separated list of client labels.
     """
     self.GrrSetUp(
-        reason=reason,
-        grr_server_url=grr_server_url,
-        grr_username=grr_username,
-        grr_password=grr_password,
-        approvers=approvers,
-        verify=verify)
+        reason, grr_server_url, grr_username, grr_password, approvers=approvers,
+        verify=verify, message_callback=self.PublishMessage)
 
     self.HuntSetup(match_mode, client_operating_systems, client_labels)
 
@@ -462,8 +459,8 @@ class GRRHuntDownloaderBase(GRRHunt):
           should be verified.
     """
     self.GrrSetUp(
-        reason, grr_server_url, grr_username, grr_password,
-        approvers=approvers, verify=verify)
+        reason, grr_server_url, grr_username, grr_password, approvers=approvers,
+        verify=verify, message_callback=self.PublishMessage)
     self.hunt_id = hunt_id
     self.output_path = tempfile.mkdtemp()
 

--- a/tests/lib/collectors/grr_base.py
+++ b/tests/lib/collectors/grr_base.py
@@ -50,12 +50,14 @@ class GRRBaseModuleTest(unittest.TestCase):
   def testSetup(self, mock_grr_inithttp, mock_mkdtemp):
     """Tests that setup works"""
     grr_base_module = grr_base.GRRBaseModule()
+    mock_publish_message = mock.MagicMock()
     mock_mkdtemp.return_value = '/fake'
     grr_base_module.GrrSetUp(
         reason='random reason',
         grr_server_url='http://fake/endpoint',
         grr_username='admin1',
         grr_password='admin2',
+        message_callback=mock_publish_message,
         approvers='approver1@example.com,approver2@example.com',
         verify=True
     )
@@ -70,12 +72,14 @@ class GRRBaseModuleTest(unittest.TestCase):
   @mock.patch('grr_api_client.api.InitHttp')
   def testApprovalWrapper(self, _):
     """Tests that the approval wrapper works correctly."""
+    mock_publish_message = mock.MagicMock()
     grr_base_module = grr_base.GRRBaseModule()
     grr_base_module.GrrSetUp(
         reason='random reason',
         grr_server_url='http://fake/endpoint',
         grr_username='admin1',
         grr_password='admin2',
+        message_callback=mock_publish_message,
         approvers='approver1@example.com,approver2@example.com',
         verify=True
     )
@@ -103,6 +107,13 @@ class GRRBaseModuleTest(unittest.TestCase):
         reason='random reason',
         notified_users=['approver1@example.com', 'approver2@example.com'])
 
+    mock_publish_message.assert_has_calls([
+      # pylint: disable=line-too-long
+      mock.call('Approval needed at: http://fake/endpoint/#/users/nobody/approvals/client/abcd/dcba', False)
+      # pylint: enable=line-too-long
+    ])
+    self.assertEqual(mock_publish_message.call_count, 1)
+
   @mock.patch('grr_api_client.api.InitHttp')
   def testNoApproversErrorsOut(self, _):
     """Tests that an error is generated if no approvers are specified.
@@ -110,12 +121,14 @@ class GRRBaseModuleTest(unittest.TestCase):
     This should only error on unauthorized objects, which is how our mock
     behaves.
     """
+    mock_publish_message = mock.MagicMock()
     grr_base_module = grr_base.GRRBaseModule()
     grr_base_module.GrrSetUp(
         reason='random',
         grr_server_url='http://fake/url',
         grr_username='admin1',
         grr_password='admin2',
+        message_callback=mock_publish_message,
         approvers='',
         verify=True
     )


### PR DESCRIPTION
Currently GRR MPA urls are sent to the logger. This PR ensures that the url is also sent to `module.PublishMessage`, so in curses mode the operator still is able to retrieve it. 