### PR TITLE
Add in container deduping to grr host modules

### DIFF
--- a/dftimewolf/lib/collectors/grr_hosts.py
+++ b/dftimewolf/lib/collectors/grr_hosts.py
@@ -452,6 +452,7 @@ class GRRArtifactCollector(GRRFlow):
       hostname = item.strip()
       if hostname:
         self.state.StoreContainer(containers.Host(hostname=hostname))
+    self.state.DedupeContainers(containers.Host)
 
     self.use_tsk = use_tsk
     if max_file_size:
@@ -593,6 +594,7 @@ class GRRFileCollector(GRRFlow):
       hostname = item.strip()
       if hostname:
         self.state.StoreContainer(containers.Host(hostname=hostname))
+    self.state.DedupeContainers(containers.Host)
 
     self.use_tsk = use_tsk
 
@@ -719,6 +721,7 @@ class GRROsqueryCollector(GRRFlow):
 
     for hostname in hosts:
       self.state.StoreContainer(containers.Host(hostname=hostname))
+    self.state.DedupeContainers(containers.Host)
 
     self.timeout_millis = timeout_millis
     self.ignore_stderr_errors = ignore_stderr_errors
@@ -912,6 +915,7 @@ class GRRFlowCollector(GRRFlow):
           if f in client_flows:
             self.state.StoreContainer(containers.GrrFlow(host, f))
             found_flows.append(f)
+    self.state.DedupeContainers(containers.GrrFlow)
 
     missing_flows = sorted([f for f in flows if f not in found_flows])
     if missing_flows:
@@ -1018,6 +1022,7 @@ class GRRTimelineCollector(GRRFlow):
       hostname = item.strip()
       if hostname:
         self.state.StoreContainer(containers.Host(hostname=hostname))
+    self.state.DedupeContainers(containers.Host)
 
     self._timeline_format = int(timeline_format)
     if self._timeline_format not in [1, 2]:

--- a/dftimewolf/lib/containers/containers.py
+++ b/dftimewolf/lib/containers/containers.py
@@ -363,6 +363,10 @@ class Host(interface.AttributeContainer):
     """Override __str()__."""
     return self.hostname
 
+  def __eq__(self, other: Host) -> bool:
+    """Override __eq__() for this container."""
+    return self.hostname == other.hostname and self.platform == other.platform
+
 
 class GrrFlow(interface.AttributeContainer):
   """Attribute container definition for a host.
@@ -382,6 +386,10 @@ class GrrFlow(interface.AttributeContainer):
   def __str__(self) -> str:
     """Override __str()__."""
     return f'{self.hostname}:{self.flow_id}'
+
+  def __eq__(self, other: GrrFlow) -> bool:
+    """Override __eq__() for this container."""
+    return self.hostname == other.hostname and self.flow_id == other.flow_id
 
 
 class WorkspaceLogs(interface.AttributeContainer):


### PR DESCRIPTION
If multiple grr host modules are set to run, they each try to add the host in SetUp to the container store, which results in duplicate flows being initiated. This rectifies that by deduping the containers. 