### PR TITLE
Add args validation to E2E tests

### DIFF
--- a/data/recipes/aws_disk_to_gcp.json
+++ b/data/recipes/aws_disk_to_gcp.json
@@ -67,7 +67,7 @@
     ["volumes", "Comma separated list of EBS volume IDs (e.g. vol-xxxxxxxx).", null, {"format": "regex", "comma_separated": true, "regex": "^vol-[0-9a-f]{8,17}$"}],
     ["aws_bucket", "AWS bucket for image storage.", null, {"format": "regex", "comma_separated": false, "regex": "^(s3:\/\/)?[0-9a-z][-\\.0-9a-z]{1,61}[0-9a-z]$"}],
     ["gcp_bucket", "GCP bucket for image storage.", null, {"format": "regex", "comma_separated": false, "regex": "^(gs:\/\/)?[0-9a-z][-\\.0-9a-z_]{1,61}[0-9a-z]$"}],
-    ["--subnet", "AWS subnet to copy instances from, required if there is no default subnet in the volume region.", null, {"format": "regex", "comma_separated": true, "regex": "^subnet-[0-9a-f]{8,17}$"}],
+    ["--subnet", "AWS subnet to copy instances from, required if there is no default subnet in the volume region.", null, {"format": "regex", "comma_separated": false, "regex": "^subnet-[0-9a-f]{8,17}$"}],
     ["--gcp_project", "Destination GCP project.", null, {"format": "regex", "comma_separated": false, "regex": "^[a-z][-a-z0-9]{4,28}[a-z0-9]$"}],
     ["--aws_profile", "Source AWS profile.", null]
   ]

--- a/data/recipes/aws_disk_to_gcp.json
+++ b/data/recipes/aws_disk_to_gcp.json
@@ -67,7 +67,7 @@
     ["volumes", "Comma separated list of EBS volume IDs (e.g. vol-xxxxxxxx).", null, {"format": "regex", "comma_separated": true, "regex": "^vol-[0-9a-f]{8,17}$"}],
     ["aws_bucket", "AWS bucket for image storage.", null, {"format": "regex", "comma_separated": false, "regex": "^(s3:\/\/)?[0-9a-z][-\\.0-9a-z]{1,61}[0-9a-z]$"}],
     ["gcp_bucket", "GCP bucket for image storage.", null, {"format": "regex", "comma_separated": false, "regex": "^(gs:\/\/)?[0-9a-z][-\\.0-9a-z_]{1,61}[0-9a-z]$"}],
-    ["--subnet", "AWS subnet to copy instances from, required if there is no default subnet in the volume region.", null, {"format": "subnet", "comma_separated": false}],
+    ["--subnet", "AWS subnet to copy instances from, required if there is no default subnet in the volume region.", null, {"format": "regex", "comma_separated": true, "regex": "^subnet-[0-9a-f]{8,17}$"}],
     ["--gcp_project", "Destination GCP project.", null, {"format": "regex", "comma_separated": false, "regex": "^[a-z][-a-z0-9]{4,28}[a-z0-9]$"}],
     ["--aws_profile", "Source AWS profile.", null]
   ]

--- a/data/recipes/aws_turbinia_ts.json
+++ b/data/recipes/aws_turbinia_ts.json
@@ -88,7 +88,7 @@
     ["volumes", "Comma separated list of EBS volume IDs (e.g. vol-xxxxxxxx).", null, {"format": "regex", "comma_separated": true, "regex": "^vol-[0-9a-f]{8,17}$"}],
     ["aws_bucket", "AWS bucket for image storage.", null, {"format": "regex", "comma_separated": false, "regex": "^(s3:\/\/)?[0-9a-z][-\\.0-9a-z]{1,61}[0-9a-z]$"}],
     ["gcp_bucket", "GCP bucket for image storage.", null, {"format": "regex", "comma_separated": false, "regex": "^(gs:\/\/)?[0-9a-z][-\\.0-9a-z_]{1,61}[0-9a-z]$"}],
-    ["--subnet", "AWS subnet to copy instances from, required if there is no default subnet in the volume region.", null, {"format": "regex", "comma_separated": true, "regex": "^subnet-[0-9a-f]{8,17}$"}],
+    ["--subnet", "AWS subnet to copy instances from, required if there is no default subnet in the volume region.", null, {"format": "regex", "comma_separated": false, "regex": "^subnet-[0-9a-f]{8,17}$"}],
     ["--gcp_project", "Destination GCP project.", null, {"format": "regex", "comma_separated": false, "regex": "^[a-z][-a-z0-9]{4,28}[a-z0-9]$"}],
     ["--aws_profile", "Source AWS profile.", null],
     ["--incident_id", "Incident ID (used for Timesketch description).", null],

