### PR TITLE
Redirect stdout to stderr for argparse

### DIFF
--- a/dftimewolf/cli/dftimewolf_recipes.py
+++ b/dftimewolf/cli/dftimewolf_recipes.py
@@ -248,7 +248,8 @@ class DFTimewolfTool(object):
 
     self._AddRecipeOptions(argument_parser)
 
-    self._command_line_options = argument_parser.parse_args(arguments)
+    with redirect_stdout(sys.stderr):
+      self._command_line_options = argument_parser.parse_args(arguments)
 
     if not getattr(self._command_line_options, 'recipe', None):
       error_message = '\nPlease specify a recipe.\n' + help_text


### PR DESCRIPTION
Currently, when passing `-h` to a recipe, argparse sends the output to stdout. In the context of the curses UI we'd prefer it be sent to stderr, so it gets captured and displayed to the user. 