### PR TITLE
Added dry_run flag

### DIFF
--- a/dftimewolf/cli/dftimewolf_recipes.py
+++ b/dftimewolf/cli/dftimewolf_recipes.py
@@ -104,6 +104,7 @@ class DFTimewolfTool(object):
     self._recipes_manager = recipes_manager.RecipesManager()
     self._recipe = {}  # type: Dict[str, Any]
     self._args_validator = args_validator.ValidatorManager()
+    self.dry_run = False
     self.cdm = cdm
 
     self._DetermineDataFilesPath()
@@ -119,6 +120,9 @@ class DFTimewolfTool(object):
     Args:
       argument_parser (argparse.ArgumentParser): argparse argument parser.
     """
+    argument_parser.add_argument('--dry_run', help='Tool dry run',
+                                 default=False, action='store_true')
+
     subparsers = argument_parser.add_subparsers()
 
     for recipe in self._recipes_manager.GetRecipes():
@@ -267,6 +271,7 @@ class DFTimewolfTool(object):
       raise errors.CommandLineParseError(error_message)
 
     self._recipe = self._command_line_options.recipe
+    self.dry_run = self._command_line_options.dry_run
 
     if self.cdm:
       self._state = DFTimewolfStateWithCDM(config.Config, self.cdm)
@@ -477,6 +482,10 @@ def RunTool(cdm: Optional[CursesDisplayManager] = None) -> bool:
     return False
 
   tool.state.LogExecutionPlan()
+
+  if tool.dry_run:
+    logger.info("Exiting as --dry_run flag is set.")
+    return True
 
   time_ready = time.time()*1000
   tool.RunPreflights()

--- a/dftimewolf/cli/dftimewolf_recipes.py
+++ b/dftimewolf/cli/dftimewolf_recipes.py
@@ -418,12 +418,12 @@ def SetupLogging(stdout_log: bool = False) -> None:
   logger.success('Success!')
 
 
-def RunTool(cdm: Optional[CursesDisplayManager] = None) -> bool:
+def RunTool(cdm: Optional[CursesDisplayManager] = None) -> int:
   """
   Runs DFTimewolfTool.
 
   Returns:
-    bool: True if DFTimewolf could be run successfully, False otherwise.
+    int: 0 DFTimewolf could be run successfully, 1 otherwise.
   """
   time_start = time.time()*1000
   tool = DFTimewolfTool(cdm)
@@ -438,7 +438,7 @@ def RunTool(cdm: Optional[CursesDisplayManager] = None) -> bool:
     if cdm:
       cdm.EnqueueMessage('dftimewolf', str(exception), True)
     logger.critical(str(exception))
-    return False
+    return 1
 
   try:
     tool.ParseArguments(sys.argv[1:])
@@ -448,7 +448,7 @@ def RunTool(cdm: Optional[CursesDisplayManager] = None) -> bool:
     if cdm:
       cdm.EnqueueMessage('dftimewolf', str(exception), True)
     logger.critical(str(exception))
-    return False
+    return 1
 
   modules = [
     module['name'] for module in tool.state.recipe.get('modules', [])
@@ -479,13 +479,13 @@ def RunTool(cdm: Optional[CursesDisplayManager] = None) -> bool:
     if cdm:
       cdm.EnqueueMessage('dftimewolf', str(exception), True)
     logger.critical(str(exception))
-    return False
+    return 1
 
   tool.state.LogExecutionPlan()
 
   if tool.dry_run:
     logger.info("Exiting as --dry_run flag is set.")
-    return True
+    return 0
 
   time_ready = time.time()*1000
   tool.RunPreflights()
@@ -499,7 +499,7 @@ def RunTool(cdm: Optional[CursesDisplayManager] = None) -> bool:
     if cdm:
       cdm.EnqueueMessage('dftimewolf', str(exception), True)
     logger.critical(str(exception))
-    return False
+    return 1
 
   time_setup = time.time()*1000
   TELEMETRY.LogTelemetry(
@@ -511,7 +511,7 @@ def RunTool(cdm: Optional[CursesDisplayManager] = None) -> bool:
     if cdm:
       cdm.EnqueueMessage('dftimewolf', str(exception), True)
     logger.critical(str(exception))
-    return False
+    return 1
 
   time_run = time.time()*1000
   TELEMETRY.LogTelemetry(
@@ -524,14 +524,15 @@ def RunTool(cdm: Optional[CursesDisplayManager] = None) -> bool:
   for telemetry_row in tool.FormatTelemetry().split('\n'):
     logger.debug(telemetry_row)
 
-  return True
+  return 0
 
 
-def Main() -> bool:
+def Main() -> int:
   """Main function for DFTimewolf.
 
   Returns:
-    bool: True if DFTimewolf could be run successfully, False otherwise."""
+    int: 0 on success, 1 otherwise.
+  """
   no_curses = any([bool(os.environ.get('DFTIMEWOLF_NO_CURSES')),
                    not sys.stdout.isatty(),
                    not sys.stdin.isatty()])
@@ -547,7 +548,7 @@ def Main() -> bool:
   stdout_null = open(os.devnull, "w")
   stderr_sio = CDMStringIOWrapper(
       'stderr', True, cursesdisplaymanager.EnqueueMessage)
-  exit_code = False
+  exit_code = 0
 
   try:
     with redirect_stdout(stdout_null), redirect_stderr(stderr_sio):
@@ -565,7 +566,4 @@ def Main() -> bool:
 
 if __name__ == '__main__':
   signal.signal(signal.SIGINT, SignalHandler)
-  if Main():
-    sys.exit(0)
-  else:
-    sys.exit(1)
+  sys.exit(Main())

--- a/tests/cli/main_tool.py
+++ b/tests/cli/main_tool.py
@@ -11,7 +11,6 @@ from dftimewolf.lib import state as dftw_state
 from dftimewolf.lib import resources, errors
 from dftimewolf import config
 
-
 # This test recipe requires two args: Anything for arg1, and the word 'Second'
 # for arg2. The value for arg1 will be substituted into 'other_arg' in arg2.
 NESTED_ARG_RECIPE = {
@@ -140,6 +139,22 @@ class MainToolTest(unittest.TestCase):
         errors.RecipeArgsValidatorError,
         'At least one argument failed validation'):
       self.tool.ValidateArguments()
+
+  def testDryRun(self):
+    """Tests setting the dry_run flag."""
+    # pylint: disable=protected-access
+    nested_arg_recipe = resources.Recipe(
+        NESTED_ARG_RECIPE.__doc__,
+        NESTED_ARG_RECIPE,
+        NESTED_ARG_RECIPE_ARGS)
+    self.tool._state = dftw_state.DFTimewolfState(config.Config)
+    self.tool._recipes_manager.RegisterRecipe(nested_arg_recipe)
+    self.tool._state.LoadRecipe(NESTED_ARG_RECIPE, dftimewolf_recipes.MODULES)
+
+    self.tool.ParseArguments(
+        ['--dry_run', 'nested_arg_recipe', 'First', 'Not Second'])
+
+    self.assertTrue(self.tool.dry_run)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added the ability to pass an argument `--dry_run` that causes the arguments to be parsed and validated, but exists before any module execution. 

The flag needs to be between the executable and the recipe on the command line, otherwise it is treated as a recipe argument, eg 
```
poetry run dftimewolf --dry_run upload_ts <etc>
```