### PR TITLE
Make every SSH multiplexing connection unique

### DIFF
--- a/dftimewolf/lib/preflights/ssh_multiplexer.py
+++ b/dftimewolf/lib/preflights/ssh_multiplexer.py
@@ -1,6 +1,7 @@
 """Opens an SSH connection to a server using ControlMaster directives."""
 
 import subprocess
+import time
 from typing import Optional, List
 
 from dftimewolf.lib import module
@@ -57,7 +58,7 @@ class SSHMultiplexer(module.PreflightModule):
     command.extend([
        '-o', 'ControlMaster=auto',
        '-o', 'ControlPersist=yes',
-       '-o', 'ControlPath=~/.ssh/ctrl-%C',
+       '-o', f'ControlPath=~/.ssh/ctrl-dftw-{str(time.time_ns())}-%C',
     ])
     if self.extra_ssh_options:
       command.extend(self.extra_ssh_options)
@@ -73,12 +74,12 @@ class SSHMultiplexer(module.PreflightModule):
     """Close the shared SSH connection."""
     command = ['ssh',
                '-O', 'exit',
-               '-o', 'ControlPath=~/.ssh/ctrl-%C',
+               '-o', f'ControlPath=~/.ssh/ctrl-dftw-{str(time.time_ns())}-%C',
                self.hostname]
     ret = subprocess.call(command)
     if ret != 0:
       self.logger.error('Error cleaning up the shared SSH connection. Remove '
-                        'any lingering ~/.ssh/ctrl-* files.')
+                        'any lingering ~/.ssh/ctrl-dftw-*-* files.')
     else:
       self.logger.info('Succesfully cleaned up SSH connection.')
 

--- a/tests/lib/preflights/ssh_multiplexer.py
+++ b/tests/lib/preflights/ssh_multiplexer.py
@@ -20,10 +20,12 @@ class SSHMultiplexer(unittest.TestCase):
     local_ssh_multiplexer = ssh_multiplexer.SSHMultiplexer(test_state)
     self.assertIsNotNone(local_ssh_multiplexer)
 
+  @mock.patch.object(ssh_multiplexer, 'time')
   @mock.patch('subprocess.call')
-  def testProcess(self, mock_call):
+  def testProcess(self, mock_call, mock_time):
     """Tests the SSH CLI has the expected parameters."""
     mock_call.return_value = 0
+    mock_time.time_ns.return_value = 123456789
     test_state = state.DFTimewolfState(config.Config)
     ssh_multi = ssh_multiplexer.SSHMultiplexer(test_state)
     ssh_multi.SetUp('fakehost', 'fakeuser', None, ['-o', "ProxyCommand='test'"])
@@ -33,22 +35,24 @@ class SSHMultiplexer(unittest.TestCase):
       'ssh', '-q', '-l', 'fakeuser',
       '-o', 'ControlMaster=auto',
       '-o', 'ControlPersist=yes',
-      '-o', 'ControlPath=~/.ssh/ctrl-%C',
+      '-o', 'ControlPath=~/.ssh/ctrl-dftw-123456789-%C',
       '-o', "ProxyCommand='test'",
       'fakehost', 'true',
     ])
 
+  @mock.patch.object(ssh_multiplexer, 'time')
   @mock.patch('subprocess.call')
-  def testCleanup(self, mock_call):
+  def testCleanup(self, mock_call, mock_time):
     """Tests that the SSH CLI is called with the expected arguments."""
     mock_call.return_value = 0
+    mock_time.time_ns.return_value = 123456789
     test_state = state.DFTimewolfState(config.Config)
     ssh_multi = ssh_multiplexer.SSHMultiplexer(test_state)
     ssh_multi.SetUp('fakehost', 'fakeuser', None, [])
     ssh_multi.CleanUp()
 
     mock_call.assert_called_with([
-      'ssh', '-O', 'exit', '-o', 'ControlPath=~/.ssh/ctrl-%C', 'fakehost'
+      'ssh', '-O', 'exit', '-o', 'ControlPath=~/.ssh/ctrl-dftw-123456789-%C', 'fakehost'
     ])
 
 

--- a/tests/lib/preflights/ssh_multiplexer.py
+++ b/tests/lib/preflights/ssh_multiplexer.py
@@ -52,7 +52,8 @@ class SSHMultiplexer(unittest.TestCase):
     ssh_multi.CleanUp()
 
     mock_call.assert_called_with([
-      'ssh', '-O', 'exit', '-o', 'ControlPath=~/.ssh/ctrl-dftw-123456789-%C', 'fakehost'
+      'ssh', '-O', 'exit', '-o',
+      'ControlPath=~/.ssh/ctrl-dftw-123456789-%C', 'fakehost'
     ])
 
 


### PR DESCRIPTION
This PR solves a problem when running to parallell dftimewolf commands, and the first one finishes before the second one, and therefore cleans up the SSH control channel that the second one would've used to download things.