### PR TITLE
Enable dir_exists_ok in LocalFilesystemCopy

### DIFF
--- a/dftimewolf/lib/exporters/local_filesystem.py
+++ b/dftimewolf/lib/exporters/local_filesystem.py
@@ -2,9 +2,7 @@
 """Local file system exporter module."""
 
 import os
-import random
 import shutil
-import string
 import tempfile
 from typing import List, Optional
 
@@ -96,11 +94,7 @@ class LocalFilesystemCopy(module.BaseModule):
     full_paths = []
     if os.path.isdir(source):
       try:
-        if os.path.exists(destination_directory):
-          destination_directory = "{0:s}/{1:s}".format(
-              destination_directory,
-              ''.join(random.choices(string.ascii_uppercase, k=10)))
-        shutil.copytree(source, destination_directory)
+        shutil.copytree(source, destination_directory, dirs_exist_ok=True)
         full_paths.append(destination_directory)
       except shutil.Error as e:
         self.ModuleError(str(e), critical=True)

--- a/tests/lib/exporters/local_filesystem.py
+++ b/tests/lib/exporters/local_filesystem.py
@@ -62,8 +62,8 @@ class LocalFileSystemTest(unittest.TestCase):
     local_filesystem_copy.Process()
 
     mock_copytree.assert_has_calls([
-        mock.call('/fake/evidence_directory',
-            '/fake/random'),
+        mock.call(
+            '/fake/evidence_directory', '/fake/random', dirs_exist_ok=True)
     ])
     mock_copy2.assert_called_with('/fake/evidence_file', '/fake/random')
 


### PR DESCRIPTION
Enable `dir_exist_ok` in LocalFilesystemCopy so that output files do not have a random string named directory to ensure uniqueness.

Now that support for 3.7 has been dropped (#566), we can revert #471 (the `dir_exists_ok` option was introduced in 3.8.)