### PR TITLE
Feature backoff and delay

### DIFF
--- a/data/recipes/gcp_logging_cloudaudit_ts.json
+++ b/data/recipes/gcp_logging_cloudaudit_ts.json
@@ -14,7 +14,7 @@
         "name": "GCPLogsCollector",
         "args": {
             "project_name": "@project_name",
-            "filter_expression": "@filter_expression",
+            "filter_expression": "logName=projects/@project_name/logs/cloudaudit.googleapis.com%2Factivity timestamp>\"@start_date\" timestamp<\"@end_date\"",
             "backoff": "@backoff",
             "delay": "@delay"
         }
@@ -40,6 +40,8 @@
         ["--incident_id", "Incident ID (used for Timesketch description).", null],
         ["--sketch_id", "Timesketch sketch to which the timeline should be added.", null],
         ["--token_password", "Optional custom password to decrypt Timesketch credential file with.", ""],
-        ["--wait_for_timelines", "Whether to wait for Timesketch to finish processing all timelines.", true]
+        ["--wait_for_timelines", "Whether to wait for Timesketch to finish processing all timelines.", true],
+        ["--backoff", "If GCP Cloud Logging API query limits are exceeded, retry with an increased delay between each query to try complete the query at a slower rate.", false],
+        ["--delay", "Number of seconds to wait between each GCP Cloud Logging query to avoid hitting API query limits", 0]
     ]
 }

--- a/data/recipes/gcp_logging_cloudaudit_ts.json
+++ b/data/recipes/gcp_logging_cloudaudit_ts.json
@@ -14,7 +14,9 @@
         "name": "GCPLogsCollector",
         "args": {
             "project_name": "@project_name",
-            "filter_expression": "logName=projects/@project_name/logs/cloudaudit.googleapis.com%2Factivity timestamp>\"@start_date\" timestamp<\"@end_date\""
+            "filter_expression": "@filter_expression",
+            "backoff": "@backoff",
+            "delay": "@delay"
         }
     }, {
         "wants": ["GCPLogsCollector"],

--- a/data/recipes/gcp_logging_cloudsql_ts.json
+++ b/data/recipes/gcp_logging_cloudsql_ts.json
@@ -15,8 +15,10 @@
       "name": "GCPLogsCollector",
       "args": {
         "project_name": "@project_name",
-        "filter_expression": "logName:\"projects/@project_name/logs/cloudsql.googleapis.com\" timestamp>\"@start_date\" timestamp<\"@end_date\""
-      }
+        "filter_expression": "@filter_expression",
+        "backoff": "@backoff",
+        "delay": "@delay"
+    }
     },
     {
       "wants": ["GCPLogsCollector"],

--- a/data/recipes/gcp_logging_cloudsql_ts.json
+++ b/data/recipes/gcp_logging_cloudsql_ts.json
@@ -15,7 +15,7 @@
       "name": "GCPLogsCollector",
       "args": {
         "project_name": "@project_name",
-        "filter_expression": "@filter_expression",
+        "filter_expression": "logName:\"projects/@project_name/logs/cloudsql.googleapis.com\" timestamp>\"@start_date\" timestamp<\"@end_date\"",
         "backoff": "@backoff",
         "delay": "@delay"
     }
@@ -44,6 +44,8 @@
     ["--incident_id", "Incident ID (used for Timesketch description).", null],
     ["--sketch_id", "Timesketch sketch to which the timeline should be added.", null],
     ["--token_password", "Optional custom password to decrypt Timesketch credential file with.", ""],
-    ["--wait_for_timelines", "Whether to wait for Timesketch to finish processing all timelines.", true]
+    ["--wait_for_timelines", "Whether to wait for Timesketch to finish processing all timelines.", true],
+    ["--backoff", "If GCP Cloud Logging API query limits are exceeded, retry with an increased delay between each query to try complete the query at a slower rate.", false],
+    ["--delay", "Number of seconds to wait between each GCP Cloud Logging query to avoid hitting API query limits", 0]
   ]
 }

