### PR TITLE
GetContainers() filter on metadata

### DIFF
--- a/dftimewolf/lib/containers/interface.py
+++ b/dftimewolf/lib/containers/interface.py
@@ -56,5 +56,6 @@ class AttributeContainer():
 
     Args:
       key: Metadata key
-      value: Metadata value"""
+      value: Metadata value
+    """
     self.metadata[key] = value

--- a/dftimewolf/lib/containers/interface.py
+++ b/dftimewolf/lib/containers/interface.py
@@ -50,3 +50,11 @@ class AttributeContainer():
       attribute_names.append(attribute_name)
 
     return attribute_names
+
+  def SetMetadata(self, key: str, value: Any) -> None:
+    """Sets metadata to the container.
+
+    Args:
+      key: Metadata key
+      value: Metadata value"""
+    self.metadata[key] = value

--- a/dftimewolf/lib/state.py
+++ b/dftimewolf/lib/state.py
@@ -283,24 +283,24 @@ class DFTimewolfState(object):
       raise RuntimeError('Must specify both key and value for attribute filter')
 
     with self._state_lock:
-      container_objects = []
+      ret_val = []
       containers = self.store.get(container_class.CONTAINER_TYPE, [])
       self.store[container_class.CONTAINER_TYPE] = []
 
       for c in containers:
         if metadata_filter_key:
           if c.metadata.get(metadata_filter_key) == metadata_filter_value:
-            container_objects.append(c)
+            ret_val.append(c)
           else:
             self.store[container_class.CONTAINER_TYPE].append(c)
         else:
-          container_objects.append(c)
+          ret_val.append(c)
 
       if not pop:
-        for c in container_objects:
+        for c in ret_val:
           self.store[container_class.CONTAINER_TYPE].append(c)
 
-      return cast(Sequence[T], container_objects)
+      return cast(Sequence[T], ret_val)
 
   def DedupeContainers(self, container_class: Type[T]) -> None:
     """Thread safe deduping of containers of the given type.

--- a/dftimewolf/lib/state.py
+++ b/dftimewolf/lib/state.py
@@ -10,7 +10,7 @@ import importlib
 import logging
 import threading
 import traceback
-from typing import TYPE_CHECKING, Callable, Dict, List, Sequence, Type, Any, TypeVar, cast  # pylint: disable=line-too-long
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Sequence, Type, Any, TypeVar, cast  # pylint: disable=line-too-long
 from dftimewolf.cli import curses_display_manager as cdm
 
 from dftimewolf.config import Config
@@ -260,24 +260,54 @@ class DFTimewolfState(object):
 
   def GetContainers(self,
                     container_class: Type[T],
-                    pop: bool=False) -> Sequence[T]:
+                    pop: bool=False,
+                    metadata_filter_key: Optional[str]=None,
+                    metadata_filter_value: Optional[Any]=None) -> Sequence[T]:
     """Thread-safe method to retrieve data from the state's store.
 
     Args:
       container_class (type): AttributeContainer class used to filter data.
       pop (Optional[bool]): Whether to remove the containers from the state when
           they are retrieved.
+      metadata_filter_key (Optional[str]): Metadata key to filter on.
+      metadata_filter_value (Optional[Any]): Metadata value to filter on.
 
     Returns:
       Collection[AttributeContainer]: attribute container objects provided in
           the store that correspond to the container type.
+
+    Raises:
+      RuntimeError: If only one metadata filter parameter is specified.
     """
+    if bool(metadata_filter_key) ^ bool(metadata_filter_value):  # logical XOR
+      raise RuntimeError('Must specify both key and value for attribute filter')
+
     with self._state_lock:
-      container_objects = cast(
-          List[T], self.store.get(container_class.CONTAINER_TYPE, []))
-      if pop:
-        self.store[container_class.CONTAINER_TYPE] = []
-      return tuple(container_objects)
+      container_objects = []
+      containers = self.store.get(container_class.CONTAINER_TYPE, [])
+      self.store[container_class.CONTAINER_TYPE] = []
+
+      for c in containers:
+        if metadata_filter_key:
+          if c.metadata.get(metadata_filter_key) == metadata_filter_value:
+            container_objects.append(c)
+          else:
+            self.store[container_class.CONTAINER_TYPE].append(c)
+        else:
+          container_objects.append(c)
+
+      if not pop:
+        for c in container_objects:
+          self.store[container_class.CONTAINER_TYPE].append(c)
+
+      return cast(Sequence[T], container_objects)
+
+#    with self._state_lock:
+#      container_objects = cast(
+#          List[T], self.store.get(container_class.CONTAINER_TYPE, []))
+#      if pop:
+#        self.store[container_class.CONTAINER_TYPE] = []
+#      return tuple(container_objects)
 
   def DedupeContainers(self, container_class: Type[T]) -> None:
     """Thread safe deduping of containers of the given type.

