### PR TITLE
Move container.src_module_name into metdata

### DIFF
--- a/dftimewolf/lib/containers/interface.py
+++ b/dftimewolf/lib/containers/interface.py
@@ -3,6 +3,9 @@
 from typing import Any, Dict, List, Optional
 
 
+METADATA_KEY_SOURCE_MODULE = "SOURCE_MODULE"
+
+
 class AttributeContainer():
   """The attribute container interface.
 
@@ -22,7 +25,6 @@ class AttributeContainer():
   """
   CONTAINER_TYPE = None  # type: str
   metadata = {}  # type: Dict[str, Any]
-  src_module_name = None  # type: str
 
   def __init__(self, metadata: Optional[Dict[str, Any]] = None):
     """Initializes an AttributeContainer.

--- a/dftimewolf/lib/module.py
+++ b/dftimewolf/lib/module.py
@@ -169,8 +169,10 @@ class BaseModule(object):
 
     self.logger.debug(f'{self.name} is retrieving {len(containers)} '
         f'{container_class.CONTAINER_TYPE} containers - pop == {pop}')
-    for item in containers:
-      self.logger.debug(f'  * {str(item)} - origin: {item.src_module_name}')
+    for c in containers:
+      self.logger.debug(
+          f'  * {str(c)} - origin: '
+          f'{c.metadata.get(interface.METADATA_KEY_SOURCE_MODULE, "Unknown")}')
 
     return containers
 

--- a/dftimewolf/lib/state.py
+++ b/dftimewolf/lib/state.py
@@ -31,6 +31,8 @@ logger = logging.getLogger('dftimewolf')
 
 NEW_ISSUE_URL = 'https://github.com/log2timeline/dftimewolf/issues/new'
 
+_CONTAINER_METADATA_KEY_SOURCE_MODULE = "SOURCE_MODULE"
+
 
 @dataclass
 class StatsEntry:
@@ -239,6 +241,8 @@ class DFTimewolfState(object):
     """
     with self._state_lock:
       container.src_module_name = source_module
+      container.SetMetadata(
+          _CONTAINER_METADATA_KEY_SOURCE_MODULE, source_module)
       self.store.setdefault(container.CONTAINER_TYPE, []).append(container)
 
   def StoreStats(self, stats_entry: StatsEntry) -> None:


### PR DESCRIPTION
Moving the source container info into container metadata means it can be filtered on.