--- a/data/recipes/gcp_logging_collect.json
+++ b/data/recipes/gcp_logging_collect.json
@@ -14,11 +14,15 @@
         "name": "GCPLogsCollector",
         "args": {
             "project_name": "@project_name",
-            "filter_expression": "@filter_expression"
+            "filter_expression": "@filter_expression",
+            "backoff": "@backoff",
+            "delay": "@delay"
         }
     }],
     "args": [
         ["project_name", "Name of the GCP project to collect logs from.", null],
-        ["filter_expression", "Filter expression to use to query GCP logs. See https://cloud.google.com/logging/docs/view/query-library for examples.", "resource.type = 'gce_instance'"]
+        ["filter_expression", "Filter expression to use to query GCP logs. See https://cloud.google.com/logging/docs/view/query-library for examples.", "resource.type = 'gce_instance'"],
+        ["--backoff", "If API query limits are exceeded, retry with an increased delay between each query to try complete the query at a slower rate.", false],
+        ["--delay", "Number of seconds to wait between each query to avoid hitting API query limits", 0]
     ]
 }

--- a/data/recipes/gcp_logging_collect.json
+++ b/data/recipes/gcp_logging_collect.json
@@ -22,7 +22,7 @@
     "args": [
         ["project_name", "Name of the GCP project to collect logs from.", null],
         ["filter_expression", "Filter expression to use to query GCP logs. See https://cloud.google.com/logging/docs/view/query-library for examples.", "resource.type = 'gce_instance'"],
-        ["--backoff", "If API query limits are exceeded, retry with an increased delay between each query to try complete the query at a slower rate.", false],
-        ["--delay", "Number of seconds to wait between each query to avoid hitting API query limits", 0]
+        ["--backoff", "If GCP Cloud Logging API query limits are exceeded, retry with an increased delay between each query to try complete the query at a slower rate.", false],
+        ["--delay", "Number of seconds to wait between each GCP Cloud Logging query to avoid hitting API query limits", 0]
     ]
 }

--- a/data/recipes/gcp_logging_gce_instance_ts.json
+++ b/data/recipes/gcp_logging_gce_instance_ts.json
@@ -14,7 +14,9 @@
         "name": "GCPLogsCollector",
         "args": {
             "project_name": "@project_name",
-            "filter_expression": "logName=projects/@project_name/logs/cloudaudit.googleapis.com%2Factivity operation.producer=\"compute.googleapis.com\" resource.labels.instance_id=\"@instance_id\""
+            "filter_expression": "@filter_expression",
+            "backoff": "@backoff",
+            "delay": "@delay"
         }
     }, {
         "wants": ["GCPLogsCollector"],

--- a/data/recipes/gcp_logging_gce_instance_ts.json
+++ b/data/recipes/gcp_logging_gce_instance_ts.json
@@ -14,7 +14,7 @@
         "name": "GCPLogsCollector",
         "args": {
             "project_name": "@project_name",
-            "filter_expression": "@filter_expression",
+            "filter_expression": "logName=projects/@project_name/logs/cloudaudit.googleapis.com%2Factivity operation.producer=\"compute.googleapis.com\" resource.labels.instance_id=\"@instance_id\"",
             "backoff": "@backoff",
             "delay": "@delay"
         }
@@ -39,6 +39,8 @@
         ["--incident_id", "Incident ID (used for Timesketch description).", null],
         ["--sketch_id", "Timesketch sketch to which the timeline should be added.", null],
         ["--token_password", "Optional custom password to decrypt Timesketch credential file with.", ""],
-        ["--wait_for_timelines", "Whether to wait for Timesketch to finish processing all timelines.", true]
+        ["--wait_for_timelines", "Whether to wait for Timesketch to finish processing all timelines.", true],
+        ["--backoff", "If GCP Cloud Logging API query limits are exceeded, retry with an increased delay between each query to try complete the query at a slower rate.", false],
+        ["--delay", "Number of seconds to wait between each GCP Cloud Logging query to avoid hitting API query limits", 0]
     ]
 }