--- a/data/recipes/aws_turbinia_ts.json
+++ b/data/recipes/aws_turbinia_ts.json
@@ -88,7 +88,7 @@
     ["volumes", "Comma separated list of EBS volume IDs (e.g. vol-xxxxxxxx).", null, {"format": "regex", "comma_separated": true, "regex": "^vol-[0-9a-f]{8,17}$"}],
     ["aws_bucket", "AWS bucket for image storage.", null, {"format": "regex", "comma_separated": false, "regex": "^(s3:\/\/)?[0-9a-z][-\\.0-9a-z]{1,61}[0-9a-z]$"}],
     ["gcp_bucket", "GCP bucket for image storage.", null, {"format": "regex", "comma_separated": false, "regex": "^(gs:\/\/)?[0-9a-z][-\\.0-9a-z_]{1,61}[0-9a-z]$"}],
-    ["--subnet", "AWS subnet to copy instances from, required if there is no default subnet in the volume region.", null, {"format": "subnet", "comma_separated": false}],
+    ["--subnet", "AWS subnet to copy instances from, required if there is no default subnet in the volume region.", null, {"format": "regex", "comma_separated": true, "regex": "^subnet-[0-9a-f]{8,17}$"}],
     ["--gcp_project", "Destination GCP project.", null, {"format": "regex", "comma_separated": false, "regex": "^[a-z][-a-z0-9]{4,28}[a-z0-9]$"}],
     ["--aws_profile", "Source AWS profile.", null],
     ["--incident_id", "Incident ID (used for Timesketch description).", null],

--- a/tests/e2e/aws_disk_forensics.py
+++ b/tests/e2e/aws_disk_forensics.py
@@ -96,13 +96,13 @@ RECIPE = {
       }
     }
   ],
-  'args': [  # TODO - Add args validators when they're all written
-    ['aws_region', 'AWS region containing the EBS volumes.', None],
-    ['gcp_zone', 'Destination GCP zone in which to create the disks.', None],
-    ['volumes', 'Comma separated list of EBS volume IDs (e.g. vol-xxxxxxxx).', None],
-    ['aws_bucket', 'AWS bucket for image storage.', None],
-    ['gcp_bucket', 'GCP bucket for image storage.', None],
-    ['--subnet', 'AWS subnet to copy instances from, required if there is no default subnet in the volume region.', None],
+  'args': [
+    ['aws_region', 'AWS region containing the EBS volumes.', None, {'format': 'aws_region'}],
+    ['gcp_zone', 'Destination GCP zone in which to create the disks.', None, {'format': 'gcp_zone'}],
+    ['volumes', 'Comma separated list of EBS volume IDs (e.g. vol-xxxxxxxx).', None, {'format': 'regex', 'comma_separated': True, 'regex': '^vol-[0-9a-f]{8,17}$'}],
+    ['aws_bucket', 'AWS bucket for image storage.', None, {'format': 'regex', 'comma_separated': False, 'regex': '^(s3:\/\/)?[0-9a-z][-\\.0-9a-z]{1,61}[0-9a-z]$'}],
+    ["gcp_bucket", "GCP bucket for image storage.", None, {'format': 'regex', 'comma_separated': False, 'regex': '^(gs:\/\/)?[0-9a-z][-\\.0-9a-z_]{1,61}[0-9a-z]$'}],
+    ['--subnet', 'AWS subnet to copy instances from, required if there is no default subnet in the volume region.', None, {'format': 'regex', 'comma_separated': True, 'regex': '^subnet-[0-9a-f]{8,17}$'}],
     ['--gcp_project', 'Destination GCP project.', None],
     ['--aws_profile', 'Source AWS profile.', None],
   ]

--- a/tests/e2e/aws_disk_forensics.py
+++ b/tests/e2e/aws_disk_forensics.py
@@ -101,7 +101,7 @@ RECIPE = {
     ['gcp_zone', 'Destination GCP zone in which to create the disks.', None, {'format': 'gcp_zone'}],
     ['volumes', 'Comma separated list of EBS volume IDs (e.g. vol-xxxxxxxx).', None, {'format': 'regex', 'comma_separated': True, 'regex': '^vol-[0-9a-f]{8,17}$'}],
     ['aws_bucket', 'AWS bucket for image storage.', None, {'format': 'regex', 'comma_separated': False, 'regex': '^(s3:\/\/)?[0-9a-z][-\\.0-9a-z]{1,61}[0-9a-z]$'}],
-    ["gcp_bucket", "GCP bucket for image storage.", None, {'format': 'regex', 'comma_separated': False, 'regex': '^(gs:\/\/)?[0-9a-z][-\\.0-9a-z_]{1,61}[0-9a-z]$'}],
+    ['gcp_bucket', 'GCP bucket for image storage.', None, {'format': 'regex', 'comma_separated': False, 'regex': '^(gs:\/\/)?[0-9a-z][-\\.0-9a-z_]{1,61}[0-9a-z]$'}],
     ['--subnet', 'AWS subnet to copy instances from, required if there is no default subnet in the volume region.', None, {'format': 'regex', 'comma_separated': False, 'regex': '^subnet-[0-9a-f]{8,17}$'}],
     ['--gcp_project', 'Destination GCP project.', None],
     ['--aws_profile', 'Source AWS profile.', None],

--- a/tests/e2e/aws_disk_forensics.py
+++ b/tests/e2e/aws_disk_forensics.py
@@ -102,7 +102,7 @@ RECIPE = {
     ['volumes', 'Comma separated list of EBS volume IDs (e.g. vol-xxxxxxxx).', None, {'format': 'regex', 'comma_separated': True, 'regex': '^vol-[0-9a-f]{8,17}$'}],
     ['aws_bucket', 'AWS bucket for image storage.', None, {'format': 'regex', 'comma_separated': False, 'regex': '^(s3:\/\/)?[0-9a-z][-\\.0-9a-z]{1,61}[0-9a-z]$'}],
     ["gcp_bucket", "GCP bucket for image storage.", None, {'format': 'regex', 'comma_separated': False, 'regex': '^(gs:\/\/)?[0-9a-z][-\\.0-9a-z_]{1,61}[0-9a-z]$'}],
-    ['--subnet', 'AWS subnet to copy instances from, required if there is no default subnet in the volume region.', None, {'format': 'regex', 'comma_separated': True, 'regex': '^subnet-[0-9a-f]{8,17}$'}],
+    ['--subnet', 'AWS subnet to copy instances from, required if there is no default subnet in the volume region.', None, {'format': 'regex', 'comma_separated': False, 'regex': '^subnet-[0-9a-f]{8,17}$'}],
     ['--gcp_project', 'Destination GCP project.', None],
     ['--aws_profile', 'Source AWS profile.', None],
   ]

--- a/tests/e2e/gcp_disk_forensics.py
+++ b/tests/e2e/gcp_disk_forensics.py
@@ -82,7 +82,7 @@ RECIPE = {
             }
         }
     ],