--- a/dftimewolf/lib/state.py
+++ b/dftimewolf/lib/state.py
@@ -302,13 +302,6 @@ class DFTimewolfState(object):
 
       return cast(Sequence[T], container_objects)
 
-#    with self._state_lock:
-#      container_objects = cast(
-#          List[T], self.store.get(container_class.CONTAINER_TYPE, []))
-#      if pop:
-#        self.store[container_class.CONTAINER_TYPE] = []
-#      return tuple(container_objects)
-
   def DedupeContainers(self, container_class: Type[T]) -> None:
     """Thread safe deduping of containers of the given type.
 

--- a/tests/lib/containers/interface.py
+++ b/tests/lib/containers/interface.py
@@ -23,6 +23,14 @@ class AttributeContainerTest(unittest.TestCase):
 
     self.assertEqual(attribute_names, expected_attribute_names)
 
+  def testSetMetadata(self):
+    """Tests setting and retrieving metadata set on a container."""
+    cont = interface.AttributeContainer()
+    cont.SetMetadata('source_module', 'example_module_name')
+
+    self.assertEqual(len(cont.metadata.keys()), 1)
+    self.assertEqual(cont.metadata['source_module'], 'example_module_name')
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/lib/state.py
+++ b/tests/lib/state.py
@@ -157,26 +157,26 @@ class StateTest(unittest.TestCase):
 
     # Test incorrect filters retrieve nothing
     filtered = test_state.GetContainers(thread_aware_modules.TestContainer,
-                                             False,
-                                             'metadata_key',
-                                             'incorrect_value')
+                                        False,
+                                        'metadata_key',
+                                        'incorrect_value')
     full_list = test_state.GetContainers(thread_aware_modules.TestContainer)
     self.assertEqual(len(filtered), 0)  # None retrieved
     self.assertEqual(len(full_list), 3)  # None removed since none were popped
 
     filtered = test_state.GetContainers(thread_aware_modules.TestContainer,
-                                             False,
-                                             'incorrect_key',
-                                             'metadata_value')
+                                        False,
+                                        'incorrect_key',
+                                        'metadata_value')
     full_list = test_state.GetContainers(thread_aware_modules.TestContainer)
     self.assertEqual(len(filtered), 0)  # None retrieved
     self.assertEqual(len(full_list), 3)  # None removed since none were popped
 
     # Test retrieval, without popping
     filtered = test_state.GetContainers(thread_aware_modules.TestContainer,
-                                             False,
-                                             'metadata_key',
-                                             '1')
+                                        False,
+                                        'metadata_key',
+                                        '1')
     full_list = test_state.GetContainers(thread_aware_modules.TestContainer)
     self.assertEqual(len(filtered), 1)  # One retrieved
     self.assertEqual(len(full_list), 3)  # None removed since none were popped
@@ -185,9 +185,9 @@ class StateTest(unittest.TestCase):
 
     # Test retrieval, with popping
     filtered = test_state.GetContainers(thread_aware_modules.TestContainer,
-                                             True,
-                                             'metadata_key',
-                                             '1')
+                                        True,
+                                        'metadata_key',
+                                        '1')
     remaining = test_state.GetContainers(thread_aware_modules.TestContainer)
     self.assertEqual(len(filtered), 1)  # One retrieved
     self.assertEqual(len(remaining), 2)  # One popped


### PR DESCRIPTION
Added ability to set metadata on a container, and then use that metadata to filter retrieval of containers via state.GetContainer()