### PR TITLE
Fix links to recipes in doc

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -49,9 +49,9 @@ dfTimewolf follows the
 
 If you're not satisfied with the way modules are chained, or default arguments
 that are passed to some of the recipes, then you can create your own. See
-[existing recipes](https://github.com/log2timeline/dftimewolf/tree/main/dftimewolf/cli/recipes)
+[existing recipes](https://github.com/log2timeline/dftimewolf/tree/main/data/recipes)
 for simple examples like
-[local_plaso](https://github.com/log2timeline/dftimewolf/blob/main/dftimewolf/cli/recipes/local_plaso.py).
+[plaso_ts](https://github.com/log2timeline/dftimewolf/blob/main/data/recipes/plaso_ts.json).
 Details on recipe keys are given [here](architecture.md#recipes).
 
 ### Recipe location


### PR DESCRIPTION
The section in the documentation describing how to create recipes contained two links that didn't work. These habe been fixed. However, recipe `local_plaso` mentioned in the text no longer exists. It has been replaced by the recipe `plaso_ts` as an example.