### PR TITLE
Add source basename to destination dir in LocalFilesystemCopy

### DIFF
--- a/dftimewolf/lib/containers/containers.py
+++ b/dftimewolf/lib/containers/containers.py
@@ -236,6 +236,8 @@ class File(interface.AttributeContainer):
 
   def __str__(self) -> str:
     """Override __str()__."""
+    if self.path.endswith(self.name):
+      return self.path  
     return f'{self.path}/{self.name}'
 
   def __eq__(self, other: File) -> bool:

--- a/dftimewolf/lib/containers/containers.py
+++ b/dftimewolf/lib/containers/containers.py
@@ -237,7 +237,7 @@ class File(interface.AttributeContainer):
   def __str__(self) -> str:
     """Override __str()__."""
     if self.path.endswith(self.name):
-      return self.path  
+      return self.path
     return f'{self.path}/{self.name}'
 
   def __eq__(self, other: File) -> bool:

--- a/dftimewolf/lib/exporters/local_filesystem.py
+++ b/dftimewolf/lib/exporters/local_filesystem.py
@@ -95,16 +95,18 @@ class LocalFilesystemCopy(module.BaseModule):
     full_paths = []
     if os.path.isdir(source):
       try:
-        shutil.copytree(source, destination_directory, dirs_exist_ok=True)
-        full_paths.append(destination_directory)
+        basename = source.split('/')[-1]
+        full_paths.append(shutil.copytree(
+            source, 
+            '/'.join([destination_directory, basename]),
+            dirs_exist_ok=True))
       except shutil.Error as e:
         self.ModuleError(str(e), critical=True)
     else:
       try:
-        shutil.copy2(source, destination_directory)
+        full_paths.append(shutil.copy2(source, destination_directory))
       except shutil.SameFileError as exception:
         self.logger.warning(str(exception))
-      full_paths.append(os.path.join(destination_directory, source))
 
     return full_paths
 

--- a/dftimewolf/lib/exporters/local_filesystem.py
+++ b/dftimewolf/lib/exporters/local_filesystem.py
@@ -95,10 +95,10 @@ class LocalFilesystemCopy(module.BaseModule):
     full_paths = []
     if os.path.isdir(source):
       try:
-        basename = source.split('/')[-1]
+        basename = os.path.basename(source)
         full_paths.append(shutil.copytree(
             source,
-            '/'.join([destination_directory, basename]),
+            os.path.join(destination_directory, basename),
             dirs_exist_ok=True))
       except shutil.Error as e:
         self.ModuleError(str(e), critical=True)

--- a/dftimewolf/lib/exporters/local_filesystem.py
+++ b/dftimewolf/lib/exporters/local_filesystem.py
@@ -97,7 +97,7 @@ class LocalFilesystemCopy(module.BaseModule):
       try:
         basename = source.split('/')[-1]
         full_paths.append(shutil.copytree(
-            source, 
+            source,
             '/'.join([destination_directory, basename]),
             dirs_exist_ok=True))
       except shutil.Error as e:


### PR DESCRIPTION
This will prevent errors when outputting to a directory you can write to, but not alter (such as `/tmp`)