### PR TITLE
Surface the turbinia request ID to the user via PublishMessage

### DIFF
--- a/dftimewolf/lib/processors/turbinia_artifact.py
+++ b/dftimewolf/lib/processors/turbinia_artifact.py
@@ -86,7 +86,9 @@ class TurbiniaArtifactProcessor(TurbiniaProcessorBase,
     evidence_ = evidence.CompressedDirectory(
         compressed_directory=container.path, source_path=container.path)
     try:
-      task_data, _ = self.TurbiniaProcess(evidence_)
+      request_id = self.TurbiniaStart(evidence_)
+      self.PublishMessage(f'Turbinia request ID: {request_id}')
+      task_data, _ = self.TurbiniaWait(request_id)
     except TurbiniaException as exception:
       self.ModuleError(str(exception), critical=True)
 

--- a/dftimewolf/lib/processors/turbinia_artifact.py
+++ b/dftimewolf/lib/processors/turbinia_artifact.py
@@ -101,7 +101,7 @@ class TurbiniaArtifactProcessor(TurbiniaProcessorBase,
 
         # We're only interested in plaso files for the time being.
         if path.endswith('.plaso'):
-          self.PublishMessage(f'  {task["name"]}: {path}')
+          self.logger.info(f'  {task["name"]}: {path}')
           container = containers.RemoteFSPath(
               path=path, hostname=container.hostname)
           self.state.StoreContainer(container)

--- a/dftimewolf/lib/processors/turbinia_base.py
+++ b/dftimewolf/lib/processors/turbinia_base.py
@@ -166,26 +166,6 @@ class TurbiniaProcessorBase(object):
     self._output_path = tempfile.mkdtemp()
     self.client = turbinia_client.get_turbinia_client()
 
-  def TurbiniaProcess(
-    self,
-    evidence_: evidence.Evidence,
-    threat_intel_indicators: Optional[List[Optional[str]]] = None,
-    yara_rules: Optional[List[str]] = None
-      ) -> Tuple[List[Dict[str, str]], Any]:
-    """Creates, sends and waits-on a Turbinia processing request.
-
-    Args:
-      evidence_: The evidence to process.
-      threat_intel_indicator: list of strings used as regular expressions in
-          the Turbinia grepper module.
-      yara_rules: List of Yara rule strings to use in the Turbinia Yara module.
-    Returns:
-      The Turbinia task data.
-    """
-    request_id = self.TurbiniaStart(
-        evidence_, threat_intel_indicators, yara_rules)
-    return self.TurbiniaWait(request_id)
-
   def TurbiniaStart(
     self,
     evidence_: evidence.Evidence,

--- a/dftimewolf/lib/processors/turbinia_gcp.py
+++ b/dftimewolf/lib/processors/turbinia_gcp.py
@@ -125,8 +125,10 @@ class TurbiniaGCPProcessor(TurbiniaProcessorBase, module.ThreadAwareModule):
       yara_rules = [rule.rule_text for rule in yara_containers]
 
     try:
-      task_data, report = self.TurbiniaProcess(
+      request_id = self.TurbiniaStart(
           evidence_, threat_intel_indicators, yara_rules)
+      self.PublishMessage(f'Turbinia request ID: {request_id}')
+      task_data, report = self.TurbiniaWait(request_id)
     except TurbiniaException as exception:
       self.ModuleError(str(exception), critical=True)
 


### PR DESCRIPTION
Surface the turbinia request ID to the user via PublishMessage.

Required a small amount of refactoring - moving `TurbiniaStart` and `TurbiniaWait` out of `TurbiniaProcess` into the child classes (and removing `TurbiniaProcess` as it's not used any more as a result.)