### PR TITLE
Disable curses if there is no tty

### DIFF
--- a/dftimewolf/cli/dftimewolf_recipes.py
+++ b/dftimewolf/cli/dftimewolf_recipes.py
@@ -443,8 +443,9 @@ def Main() -> bool:
 
   Returns:
     bool: True if DFTimewolf could be run successfully, False otherwise."""
-  no_curses = bool(os.environ.get('DFTIMEWOLF_NO_CURSES'))
-
+  no_curses = any([bool(os.environ.get('DFTIMEWOLF_NO_CURSES')),
+                   not sys.stdout.isatty(),
+                   not sys.stdin.isatty()])
   SetupLogging(no_curses)
 
   if any([no_curses, '-h' in sys.argv, '--help' in sys.argv]):


### PR DESCRIPTION
Continue in non-curses mode if there is no tty. 

Fixes #616 