### PR TITLE
Fix redraw in curses mode on SIGWINCH

### DIFF
--- a/dftimewolf/cli/curses_display_manager.py
+++ b/dftimewolf/cli/curses_display_manager.py
@@ -9,6 +9,7 @@ import traceback
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import curses
+import shutil
 import signal
 
 
@@ -393,6 +394,7 @@ class CursesDisplayManager:
 
   def SIGWINCH_Handler(self, *unused_argvs: Any) -> None:
     """Redraw the window when SIGWINCH is raised."""
+    curses.resizeterm(*shutil.get_terminal_size())
     self.Draw()
 
 

--- a/tests/cli/curses_display_manager.py
+++ b/tests/cli/curses_display_manager.py
@@ -609,7 +609,8 @@ class CursesDisplayManagerTest(unittest.TestCase):
 
     with mock.patch.object(self.cdm._stdscr, 'getmaxyx') as mock_getmaxyx, \
         mock.patch.object(self.cdm._stdscr, 'clear') as mock_clear, \
-        mock.patch.object(self.cdm._stdscr, 'addstr') as mock_addstr:
+        mock.patch.object(self.cdm._stdscr, 'addstr') as mock_addstr, \
+        mock.patch('curses.resizeterm'):
       mock_getmaxyx.return_value = 30, 140
 
       self.cdm.SIGWINCH_Handler(None, None)


### PR DESCRIPTION
This PR corrects the redraw behaviour when SIGWINCH is raised when curses mode is in use. 