### PR TITLE
Handle curses error when window is too short

### DIFF
--- a/dftimewolf/cli/curses_display_manager.py
+++ b/dftimewolf/cli/curses_display_manager.py
@@ -241,9 +241,9 @@ class CursesDisplayManager:
     self._preflights[m.runtime_name] = m
 
   def EnqueueModule(self,
-                       name: str,
-                       dependencies: List[str],
-                       runtime_name: Optional[str]) -> None:
+                    name: str,
+                    dependencies: List[str],
+                    runtime_name: Optional[str]) -> None:
     """Enqueue a module object for display.
 
     Args:
@@ -302,53 +302,59 @@ class CursesDisplayManager:
       return
 
     with self._lock:
-      self._stdscr.clear()
-      y, _ = self._stdscr.getmaxyx()
+      try:
+        self._stdscr.clear()
+        y, _ = self._stdscr.getmaxyx()
 
-      curr_line = 1
-      self._stdscr.addstr(curr_line, 0, f' {self._recipe_name}')
-      curr_line += 1
-
-      # Preflights
-      if self._preflights:
-        self._stdscr.addstr(curr_line, 0, '   Preflights:')
-        curr_line += 1
-        for _, module in self._preflights.items():
-          for line in module.Stringify():
-            self._stdscr.addstr(curr_line, 0, line)
-            curr_line += 1
-
-      # Modules
-      self._stdscr.addstr(curr_line, 0, '   Modules:')
-      curr_line += 1
-      for status in Status:  # Print the modules in Status order
-        for _, module in self._modules.items():
-          if module.status != status:
-            continue
-          for line in module.Stringify():
-            self._stdscr.addstr(curr_line, 0, line)
-            curr_line += 1
-
-      # Messages
-      curr_line += 1
-      self._stdscr.addstr(curr_line, 0, ' Messages:')
-      curr_line += 1
-
-      message_space = y - 4 - curr_line
-      start = len(self._messages) - message_space
-      start = 0 if start < 0 else start
-
-      # Slice the aray, we may not be able to fit all messages on the screen
-      for m in self._messages[start:]:
-        self._stdscr.addstr(
-            curr_line, 0, f'  {m.Stringify(self._messages_longest_source_len)}')
+        curr_line = 1
+        self._stdscr.addstr(curr_line, 0, f' {self._recipe_name}')
         curr_line += 1
 
-      # Exceptions
-      if self._exception:
-        self._stdscr.addstr(y - 2, 0,
-            f' Exception encountered: {str(self._exception)}')
-      self._stdscr.move(curr_line, 0)
+        # Preflights
+        if self._preflights:
+          self._stdscr.addstr(curr_line, 0, '   Preflights:')
+          curr_line += 1
+          for _, module in self._preflights.items():
+            for line in module.Stringify():
+              self._stdscr.addstr(curr_line, 0, line)
+              curr_line += 1
+
+        # Modules
+        self._stdscr.addstr(curr_line, 0, '   Modules:')
+        curr_line += 1
+        for status in Status:  # Print the modules in Status order
+          for _, module in self._modules.items():
+            if module.status != status:
+              continue
+            for line in module.Stringify():
+              self._stdscr.addstr(curr_line, 0, line)
+              curr_line += 1
+
+        # Messages
+        curr_line += 1
+        self._stdscr.addstr(curr_line, 0, ' Messages:')
+        curr_line += 1
+
+        message_space = y - 4 - curr_line
+        start = len(self._messages) - message_space
+        start = 0 if start < 0 else start
+
+        # Slice the aray, we may not be able to fit all messages on the screen
+        for m in self._messages[start:]:
+          self._stdscr.addstr(
+              curr_line, 0, f'  {m.Stringify(self._messages_longest_source_len)}')
+          curr_line += 1
+
+        # Exceptions
+        if self._exception:
+          self._stdscr.addstr(y - 2, 0,
+              f' Exception encountered: {str(self._exception)}')
+      except curses.error as e:
+        self._stdscr.addstr(y - 3, 0, '*********************************************************************** ')
+        self._stdscr.addstr(y - 2, 0, '*** Terminal not large enough, consider increasing your window size *** ')
+        self._stdscr.addstr(y - 1, 0, '*********************************************************************** ')
+
+      self._stdscr.move(y - 1, 0)
       self._stdscr.refresh()
 
   def PrintMessages(self) -> None:

--- a/dftimewolf/cli/curses_display_manager.py
+++ b/dftimewolf/cli/curses_display_manager.py
@@ -350,11 +350,11 @@ class CursesDisplayManager:
           self._stdscr.addstr(y - 2, 0,
               f' Exception encountered: {str(self._exception)}')
       except curses.error:
-        # pylint: disable=line-too-long
+#        # pylint: disable=line-too-long
         self._stdscr.addstr(y - 3, 0, '*********************************************************************** ')
         self._stdscr.addstr(y - 2, 0, '*** Terminal not large enough, consider increasing your window size *** ')
         self._stdscr.addstr(y - 1, 0, '*********************************************************************** ')
-        # pylint: enable=line-too-long
+#        # pylint: enable=line-too-long
 
       self._stdscr.move(y - 1, 0)
       self._stdscr.refresh()

--- a/dftimewolf/cli/curses_display_manager.py
+++ b/dftimewolf/cli/curses_display_manager.py
@@ -302,11 +302,11 @@ class CursesDisplayManager:
       return
 
     with self._lock:
-      try:
-        self._stdscr.clear()
-        y, _ = self._stdscr.getmaxyx()
+      self._stdscr.clear()
+      y, _ = self._stdscr.getmaxyx()
 
-        curr_line = 1
+      try:
+        curr_line = 0
         self._stdscr.addstr(curr_line, 0, f' {self._recipe_name}')
         curr_line += 1
 
@@ -341,18 +341,20 @@ class CursesDisplayManager:
 
         # Slice the aray, we may not be able to fit all messages on the screen
         for m in self._messages[start:]:
-          self._stdscr.addstr(
-              curr_line, 0, f'  {m.Stringify(self._messages_longest_source_len)}')
+          self._stdscr.addstr(curr_line, 0,
+              f'  {m.Stringify(self._messages_longest_source_len)}')
           curr_line += 1
 
         # Exceptions
         if self._exception:
           self._stdscr.addstr(y - 2, 0,
               f' Exception encountered: {str(self._exception)}')
-      except curses.error as e:
+      except curses.error:
+        # pylint: disable=line-too-long
         self._stdscr.addstr(y - 3, 0, '*********************************************************************** ')
         self._stdscr.addstr(y - 2, 0, '*** Terminal not large enough, consider increasing your window size *** ')
         self._stdscr.addstr(y - 1, 0, '*********************************************************************** ')
+        # pylint: enable=line-too-long
 
       self._stdscr.move(y - 1, 0)
       self._stdscr.refresh()

--- a/dftimewolf/lib/collectors/bigquery.py
+++ b/dftimewolf/lib/collectors/bigquery.py
@@ -4,7 +4,7 @@ import tempfile
 from typing import Optional
 
 from google.auth import exceptions as google_auth_exceptions
-from google.cloud import bigquery
+from google.cloud import bigquery # type: ignore
 import google.cloud.exceptions
 
 from dftimewolf.lib import module

--- a/dftimewolf/lib/collectors/bigquery.py
+++ b/dftimewolf/lib/collectors/bigquery.py
@@ -4,7 +4,7 @@ import tempfile
 from typing import Optional
 
 from google.auth import exceptions as google_auth_exceptions
-from google.cloud import bigquery # type: ignore
+from google.cloud import bigquery
 import google.cloud.exceptions
 
 from dftimewolf.lib import module

--- a/tests/cli/curses_display_manager.py
+++ b/tests/cli/curses_display_manager.py
@@ -3,6 +3,7 @@
 """Tests the CursesDisplayManager."""
 
 from contextlib import redirect_stdout
+import curses
 import io
 import unittest
 from unittest import mock
@@ -446,7 +447,7 @@ class CursesDisplayManagerTest(unittest.TestCase):
           mock.call(6, 0,  '     2nd Module: Running'),
           mock.call(7, 0,  '     3rd Module: Processing - 1 of 5 containers completed'),
           mock.call(8, 0,  '       thread_3_0: Running (container_3_4)'),
-          mock.call(9, 0, '       thread_3_1: Running (container_3_1)'),
+          mock.call(9, 0,  '       thread_3_1: Running (container_3_1)'),
           mock.call(10, 0, '       thread_3_2: Running (container_3_2)'),
           mock.call(11, 0, '     4th Module: Processing - 1 of 8 containers completed'),
           mock.call(12, 0, '       thread_4_0: Running (container_4_4)'),
@@ -465,6 +466,91 @@ class CursesDisplayManagerTest(unittest.TestCase):
           mock.call(28, 0, ' Exception encountered: Test Exception')])
       self.assertEqual(mock_addstr.call_count, 26)
       # pylint: enable=line-too-long
+
+  def testShortWindowDraw(self):
+    """Tests drawing to the console via curses. The terminal is too small."""
+    with mock.patch('curses.cbreak'), \
+        mock.patch('curses.noecho'), \
+        mock.patch('curses.initscr'):
+      self.cdm.StartCurses()
+
+    with mock.patch.object(self.cdm._stdscr, 'getmaxyx') as mock_getmaxyx, \
+        mock.patch.object(self.cdm, 'Draw'):
+      mock_getmaxyx.return_value = 10, 140
+
+      self.cdm.SetRecipe('Recipe name')
+      self.cdm.EnqueuePreflight('First Preflight', [], '1st Preflight')
+      self.cdm.EnqueuePreflight('Second Preflight', [], '2nd Preflight')
+      self.cdm.EnqueueModule('First Module', [], '1st Module')
+      self.cdm.EnqueueModule('Second Module', ['1st Module'], '2nd Module')
+      self.cdm.EnqueueModule('Third Module', ['1st Module'], '3rd Module')
+      self.cdm.EnqueueModule('Fourth Module', ['1st Module'], '4th Module')
+      self.cdm.EnqueueModule('Fifth Module',
+          ['2nd Module', '3rd Module', '4th Module'], '5th Module')
+      self.cdm.UpdateModuleStatus('1st Preflight', Status.COMPLETED)
+      self.cdm.UpdateModuleStatus('2nd Preflight', Status.COMPLETED)
+      self.cdm.UpdateModuleStatus('1st Module', Status.COMPLETED)
+      self.cdm.UpdateModuleStatus('2nd Module', Status.RUNNING)
+      self.cdm.UpdateModuleStatus('3rd Module', Status.PROCESSING)
+      self.cdm.UpdateModuleStatus('4th Module', Status.PROCESSING)
+      self.cdm.SetThreadedModuleContainerCount('3rd Module', 5)
+      self.cdm.SetThreadedModuleContainerCount('4th Module', 8)
+      self.cdm.UpdateModuleThreadState('3rd Module', Status.RUNNING,
+          'thread_3_0', 'container_3_0')
+      self.cdm.UpdateModuleThreadState('3rd Module', Status.RUNNING,
+          'thread_3_1', 'container_3_1')
+      self.cdm.UpdateModuleThreadState('3rd Module', Status.RUNNING,
+          'thread_3_2', 'container_3_2')
+      self.cdm.UpdateModuleThreadState('3rd Module', Status.COMPLETED,
+          'thread_3_0', 'container_3_0')
+      self.cdm.UpdateModuleThreadState('3rd Module', Status.RUNNING,
+          'thread_3_0', 'container_3_4')
+      self.cdm.UpdateModuleThreadState('4th Module', Status.RUNNING,
+          'thread_4_0', 'container_4_0')
+      self.cdm.UpdateModuleThreadState('4th Module', Status.RUNNING,
+          'thread_4_1', 'container_4_1')
+      self.cdm.UpdateModuleThreadState('4th Module', Status.RUNNING,
+          'thread_4_2', 'container_4_2')
+      self.cdm.UpdateModuleThreadState('4th Module', Status.COMPLETED,
+          'thread_4_0', 'container_4_0')
+      self.cdm.UpdateModuleThreadState('4th Module', Status.RUNNING,
+          'thread_4_0', 'container_4_4')
+
+      try:
+        raise RuntimeError('Test Exception')
+      except RuntimeError as e:
+        self.cdm.SetException(e)
+
+      for i in range(10):
+        self.cdm.EnqueueMessage('source', f'Message {i}')
+
+    with mock.patch.object(self.cdm._stdscr, 'getmaxyx') as mock_getmaxyx, \
+        mock.patch.object(self.cdm._stdscr, 'clear') as mock_clear, \
+        mock.patch.object(self.cdm._stdscr, 'addstr') as mock_addstr:
+      mock_getmaxyx.return_value = 10, 140
+      mock_addstr.side_effect = [None, None, None, None, None, None, None, None,
+                                 curses.error(), None, None, None]
+
+      self.cdm.Draw()
+
+      mock_clear.assert_called_once_with()
+      # pylint: disable=line-too-long
+      mock_addstr.assert_has_calls([
+          mock.call(0, 0, ' Recipe name'),
+          mock.call(1, 0, '   Preflights:'),
+          mock.call(2, 0, '     1st Preflight: Completed'),
+          mock.call(3, 0, '     2nd Preflight: Completed'),
+          mock.call(4, 0, '   Modules:'),
+          mock.call(5, 0, '     1st Module: Completed'),
+          mock.call(6, 0, '     2nd Module: Running'),
+          mock.call(7, 0, '     3rd Module: Processing - 1 of 5 containers completed'),
+          mock.call(8, 0, '       thread_3_0: Running (container_3_4)'),
+          mock.call(7, 0, '*********************************************************************** '),
+          mock.call(8, 0, '*** Terminal not large enough, consider increasing your window size *** '),
+          mock.call(9, 0, '*********************************************************************** ')])
+      self.assertEqual(mock_addstr.call_count, 12)
+      # pylint: enable=line-too-long
+
 
 class CDMStringIOWrapperTest(unittest.TestCase):
   """Tests for the CDMStringIOWrapper class."""

--- a/tests/cli/curses_display_manager.py
+++ b/tests/cli/curses_display_manager.py
@@ -437,23 +437,24 @@ class CursesDisplayManagerTest(unittest.TestCase):
       mock_clear.assert_called_once_with()
       # pylint: disable=line-too-long
       mock_addstr.assert_has_calls([
-          mock.call(1, 0,  ' Recipe name'),
-          mock.call(2, 0,  '   Preflights:'),
-          mock.call(3, 0,  '     1st Preflight: Completed'),
-          mock.call(4, 0,  '     2nd Preflight: Completed'),
-          mock.call(5, 0,  '   Modules:'),
-          mock.call(6, 0,  '     1st Module: Completed'),
-          mock.call(7, 0,  '     2nd Module: Running'),
-          mock.call(8, 0,  '     3rd Module: Processing - 1 of 5 containers completed'),
-          mock.call(9, 0,  '       thread_3_0: Running (container_3_4)'),
-          mock.call(10, 0, '       thread_3_1: Running (container_3_1)'),
-          mock.call(11, 0, '       thread_3_2: Running (container_3_2)'),
-          mock.call(12, 0, '     4th Module: Processing - 1 of 8 containers completed'),
-          mock.call(13, 0, '       thread_4_0: Running (container_4_4)'),
-          mock.call(14, 0, '       thread_4_1: Running (container_4_1)'),
-          mock.call(15, 0, '       thread_4_2: Running (container_4_2)'),
-          mock.call(16, 0, '     5th Module: Pending (2nd Module, 3rd Module, 4th Module)'),
-          mock.call(18, 0, ' Messages:'),
+          mock.call(0, 0,  ' Recipe name'),
+          mock.call(1, 0,  '   Preflights:'),
+          mock.call(2, 0,  '     1st Preflight: Completed'),
+          mock.call(3, 0,  '     2nd Preflight: Completed'),
+          mock.call(4, 0,  '   Modules:'),
+          mock.call(5, 0,  '     1st Module: Completed'),
+          mock.call(6, 0,  '     2nd Module: Running'),
+          mock.call(7, 0,  '     3rd Module: Processing - 1 of 5 containers completed'),
+          mock.call(8, 0,  '       thread_3_0: Running (container_3_4)'),
+          mock.call(9, 0, '       thread_3_1: Running (container_3_1)'),
+          mock.call(10, 0, '       thread_3_2: Running (container_3_2)'),
+          mock.call(11, 0, '     4th Module: Processing - 1 of 8 containers completed'),
+          mock.call(12, 0, '       thread_4_0: Running (container_4_4)'),
+          mock.call(13, 0, '       thread_4_1: Running (container_4_1)'),
+          mock.call(14, 0, '       thread_4_2: Running (container_4_2)'),
+          mock.call(15, 0, '     5th Module: Pending (2nd Module, 3rd Module, 4th Module)'),
+          mock.call(17, 0, ' Messages:'),
+          mock.call(18, 0, '  [ source ] Message 2'),
           mock.call(19, 0, '  [ source ] Message 3'),
           mock.call(20, 0, '  [ source ] Message 4'),
           mock.call(21, 0, '  [ source ] Message 5'),
@@ -462,7 +463,7 @@ class CursesDisplayManagerTest(unittest.TestCase):
           mock.call(24, 0, '  [ source ] Message 8'),
           mock.call(25, 0, '  [ source ] Message 9'),
           mock.call(28, 0, ' Exception encountered: Test Exception')])
-      self.assertEqual(mock_addstr.call_count, 25)
+      self.assertEqual(mock_addstr.call_count, 26)
       # pylint: enable=line-too-long
 
 class CDMStringIOWrapperTest(unittest.TestCase):


### PR DESCRIPTION
In curses mode, if the terminal is too short (read: has too few rows) the cursor moves off the screen, and an uncaught exception is thrown. This PR catches that exception and advises the user they may wish to make the terminal larger, and keeps running the recipe. 