-    'args': [  # TODO - Add args validators when they're all written
+    'args': [
         ['source_project_name', 'Name of the project containing the instance / disks to copy.', None, {'format': 'regex', 'comma_separated': False, 'regex': '^[a-z][-a-z0-9]{4,28}[a-z0-9]$'}],
         ['destination_project_name', 'Name of the project where the analysis VM will be created and disks copied to.', None, {'format': 'regex', 'comma_separated': False, 'regex': '^[a-z][-a-z0-9]{4,28}[a-z0-9]$'}],
         ['--incident_id', 'Incident ID to label the VM with.', None],

--- a/tests/e2e/gcp_disk_forensics.py
+++ b/tests/e2e/gcp_disk_forensics.py
@@ -83,14 +83,14 @@ RECIPE = {
         }
     ],
     'args': [  # TODO - Add args validators when they're all written
-        ['source_project_name', 'Name of the project containing the instance / disks to copy.', None],
-        ['destination_project_name', 'Name of the project where the analysis VM will be created and disks copied to.', None],
+        ['source_project_name', 'Name of the project containing the instance / disks to copy.', None, {'format': 'regex', 'comma_separated': False, 'regex': '^[a-z][-a-z0-9]{4,28}[a-z0-9]$'}],
+        ['destination_project_name', 'Name of the project where the analysis VM will be created and disks copied to.', None, {'format': 'regex', 'comma_separated': False, 'regex': '^[a-z][-a-z0-9]{4,28}[a-z0-9]$'}],
         ['--incident_id', 'Incident ID to label the VM with.', None],
         ['--instances', 'Name of the instance to analyze.', None],
         ['--disks', 'Comma-separated list of disks to copy from the source GCP project (if `instance` not provided).', None],
         ['--all_disks', 'Copy all disks in the designated instance. Overrides `disk_names` if specified.', False],
         ['--stop_instances', 'Stop the designated instance after copying disks.', False],
-        ['--zone', 'The GCP zone where the Analysis VM and copied disks will be created.', 'us-central1-f']
+        ['--zone', 'The GCP zone where the Analysis VM and copied disks will be created.', 'us-central1-f', {'format': 'gcp_zone'}]
     ]
 }
 # pylint: enable=line-too-long


### PR DESCRIPTION
Add args validation to E2E tests

Also, correction to aws subnets - they're AWS subnet IDs, not actual network addresses with masks. 