--- a/data/recipes/gcp_logging_gce_ts.json
+++ b/data/recipes/gcp_logging_gce_ts.json
@@ -14,7 +14,9 @@
         "name": "GCPLogsCollector",
         "args": {
             "project_name": "@project_name",
-            "filter_expression": "logName=projects/@project_name/logs/cloudaudit.googleapis.com%2Factivity resource.type:\"gce\" timestamp>\"@start_date\" timestamp<\"@end_date\""
+            "filter_expression": "@filter_expression",
+            "backoff": "@backoff",
+            "delay": "@delay"
         }
     }, {
         "wants": ["GCPLogsCollector"],

--- a/data/recipes/gcp_logging_gce_ts.json
+++ b/data/recipes/gcp_logging_gce_ts.json
@@ -14,7 +14,7 @@
         "name": "GCPLogsCollector",
         "args": {
             "project_name": "@project_name",
-            "filter_expression": "@filter_expression",
+            "filter_expression": "logName=projects/@project_name/logs/cloudaudit.googleapis.com%2Factivity resource.type:\"gce\" timestamp>\"@start_date\" timestamp<\"@end_date\"",
             "backoff": "@backoff",
             "delay": "@delay"
         }
@@ -40,6 +40,8 @@
         ["--incident_id", "Incident ID (used for Timesketch description).", null],
         ["--sketch_id", "Timesketch sketch to which the timeline should be added.", null],
         ["--token_password", "Optional custom password to decrypt Timesketch credential file with.", ""],
-        ["--wait_for_timelines", "Whether to wait for Timesketch to finish processing all timelines.", true]
+        ["--wait_for_timelines", "Whether to wait for Timesketch to finish processing all timelines.", true],
+        ["--backoff", "If GCP Cloud Logging API query limits are exceeded, retry with an increased delay between each query to try complete the query at a slower rate.", false],
+        ["--delay", "Number of seconds to wait between each GCP Cloud Logging query to avoid hitting API query limits", 0]
     ]
 }

--- a/dftimewolf/lib/collectors/gcp_logging.py
+++ b/dftimewolf/lib/collectors/gcp_logging.py
@@ -84,6 +84,9 @@ class GCPLogsCollector(module.BaseModule):
       backoff_multiplier (str): Query delay multiplier if the API quota is met and backoff is enabled
       output_file (str): Output file name
       output_path (str): Output file path
