### PR TITLE
Remove references to `pip`

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -25,6 +25,9 @@ jobs:
       run: |
         pip install poetry
         poetry install
-    - name: Test dftimewolf shortcut
+    - name: Test running with full Python path
+      run: |
+        poetry run python dftimewolf/cli/dftimewolf_recipes.py -h
+    - name: Test Python script shortcut
       run: |
         poetry run python dftimewolf/cli/dftimewolf_recipes.py -h

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -30,4 +30,4 @@ jobs:
         poetry run python dftimewolf/cli/dftimewolf_recipes.py -h
     - name: Test Python script shortcut
       run: |
-        poetry run python dftimewolf/cli/dftimewolf_recipes.py -h
+        poetry run dftimewolf -h

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -115,7 +115,7 @@ There are two locations to register new modules:
 It is recommended to run tests locally to discover issues early in the development lifecycle.
 
 ```bash
-pip install pipenv
-pipenv install --dev
-python -m unittest discover -s tests -p '*.py'
+pip install poetry
+poetry install
+poetry run python -m unittest discover -s tests -p '*.py'
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,8 +6,8 @@ Ideally you'll want to install dftimewolf in its own virtual environment.
 
 ```code
 git clone https://github.com/log2timeline/dftimewolf.git && cd dftimewolf
-pip install -r requirements.txt
-pip install -e .
+pip install poetry
+poetry install
 ```
 
 <div class="admonition note">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Thomas Chopitea <tomchop@gmail.com>"]
 license = "Apache"
 
 [tool.poetry.scripts]
-dftimewolf = 'dftimewolf.cli.dftimewolf_recipes:main'
+dftimewolf = 'dftimewolf.cli.dftimewolf_recipes:Main'
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ description = ""
 authors = ["Thomas Chopitea <tomchop@gmail.com>"]
 license = "Apache"
 
+[tool.poetry.scripts]
+dftimewolf = 'dftimewolf.cli.dftimewolf_recipes:main'
+
 [tool.poetry.dependencies]
 python = ">=3.9,<3.11"
 docker = "^5.0.3"


### PR DESCRIPTION
* Remove references to `pip`. This was confusing for users (rightly so, as the documentation mentions this is the way to install dftimewolf). We now exclusively use `poetry` to install this package.
* Add a `poetry.script` reference to `pyproject.toml` to ensure that the `dftimewolf` script is available in poetry's virtualenv. 