### PR TITLE
Argument Validator updates

### DIFF
--- a/data/recipes/upload_turbinia.json
+++ b/data/recipes/upload_turbinia.json
@@ -61,7 +61,7 @@
         ["files", "Paths to process.", null],
         ["--turbinia_recipe", "The Turbinia recipe name to use for evidence processing.", null],
         ["--destination_turbinia_dir", "Destination path in Turbinia host to write the files to.", null],
-        ["--hostname", "Remote host.", null, {"format": "fqdn"}],
+        ["--hostname", "Remote host.", null, {"format": "hostname"}],
         ["--directory", "Directory in which to copy and compress files.", null],
         ["--turbinia_config", "Turbinia config file to use.", null],
         ["--local_turbinia_results", "Directory where Turbinia results will be downloaded to.", null],

--- a/dftimewolf/cli/dftimewolf_recipes.py
+++ b/dftimewolf/cli/dftimewolf_recipes.py
@@ -295,8 +295,13 @@ class DFTimewolfTool(object):
         switch = arg.switch.replace('--', '')
         if (switch == arg.switch or  # Ignore optional args, unless present
             self.state.command_line_options[switch] is not None):
-          self._args_validator.Validate(self.state.command_line_options[switch],
-                                        arg.format)
+          value, message = self._args_validator.Validate(
+              self.state.command_line_options[switch], arg.format)
+          if not value:
+            error_messages.append(
+                f'Argument validation error: "{arg.switch}" with value '
+                f'"{self.state.command_line_options[switch]}" gave error: '
+                f'{str(message)}')
       except errors.RecipeArgsValidatorError as exception:
         error_messages.append(f'Argument validation error: "{arg.switch}" with '
             f'value "{self.state.command_line_options[switch]}" gave error: '
@@ -304,6 +309,8 @@ class DFTimewolfTool(object):
 
     if error_messages:
       for message in error_messages:
+        if self.cdm:
+          self.cdm.EnqueueMessage('dftimewolf', message, True)
         logger.critical(message)
       raise errors.RecipeArgsValidatorError(
           'At least one argument failed validation')

--- a/dftimewolf/lib/args_validator.py
+++ b/dftimewolf/lib/args_validator.py
@@ -35,6 +35,9 @@ class AbstractValidator(abc.ABC):
       A Tuple:
         boolean: True if operand passes validation, False otherwise.
         str: A message for validation failure. Only set if the boolean is false.
+    
+    Raises:
+      errors.RecipeArgsValidatorError
     """
 
 
@@ -152,9 +155,6 @@ class AWSRegionValidator(AbstractValidator):
       A Tuple:
         boolean: True if operand is a valid AWS region, False otherwise.
         str: A message for validation failure. Only set if the boolean is false.
-
-    Raises:
-      errors.RecipeArgsValidatorError: An error in validation.
     """
     if operand not in self._regions:
       return False, 'Invalid AWS Region name'
@@ -202,9 +202,6 @@ class AzureRegionValidator(AbstractValidator):
       A Tuple:
         boolean: True if operand is a valid Azure region, False otherwise.
         str: A message for validation failure. Only set if the boolean is false.
-
-    Raises:
-      errors.RecipeArgsValidatorError: An error in validation.
     """
     if operand not in self._regions:
       return False, 'Invalid Azure Region name'
@@ -265,9 +262,6 @@ class GCPZoneValidator(AbstractValidator):
       A Tuple:
         boolean: True if operand is a valid GCP zone, False otherwise.
         str: A message for validation failure. Only set if the boolean is false.
-
-    Raises:
-      errors.RecipeArgsValidatorError: An error in validation.
     """
     if operand not in self._zones:
       return False, 'Invalid GCP Zone name'
@@ -294,9 +288,6 @@ class RegexValidator(CommaSeparatedValidator):
       A Tuple:
         boolean: True if operand matches the regex, False otherwise.
         str: A message for validation failure. Only set if the boolean is false.
-
-    Raises:
-      errors.RecipeArgsValidatorError: An error in validation.
     """
     if not validator_params or 'regex' not in validator_params:
       raise errors.RecipeArgsValidatorError(
@@ -328,9 +319,6 @@ class SubnetValidator(CommaSeparatedValidator):
       A Tuple:
         boolean: True if operand passes validation, False otherwise.
         str: A message for validation failure. Only set if the boolean is false.
-
-    Raises:
-      errors.RecipeArgsValidatorError: An error in validation.
     """
     try:
       ipaddress.ip_network(operand)
@@ -486,9 +474,6 @@ class HostnameValidator(RegexValidator):
       A Tuple:
         boolean: True if operand is a valid FQDN, False otherwise.
         str: A message for validation failure. Only set if the boolean is false.
-
-    Raises:
-      errors.RecipeArgsValidatorError: An error in validation.
     """
     if not validator_params:
       validator_params = {}
@@ -531,9 +516,6 @@ class GRRHostValidator(HostnameValidator):
       A Tuple:
         boolean: True if operand is a valid Grr ID, False otherwise.
         str: A message for validation failure. Only set if the boolean is false.
-
-    Raises:
-      errors.RecipeArgsValidatorError: An error in validation.
     """
     if not validator_params:
       validator_params = {}
@@ -567,9 +549,6 @@ class URLValidator(HostnameValidator):
       A Tuple:
         boolean: True if operand is a valid URL, False otherwise.
         str: A message for validation failure. Only set if the boolean is false.
-
-    Raises:
-      errors.RecipeArgsValidatorError: An error in validation.
     """
     url = urlparse(operand)
     if not url.hostname:

--- a/dftimewolf/lib/args_validator.py
+++ b/dftimewolf/lib/args_validator.py
@@ -35,7 +35,7 @@ class AbstractValidator(abc.ABC):
       A Tuple:
         boolean: True if operand passes validation, False otherwise.
         str: A message for validation failure. Only set if the boolean is false.
-    
+
     Raises:
       errors.RecipeArgsValidatorError
     """
@@ -288,6 +288,9 @@ class RegexValidator(CommaSeparatedValidator):
       A Tuple:
         boolean: True if operand matches the regex, False otherwise.
         str: A message for validation failure. Only set if the boolean is false.
+
+    Raises:
+      errors.RecipeArgsValidatorError: If no regex is found to use.
     """
     if not validator_params or 'regex' not in validator_params:
       raise errors.RecipeArgsValidatorError(

--- a/tests/lib/args_validator.py
+++ b/tests/lib/args_validator.py
@@ -19,13 +19,14 @@ class DefaultValidatorTest(unittest.TestCase):
     self.assertEqual(self.validator.NAME, 'default')
 
   def test_ValidateSuccess(self):
-    """Test that correct values do not throw an exception."""
-    self.validator.Validate('operand', {})
+    """Test for Default Validator."""
+    val, _ = self.validator.Validate('operand', {})
+    self.assertTrue(val)
 
 
 # pylint: disable=abstract-class-instantiated
 # pytype: disable=not-instantiable
-class CommaSeparatedValidatorTester(unittest.TestCase):
+class CommaSeparatedValidatorTest(unittest.TestCase):
   """Tests CommaSeparatedValidator."""
 
   def test_Init(self):
@@ -50,24 +51,39 @@ class CommaSeparatedValidatorTester(unittest.TestCase):
 
     with mock.patch.object(args_validator.CommaSeparatedValidator,
                            'ValidateSingle',
-                           return_value=None) as mock_validatesingle:
+                           return_value=(True, '')) as mock_validatesingle:
       validator = args_validator.CommaSeparatedValidator()
-      validator.Validate('one,two,three', {'comma_separated': True})
+      val, _ = validator.Validate('one,two,three', {'comma_separated': True})
       self.assertEqual(mock_validatesingle.call_count, 3)
+      self.assertTrue(val)
 
     with mock.patch.object(args_validator.CommaSeparatedValidator,
                            'ValidateSingle',
-                           return_value=None) as mock_validatesingle:
+                           return_value=(True, '')) as mock_validatesingle:
       validator = args_validator.CommaSeparatedValidator()
-      validator.Validate('one,two,three', {'comma_separated': False})
+      val, _ = validator.Validate('one,two,three', {'comma_separated': False})
       self.assertEqual(mock_validatesingle.call_count, 1)
+      self.assertTrue(val)
 
     with mock.patch.object(args_validator.CommaSeparatedValidator,
                            'ValidateSingle',
-                           return_value=None):
+                           return_value=(True, '')):
       validator = args_validator.CommaSeparatedValidator()
-      validator.Validate('one,two,three', {})
+      val, _ = validator.Validate('one,two,three', {})
       self.assertEqual(mock_validatesingle.call_count, 1)
+      self.assertTrue(val)
+
+  def test_ValidateFailure(self):
+    """Tests validation failure."""
+    with mock.patch.object(args_validator.CommaSeparatedValidator,
+                           'ValidateSingle',
+                           side_effect=[(True, ''),
+                                        (False, 'Failure1'),
+                                        (False, 'Failure2')]):
+      validator = args_validator.CommaSeparatedValidator()
+      val, msg = validator.Validate('one,two,three', {'comma_separated': True})
+      self.assertFalse(val)
+      self.assertEqual(msg, 'Failure1\nFailure2')
 # pylint: enable=abstract-class-instantiated
 # pytype: enable=not-instantiable
 
@@ -88,16 +104,17 @@ class AWSRegionValidatorTest(unittest.TestCase):
     regions = ['ap-southeast-2', 'us-east-1', 'me-central-1']
 
     for r in regions:
-      self.validator.Validate(r, {})
+      val, _ = self.validator.Validate(r, {})
+      self.assertTrue(val)
 
   def test_ValidateFailure(self):
     """Tests invalid values correctly throw an exception."""
     regions = ['invalid', '123456']
 
     for r in regions:
-      with self.assertRaisesRegex(
-          errors.RecipeArgsValidatorError, 'Invalid AWS Region name'):
-        self.validator.Validate(r, {})
+      val, msg = self.validator.Validate(r, {})
+      self.assertFalse(val)
+      self.assertEqual(msg, 'Invalid AWS Region name')
 
 
 class AzureRegionValidatorTest(unittest.TestCase):
@@ -116,16 +133,17 @@ class AzureRegionValidatorTest(unittest.TestCase):
     regions = ['eastasia', 'norwaywest', 'westindia']
 
     for r in regions:
-      self.validator.Validate(r, {})
+      val, _ = self.validator.Validate(r, {})
+      self.assertTrue(val)
 
   def test_ValidateFailure(self):
     """Tests invalid values correctly throw an exception."""
     regions = ['invalid', '123456']
 
     for r in regions:
-      with self.assertRaisesRegex(
-          errors.RecipeArgsValidatorError, 'Invalid Azure region name'):
-        self.validator.Validate(r, {})
+      val, msg = self.validator.Validate(r, {})
+      self.assertFalse(val)
+      self.assertEqual(msg, 'Invalid Azure Region name')
 
 
 class GCPZoneValidatorTest(unittest.TestCase):
@@ -141,19 +159,20 @@ class GCPZoneValidatorTest(unittest.TestCase):
 
   def test_ValidateSuccess(self):
     """Test that correct values do not throw an exception."""
-    regions = ['asia-east1-a', 'europe-west2-a', 'us-central1-f']
+    zones = ['asia-east1-a', 'europe-west2-a', 'us-central1-f']
 
-    for r in regions:
-      self.validator.Validate(r, None)
+    for z in zones:
+      val, _ = self.validator.Validate(z, {})
+      self.assertTrue(val)
 
   def test_ValidateFailure(self):
     """Tests invalid values correctly throw an exception."""
-    regions = ['nope', '123456']
+    zones = ['nope', '123456']
 
-    for r in regions:
-      with self.assertRaisesRegex(
-          errors.RecipeArgsValidatorError, 'Invalid GCP zone name'):
-        self.validator.Validate(r, None)
+    for z in zones:
+      val, msg = self.validator.Validate(z, {})
+      self.assertFalse(val)
+      self.assertEqual(msg, 'Invalid GCP Zone name')
 
 
 class RegexValidatorTest(unittest.TestCase):
@@ -169,18 +188,19 @@ class RegexValidatorTest(unittest.TestCase):
 
   def test_ValidateSuccess(self):
     """Test that correct values do not throw an exception."""
-    values = ['abcdef','bcdefg','abcdef,bcdefg']
+    values = ['abcdef', 'bcdefg', 'abcdef,bcdefg']
     params = {'comma_separated': True, 'regex': '.?bcdef.?'}
     for v in values:
-      self.validator.Validate(v, params)
+      val, _ = self.validator.Validate(v, params)
+      self.assertTrue(val)
 
   def test_ValidateFailure(self):
     """Test Regex test failure."""
     params = {'comma_separated': True, 'regex': '.?bcdef.?'}
-    with self.assertRaisesRegex(
-        errors.RecipeArgsValidatorError,
-        r'"tuvwxy" does not match regex \/\.\?bcdef\.\?\/'):
-      self.validator.Validate('tuvwxy', params)
+
+    val, msg = self.validator.Validate('tuvwxy', params)
+    self.assertFalse(val)
+    self.assertEqual(msg, '"tuvwxy" does not match regex /.?bcdef.?/')
 
   def test_RequiredParam(self):
     """Tests an error is thrown is the regex param is missing."""
@@ -207,17 +227,18 @@ class SubnetValidatorTest(unittest.TestCase):
     values = ['1.2.3.4/32','192.168.0.0/24','1.2.3.4/32,192.168.0.0/24']
     params = {'comma_separated': True}
     for v in values:
-      self.validator.Validate(v, params)
+      val, _ = self.validator.Validate(v, params)
+      self.assertTrue(val)
 
   def test_ValidateFailure(self):
     """Test Subnet test failure."""
     values = ['1.2.3.4/33', '267.0.0.1/32', 'text']
     params = {'comma_separated': True}
+
     for value in values:
-      with self.assertRaisesRegex(
-          errors.RecipeArgsValidatorError,
-          f'{value} is not a valid subnet.'):
-        self.validator.Validate(value, params)
+      val, msg = self.validator.Validate(value, params)
+      self.assertFalse(val)
+      self.assertEqual(msg, f'{value} is not a valid subnet.')
 
 
 class DatetimeValidatorTest(unittest.TestCase):
@@ -242,32 +263,49 @@ class DatetimeValidatorTest(unittest.TestCase):
 
   def test_ValidateSuccess(self):
     """Tests a successful validation."""
-    self.validator.Validate(
+    val, _ = self.validator.Validate(
         '2023-12-31 23:29:59', {'format_string': self.FORMAT_STRING})
+    self.assertTrue(val)
 
   def test_ValidateSuccessWithOrder(self):
     """Tests validation success with order parameters."""
     first = '2023-01-01 00:00:00'
     second = '2023-01-02 00:00:00'
     third = '2023-01-03 00:00:00'
+    fourth = '2023-01-04 00:00:00'
+    fifth = '2023-01-05 00:00:00'
 
     params = {
       'format_string': self.FORMAT_STRING,
-      'before': third,
-      'after': first
+      'before': fourth,
+      'after': second
     }
 
-    self.validator.Validate(second, params)
+    val, _ = self.validator.Validate(third, params)
+    self.assertTrue(val)
 
+    val, msg = self.validator.Validate(first, params)
+    self.assertFalse(val)
+    self.assertEqual(
+        msg,
+        f'{first} is before {second} but it should be the other way around')
+
+    val, msg = self.validator.Validate(fifth, params)
+    self.assertFalse(val)
+    self.assertEqual(
+        msg,
+        f'{fourth} is before {fifth} but it should be the other way around')
 
   def test_ValidateFailureInvalidFormat(self):
     """Tests invalid date formats correctly fail."""
     values = ['value', '2023-12-31', '2023-31-12 23:29:59']
     for v in values:
-      with self.assertRaisesRegex(
-          errors.RecipeArgsValidatorError,
-          f"time data '{v}' does not match format '{self.FORMAT_STRING}'"):
-        self.validator.Validate(v, {'format_string': self.FORMAT_STRING})
+      val, msg = self.validator.Validate(
+          v, {'format_string': self.FORMAT_STRING})
+      self.assertFalse(val)
+      self.assertEqual(
+          msg,
+          f"time data '{v}' does not match format '{self.FORMAT_STRING}'")
 
   # pylint: disable=protected-access
   def test_ValidateOrder(self):
@@ -275,51 +313,70 @@ class DatetimeValidatorTest(unittest.TestCase):
     first = '2023-01-01 00:00:00'
     second = '2023-01-02 00:00:00'
 
-    # Correct order passes without exception
-    self.validator._ValidateOrder(first, second, self.FORMAT_STRING)
+    # Correct order passes
+    val = self.validator._ValidateOrder(first, second, self.FORMAT_STRING)
+    self.assertTrue(val)
 
-    # Reverse order raises exception
-    with self.assertRaisesRegex(
-        errors.RecipeArgsValidatorError,
-        f"{second} is after {first} but it should be the other way around"):
-      self.validator._ValidateOrder(second, first, self.FORMAT_STRING)
+    # Reverse order fails
+    val = self.validator._ValidateOrder(second, first, self.FORMAT_STRING)
+    self.assertFalse(val)
 
 
-class FQDNValidatorTest(unittest.TestCase):
-  """Tests the FQDNValidator class."""
+class HostnameValidatorTest(unittest.TestCase):
+  """Tests the HostnameValidator class."""
 
   def setUp(self):
     """Setup."""
-    self.validator = args_validator.FQDNValidator()
+    self.validator = args_validator.HostnameValidator()
 
   def test_Init(self):
     """Tests initialization."""
-    self.assertEqual(self.validator.NAME, 'fqdn')
+    self.assertEqual(self.validator.NAME, 'hostname')
 
   def test_ValidateSuccess(self):
     """Test successful validation."""
-    fqdns = ['github.com',
-             'grr-client-ubuntu.c.ramoj-playground.internal',
-             'www.google.com.au',
-             'www.google.co.uk']
+    fqdns = [
+      'github.com',
+      'grr-client-ubuntu.c.ramoj-playground.internal',
+      'www.google.com.au',
+      'www.google.co.uk',
+      'localhost',
+      'grr-server'
+    ]
     for fqdn in fqdns:
-      self.validator.Validate(fqdn)
+      val, _ = self.validator.Validate(fqdn)
+      self.assertTrue(val)
 
-    self.validator.Validate(','.join(fqdns), {'comma_separated': True})
+    val, _ = self.validator.Validate(','.join(fqdns), {'comma_separated': True})
+    self.assertTrue(val)
 
   def test_ValidationFailure(self):
     """Tests validation failures."""
-    fqdns = ['value', 'a-.com', '-a.com']
+    fqdns = ['a-.com', '-a.com']
     for fqdn in fqdns:
-      with self.assertRaisesRegex(
-          errors.RecipeArgsValidatorError,
-          f"'{fqdn}' is an invalid hostname."):
-        self.validator.Validate(fqdn)
+      val, msg = self.validator.Validate(fqdn)
+      self.assertFalse(val)
+      self.assertEqual(msg, f"'{fqdn}' is an invalid hostname.")
 
-    with self.assertRaisesRegex(
-        errors.RecipeArgsValidatorError,
-        "'value' is an invalid hostname."):  # Fails on the first listed
-      self.validator.Validate(','.join(fqdns), {'comma_separated': True})
+    val, msg =self.validator.Validate(
+        ','.join(fqdns), {'comma_separated': True})
+    self.assertFalse(val)
+    self.assertEqual(msg, ("'a-.com' is an invalid hostname.\n"
+                           "'-a.com' is an invalid hostname."))
+
+  def test_ValidationFailureWithFQDNOnly(self):
+    """tests validation fails for flat names when FQDN_ONLY is set."""
+    fqdns = ['localhost', 'grr-server']
+    for fqdn in fqdns:
+      val, msg = self.validator.Validate(fqdn, {'fqdn_only': True})
+      self.assertFalse(val)
+      self.assertEqual(msg, f"'{fqdn}' is an invalid hostname.")
+
+    val, msg =self.validator.Validate(
+        ','.join(fqdns), {'comma_separated': True, 'fqdn_only': True})
+    self.assertFalse(val)
+    self.assertEqual(msg, ("'localhost' is an invalid hostname.\n"
+                           "'grr-server' is an invalid hostname."))
 
 
 class GRRHostValidatorTest(unittest.TestCase):
@@ -336,25 +393,30 @@ class GRRHostValidatorTest(unittest.TestCase):
   def test_ValidateSuccess(self):
     """Test successful validation."""
     fqdns = ['C.1facf5562db006ad',
-             'grr-client-ubuntu.c.ramoj-playground.internal']
+             'grr-client-ubuntu.c.ramoj-playground.internal',
+             'grr-client']
     for fqdn in fqdns:
-      self.validator.Validate(fqdn)
+      val, _ = self.validator.Validate(fqdn)
+      self.assertTrue(val)
 
-    self.validator.Validate(','.join(fqdns), {'comma_separated': True})
+    val, _ = self.validator.Validate(','.join(fqdns), {'comma_separated': True})
+    self.assertTrue(val)
 
   def test_ValidationFailure(self):
     """Tests validation failures."""
-    fqdns = ['value', 'C.a', 'C.01234567890123456789']
+    fqdns = ['a-.com', 'C.a', 'C.01234567890123456789']
     for fqdn in fqdns:
-      with self.assertRaisesRegex(
-          errors.RecipeArgsValidatorError,
-          f"'{fqdn}' is an invalid Grr host ID."):
-        self.validator.Validate(fqdn)
+      val, msg = self.validator.Validate(fqdn)
+      self.assertFalse(val)
+      self.assertEqual(msg, f"'{fqdn}' is an invalid Grr host ID.")
 
-    with self.assertRaisesRegex(
-        errors.RecipeArgsValidatorError,
-        "'value' is an invalid Grr host ID."):
-      self.validator.Validate(','.join(fqdns), {'comma_separated': True})
+    val, msg = self.validator.Validate(','.join(fqdns),
+                                       {'comma_separated': True})
+    self.assertFalse(val)
+    self.assertEqual(msg,
+                     ("'a-.com' is an invalid Grr host ID.\n"
+                      "'C.a' is an invalid Grr host ID.\n"
+                      "'C.01234567890123456789' is an invalid Grr host ID."))
 
 
 class URLValidatorTest(unittest.TestCase):
@@ -381,9 +443,11 @@ class URLValidatorTest(unittest.TestCase):
         'https://grr.ramoj-playground.internal',
     ]
     for fqdn in fqdns:
-      self.validator.Validate(fqdn)
+      val, _ = self.validator.Validate(fqdn)
+      self.assertTrue(val, f'{fqdn} failed validation')
 
-    self.validator.Validate(','.join(fqdns), {'comma_separated': True})
+    val, _ = self.validator.Validate(','.join(fqdns), {'comma_separated': True})
+    self.assertTrue(val)
 
   def test_ValidationFailure(self):
     """Tests validation failures."""
@@ -393,15 +457,16 @@ class URLValidatorTest(unittest.TestCase):
         'http://one.*.com'
     ]
     for fqdn in fqdns:
-      with self.assertRaisesRegex(
-          errors.RecipeArgsValidatorError,
-          f"'{fqdn}' is an invalid URL."):
-        self.validator.Validate(fqdn)
+      val, msg = self.validator.Validate(fqdn)
+    self.assertFalse(val)
+    self.assertEqual(msg, f"'{fqdn}' is an invalid URL.")
 
-    with self.assertRaisesRegex(
-        errors.RecipeArgsValidatorError,
-        "'value' is an invalid URL."):
-      self.validator.Validate(','.join(fqdns), {'comma_separated': True})
+    val, msg = self.validator.Validate(','.join(fqdns),
+                                       {'comma_separated': True})
+    self.assertFalse(val)
+    self.assertEqual(msg, ("'value' is an invalid URL.\n"
+                           "'10.100.0.100' is an invalid URL.\n"
+                           "'http://one.*.com' is an invalid URL."))
 
 
 # pylint: disable=protected-access
@@ -422,9 +487,9 @@ class ValidatorManagerTest(unittest.TestCase):
     self.assertIn('aws_region', self.vm._validators)
     self.assertIn('azure_region', self.vm._validators)
     self.assertIn('datetime', self.vm._validators)
-    self.assertIn('fqdn', self.vm._validators)
     self.assertIn('gcp_zone', self.vm._validators)
     self.assertIn('grr_host', self.vm._validators)
+    self.assertIn('hostname', self.vm._validators)
     self.assertIn('regex', self.vm._validators)
     self.assertIn('subnet', self.vm._validators)
     self.assertIn('url', self.vm._validators)
@@ -435,12 +500,12 @@ class ValidatorManagerTest(unittest.TestCase):
                           args_validator.AzureRegionValidator)
     self.assertIsInstance(self.vm._validators['datetime'],
                           args_validator.DatetimeValidator)
-    self.assertIsInstance(self.vm._validators['fqdn'],
-                          args_validator.FQDNValidator)
     self.assertIsInstance(self.vm._validators['gcp_zone'],
                           args_validator.GCPZoneValidator)
     self.assertIsInstance(self.vm._validators['grr_host'],
                           args_validator.GRRHostValidator)
+    self.assertIsInstance(self.vm._validators['hostname'],
+                          args_validator.HostnameValidator)
     self.assertIsInstance(self.vm._validators['regex'],
                           args_validator.RegexValidator)
     self.assertIsInstance(self.vm._validators['subnet'],
@@ -450,20 +515,21 @@ class ValidatorManagerTest(unittest.TestCase):
 
   def test_Validation(self):
     """Tests validation."""
-    self.vm.Validate('192.168.0.0/24',
-                     {'format': 'subnet', 'comma_separated': False})
+    val, _ = self.vm.Validate(
+        '192.168.0.0/24', {'format': 'subnet', 'comma_separated': False})
+    self.assertTrue(val)
 
   def test_DefaultValidation(self):
     """Tests param validation with DefaultValidator."""
-    self.vm.Validate('operand')
+    val, _ = self.vm.Validate('operand')
+    self.assertTrue(val)
 
   def test_ValidationFailure(self):
     """Tests validation failure."""
-    with self.assertRaisesRegex(
-        errors.RecipeArgsValidatorError,
-        'invalid is not a valid subnet.'):
-      self.vm.Validate('invalid',
-                       {'format': 'subnet', 'comma_separated': False})
+    val, msg = self.vm.Validate('invalid',
+                     {'format': 'subnet', 'comma_separated': False})
+    self.assertFalse(val)
+    self.assertEqual(msg, 'invalid is not a valid subnet.')
 
   def test_InvalidValidator(self):
     """Tests an exception is thrown if an invalid validator is specified."""


### PR DESCRIPTION
Changes argument validators to return a `tuple[bool, str]` rather than nothing, or raise an exception. This is better suited for cases of overlap, such as between fqdns, flat hostnames, urls and grr ids.