+    
+    Returns:
+      output_path (str): Log output path (may have been updated if API quota was exceeded)
     """
     while True:
       try:

--- a/dftimewolf/lib/collectors/gcp_logging.py
+++ b/dftimewolf/lib/collectors/gcp_logging.py
@@ -16,8 +16,6 @@ from dftimewolf.lib.containers import containers
 from dftimewolf.lib.modules import manager as modules_manager
 from dftimewolf.lib.state import DFTimewolfState
 
-MAX_RETRIES = 10
-
 # Monkey patching the ProtobufEntry because of various issues, notably
 # https://github.com/googleapis/google-cloud-python/issues/7918
 
@@ -42,75 +40,118 @@ class GCPLogsCollector(module.BaseModule):
     super(GCPLogsCollector, self).__init__(state, name=name, critical=critical)
     self._filter_expression = ''
     self._project_name = ''
+    self._backoff = False
+    self._delay = 0
+
+  def OutputFile(self):
+    """Generate an output file name and path"""
+    output_file = tempfile.NamedTemporaryFile(
+        mode='w', delete=False, encoding='utf-8', suffix='.jsonl')
+    output_path = output_file.name
+    self.logger.info('Downloading logs to {0:s}'.format(output_path))
+    return output_file, output_path
+
+  def SetupLoggingClient(self):
+    """Sets up a GCP Logging Client
+    
+    Args:
+      N/A
+    """
+    if self._project_name:
+      return logging.Client(_use_grpc=False,  # type: ignore
+                                        project=self._project_name)
+    else:
+      return logging.Client(_use_grpc=False)  # type: ignore
+  
+  def ListPages(self, logging_client):
+    """Returns pages based on a Cloud Logging filter
+    
+    Args:
+      logging_client: A GCP Cloud Logging client
+    """
+    results = logging_client.list_entries(  # type: ignore
+          order_by=logging.DESCENDING,
+          filter_=self._filter_expression,
+          page_size=1000)
+    return results.pages
+
+  def ProcessPages(self, pages, backoff_multiplier, output_file, output_path):
+    """Iterates through a generator or pages and saves logs to disk.
+    Can optionally perform exponential backoff if query API limits are exceeded.
+    
+    Args:
+      pages (generator): A google cloud logging list_entries generator pages object
+      backoff_multiplier (str): Query delay multiplier if the API quota is met and backoff is enabled
+      output_file (str): Output file name
+      output_path (str): Output file path
+    """
+    while True:
+      try:
+        time.sleep(self._delay)
+        page = next(pages)
+      except google_api_exceptions.TooManyRequests as exception:
+        self.PublishMessage('Hit quota limit requesting GCP logs.')
+        if self._backoff is True:
+          self.PublishMessage('Retrying in 60 seconds with a slower query rate.')
+          self.PublishMessage('Due to the GCP logging API, the query must restart from the beginning')
+          time.sleep(60)
+          if self._delay == 0:
+            self._delay = 1
+          else:
+            self._delay *= backoff_multiplier
+          self.PublishMessage('Setting up new logging client.')
+          logging_client = self.SetupLoggingClient()
+          pages = self.ListPages(logging_client)
+          self.PublishMessage('Restarting query with an API request rate of 1 per {0}s'.format(self._delay))
+          output_file, output_path = self.OutputFile()
+        else:
+          self.PublishMessage('Exponential backoff was not enabled, so query has exited.')
+          self.PublishMessage('The collection is most likely incomplete.')
+      except StopIteration:
+        break
+
+      for entry in page:
+        log_dictionary = entry.to_api_repr()
+        output_file.write(json.dumps(log_dictionary))
+        output_file.write('\n')
+    
+    return output_path
 
   # pylint: disable=arguments-differ
-  def SetUp(self, project_name: str, filter_expression: str) -> None:
+  def SetUp(self, project_name: str, filter_expression: str, backoff: bool, delay: str) -> None:
     """Sets up a a GCP logs collector.
 
     Args:
       project_name (str): name of the project to fetch logs from.
       filter_expression (str): GCP advanced logs filter expression.
