### PR TITLE
Fix GRRFileCollector to use TSK API input for GRR

### DIFF
--- a/dftimewolf/lib/collectors/grr_hosts.py
+++ b/dftimewolf/lib/collectors/grr_hosts.py
@@ -12,7 +12,7 @@ import pandas as pd
 
 from grr_api_client import errors as grr_errors
 from grr_api_client.client import Client
-from grr_response_proto import flows_pb2, timeline_pb2
+from grr_response_proto import flows_pb2, jobs_pb2, timeline_pb2
 from grr_response_proto import osquery_pb2 as osquery_flows
 
 from dftimewolf.lib import module
@@ -612,6 +612,9 @@ class GRRFileCollector(GRRFlow):
     Raises:
       DFTimewolfError: if no files specified.
     """
+    path_type = jobs_pb2.PathSpec.OS
+    if self.use_tsk:
+        path_type = jobs_pb2.PathSpec.TSK
     for client in self._FindClients([container.hostname]):
       flow_action = flows_pb2.FileFinderAction(
         action_type=self.action,
@@ -620,6 +623,7 @@ class GRRFileCollector(GRRFlow):
         ))
       flow_args = flows_pb2.FileFinderArgs(
           paths=self.files,
+          pathtype=path_type,
           action=flow_action)
       flow_id = self._LaunchFlow(client, 'FileFinder', flow_args)
       self._AwaitFlow(client, flow_id)

--- a/dftimewolf/lib/collectors/grr_hosts.py
+++ b/dftimewolf/lib/collectors/grr_hosts.py
@@ -614,7 +614,7 @@ class GRRFileCollector(GRRFlow):
     """
     path_type = jobs_pb2.PathSpec.OS
     if self.use_tsk:
-        path_type = jobs_pb2.PathSpec.TSK
+      path_type = jobs_pb2.PathSpec.TSK
     for client in self._FindClients([container.hostname]):
       flow_action = flows_pb2.FileFinderAction(
         action_type=self.action,

--- a/tests/lib/collectors/grr_hosts.py
+++ b/tests/lib/collectors/grr_hosts.py
@@ -10,6 +10,7 @@ import six
 import pandas as pd
 from grr_api_client import errors as grr_errors
 from grr_response_proto import flows_pb2
+from grr_response_proto import jobs_pb2
 from grr_response_proto import osquery_pb2
 from tests.lib.collectors.test_data import mock_grr_hosts
 
@@ -413,6 +414,7 @@ class GRRFileCollectorTest(unittest.TestCase):
         'FileFinder',
         flows_pb2.FileFinderArgs(
             paths=['/etc/passwd', '/etc/hosts'],
+            pathtype=jobs_pb2.PathSpec.TSK,
             action=flows_pb2.FileFinderAction(
                 action_type=flows_pb2.FileFinderAction.STAT,
                 download=flows_pb2.FileFinderDownloadActionOptions(


### PR DESCRIPTION
By [default](https://github.com/google/grr/blob/master/grr/proto/grr_response_proto/flows.proto#L1852) the PathType for the GRR File Finder flow uses `OS`. When TSK is enabled via the command line this option is passed into the GRR client's flow arguments.