+      backoff (bool): Retry queries with an increased delay when API quotas are exceeded.
+      delay (str): Seconds to wait between retreiving results pages to avoid exceeding API quotas
     """
     self._project_name = project_name
     self._filter_expression = filter_expression
+    self._backoff = backoff
+    self._delay = float(delay)
+    self.PublishMessage(f'backoff {self._backoff}')
+    self.PublishMessage(f'delay {self._delay}')
 
   def Process(self) -> None:
     """Copies logs from a cloud project."""
 
-    output_file = tempfile.NamedTemporaryFile(
-        mode='w', delete=False, encoding='utf-8', suffix='.jsonl')
-    output_path = output_file.name
-    self.logger.info(f'Downloading logs to {output_path:s}')
+    output_file, output_path = self.OutputFile()
 
     try:
-      if self._project_name:
-        logging_client = logging.Client(_use_grpc=False,  # type: ignore
-                                        project=self._project_name)
-      else:
-        logging_client = logging.Client(_use_grpc=False)  # type: ignore
+      'Setup a logging client'
+      logging_client = self.SetupLoggingClient()
+      
+      'Get a generator of query results'
+      pages = self.ListPages(logging_client)
 
-      results = logging_client.list_entries(  # type: ignore
-          order_by=logging.DESCENDING,
-          filter_=self._filter_expression,
-          page_size=1000)
-
-      pages = results.pages
-
-      have_results = True
-      while have_results:
-        have_page = False
-        page = []
-        retries = 0
-        while not have_page and retries < MAX_RETRIES:
-          try:
-            page = next(pages)
-            have_page = True
-          except google_api_exceptions.TooManyRequests as exception:
-            retries += 1
-            self.logger.warning(
-                'Hit quota limit requesting GCP logs (retries {0:d} of {1:d}): '
-                '{2:s}'.format(
-                    retries, MAX_RETRIES, str(exception)))
-            time.sleep(4)
-            continue
-          except StopIteration:
-            have_results = False
-            break
-
-        if not have_page and retries >= MAX_RETRIES:
-          self.ModuleError(
-              f'Hit max retries ({MAX_RETRIES:d}) requesting GCP logs',
-              critical=True)
-
-        for entry in page:
-
-          log_dict = entry.to_api_repr()
-          output_file.write(json.dumps(log_dict))
-          output_file.write('\n')
+      'Iterate through query result pages and save json logs to disk'
+      output_path = self.ProcessPages(pages, 2, output_file, output_path)
 
     except google_api_exceptions.NotFound as exception:
       self.ModuleError(
-          f'Error accessing project: {exception!s}', critical=True)
+          'Error accessing project: {0!s}'.format(exception), critical=True)
 
     except google_api_exceptions.InvalidArgument as exception:
       self.ModuleError(

--- a/dftimewolf/lib/collectors/gcp_logging.py
+++ b/dftimewolf/lib/collectors/gcp_logging.py
@@ -56,6 +56,9 @@ class GCPLogsCollector(module.BaseModule):
 
     Args:
       N/A
+    
+    Returns:
+      logging.Client: A GCP logging client
     """
     if self._project_name:
       return logging.Client(_use_grpc=False,  # type: ignore
@@ -67,6 +70,9 @@ class GCPLogsCollector(module.BaseModule):
 
     Args:
       logging_client: A GCP Cloud Logging client
+    
+    Returns:
+      results.pages: Query result pages generator
     """
     results = logging_client.list_entries(
           order_by=logging.DESCENDING,

--- a/docs/recipe-list.md
+++ b/docs/recipe-list.md
@@ -544,6 +544,8 @@ Parameter|Default value|Description
 `--sketch_id`|`None`|Timesketch sketch to which the timeline should be added.
 `--token_password`|`''`|Optional custom password to decrypt Timesketch credential file with.
 `--wait_for_timelines`|`True`|Whether to wait for Timesketch to finish processing all timelines.
+`--backoff`|`False`|Option to attempt to retry collection at a slower rate if the Cloud Logging API quota is exceeded.
+`--delay`|`0`|Optional number of seconds to delay each Cloud Logging request.
 
 
 
@@ -575,7 +577,8 @@ Parameter|Default value|Description
 `--sketch_id`|`None`|Timesketch sketch to which the timeline should be added.
 `--token_password`|`''`|Optional custom password to decrypt Timesketch credential file with.
 `--wait_for_timelines`|`True`|Whether to wait for Timesketch to finish processing all timelines.
-
+`--backoff`|`False`|Option to attempt to retry collection at a slower rate if the Cloud Logging API quota is exceeded.
+`--delay`|`0`|Optional number of seconds to delay each Cloud Logging request.
 
 
 
@@ -601,7 +604,8 @@ Parameter|Default value|Description
 ---------|-------------|-----------
 `project_name`|`None`|Name of the GCP project to collect logs from.
 `filter_expression`|`"resource.type = 'gce_instance'"`|Filter expression to use to query GCP logs. See https://cloud.google.com/logging/docs/view/query-library for examples.
-
+`--backoff`|`False`|Option to attempt to retry collection at a slower rate if the Cloud Logging API quota is exceeded.
+`--delay`|`0`|Optional number of seconds to delay each Cloud Logging request.
 
 
 
@@ -631,7 +635,8 @@ Parameter|Default value|Description
 `--sketch_id`|`None`|Timesketch sketch to which the timeline should be added.
 `--token_password`|`''`|Optional custom password to decrypt Timesketch credential file with.
 `--wait_for_timelines`|`True`|Whether to wait for Timesketch to finish processing all timelines.
-
+`--backoff`|`False`|Option to attempt to retry collection at a slower rate if the Cloud Logging API quota is exceeded.
+`--delay`|`0`|Optional number of seconds to delay each Cloud Logging request.
 
 
 
@@ -662,7 +667,8 @@ Parameter|Default value|Description
 `--sketch_id`|`None`|Timesketch sketch to which the timeline should be added.
 `--token_password`|`''`|Optional custom password to decrypt Timesketch credential file with.
 `--wait_for_timelines`|`True`|Whether to wait for Timesketch to finish processing all timelines.
-
+`--backoff`|`False`|Option to attempt to retry collection at a slower rate if the Cloud Logging API quota is exceeded.
+`--delay`|`0`|Optional number of seconds to delay each Cloud Logging request.
 
 
 


### PR DESCRIPTION
This PR adds two optional arguments to the gcp_logging_collect recipe: backoff and delay. These are introduced to help manage GCP's logging api limits, which I have regularly exceeded when using dftimewolf.

Both are disabled by default, so should not impact existing dftimewolf workflows.

Backoff is a boolean value, which if True, will retry log collection if the GCP logging API quota is exceeded. Due to the way the logging API handles subsequent requests after exceeding an the API limit (https://github.com/log2timeline/dftimewolf/issues/679), a new cloud logging client must be created for the re-try. This means the collection must start again. If no delay was configured, the collection will be retried with a delay of 1s between each request. If a delay was configured, the collection will be retried with a delay of 2x the set value.

Delay is the number of seconds to delay between each API request.

When dftimewolf if run without delay or backoff arguments, and the API limit is exceeded, the output will look like this:
```
poetry run dftimewolf gcp_logging_collect 'projectname' 'timestamp >= "2022-11-30T00:00:00Z" AND timestamp <= "2022-12-08T08:00:00Z"'
  [ dftimewolf       ] Debug log: /tmp/dftimewolf-run-20221202_081136_l_1y_kd9.log
  [ GCPLogsCollector ] backoff False
  [ GCPLogsCollector ] delay 0.0
  [ GCPLogsCollector ] Hit quota limit requesting GCP logs.
  [ GCPLogsCollector ] Exponential backoff was not enabled, so query has exited.
  [ GCPLogsCollector ] The collection is most likely incomplete.
  [ GCPLogsCollector ] Downloaded logs to /tmp/tmpjfwq0jhv.jsonl
```

When backoff and delay are specified, the output will look like this:
```
poetry run dftimewolf gcp_logging_collect 'projectname' 'timestamp >= "2022-11-30T00:00:00Z" AND timestamp <= "2022-12-08T08:00:00Z"' --backoff --delay 1
Messages
  [ dftimewolf       ] Debug log: /tmp/dftimewolf-run-20221202_081057_1ph_z9ws.log
  [ GCPLogsCollector ] backoff True
  [ GCPLogsCollector ] delay 1.0
  [ GCPLogsCollector ] Hit quota limit requesting GCP logs.
  [ GCPLogsCollector ] Retrying in 60 seconds with a slower query rate.
  [ GCPLogsCollector ] Due to the GCP logging API, the query must restart from the beginning
  [ GCPLogsCollector ] Setting up new logging client.
  [ GCPLogsCollector ] Restarting query with an API request rate of 1 per 2s
  [ GCPLogsCollector ] Downloaded logs to /tmp/tmpfr1nz782.jsonl
```

Please note that I had to break up the bulk of the code in the 'Process' function into distinct functions, however most of the code base is the same. I had to break it up because I needed a way to re-call the functions to generate a new logging client, and set a new output path, once the api limit was exceeded.