### PR TITLE
Added module progress reporting

### DIFF
--- a/dftimewolf/cli/curses_display_manager.py
+++ b/dftimewolf/cli/curses_display_manager.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Curses output management class."""
 
+import dataclasses
 from enum import Enum
 import io
 import textwrap
@@ -28,6 +29,13 @@ class Status(Enum):
   CANCELLED = 'Cancelled'
 
 
+@dataclasses.dataclass
+class _ModuleThread:
+  status: Status
+  container: str
+  progress: Optional[str] = None  # Of the form 'XX.X%'
+
+
 class Module:
   """An object used by the CursesDisplayManager used to represent a DFTW module.
   """
@@ -47,7 +55,7 @@ class Module:
     self.status: Status = Status.PENDING
     self._dependencies: List[str] = dependencies
     self._error_message: str = ''
-    self._threads: Dict[str, Dict[str, Any]] = {}
+    self._threads: Dict[str, _ModuleThread] = {}
     self._threads_containers_max: int = 0
     self._threads_containers_completed: int = 0
 
@@ -64,8 +72,9 @@ class Module:
       module_line += (f' - {self._threads_containers_completed} of '
           f'{self._threads_containers_max} containers completed')
       for n, t in self._threads.items():
+        percentage = f'{t.progress} ' if t.progress else ''
         thread_lines.append(
-            f'       {n}: {t["status"].value} ({t["container"]})')
+            f'       {n}: {t.status.value} {percentage}({t.container})')
 
     return [module_line] + thread_lines
 
@@ -85,9 +94,29 @@ class Module:
       status: The current status of the thread.
       container: The name of the container the thread is currently processing.
     """
-    self._threads[thread] = {'status': status, 'container': container}
+    self._threads[thread] = _ModuleThread(status, container)
     if status == Status.COMPLETED:
       self._threads_containers_completed += 1
+
+  def SetThreadProgress(self,
+                        thread_id: str,
+                        steps_taken: int,
+                        steps_expected: int) -> None:
+    """Sets a threads progress values.
+
+    Args:
+      thread_id: The thread id in question.
+      steps_taken: The number of steps taken so far.
+      steps_expected: The number of total steps expected for completion.
+
+    Raises:
+      ValueError: if thread_id is not being tracked.
+    """
+    if thread_id not in self._threads:
+      raise ValueError(f'{thread_id} not found')
+
+    self._threads[thread_id].progress = (
+        f'{steps_taken / steps_expected * 100:.1f}%')
 
   def SetError(self, message: str) -> None:
     """Sets the error for the module.
@@ -308,6 +337,29 @@ class CursesDisplayManager:
     if module in self._modules:
       self._modules[module].SetThreadState(thread, status, container)
 
+    self.Draw()
+
+  def SetModuleThreadProgress(self,
+                              module_name: str,
+                              thread_id: str,
+                              steps_taken: int,
+                              steps_expected: int) -> None:
+    """Sets the thread progress values for a processing thread in a module.
+
+    Args:
+      module_name: The module in question.
+      thread_id: The thread id in question.
+      steps_taken: The number of steps taken so far.
+      steps_expected: The number of total steps expected for completion.
+
+    Raises:
+      ValueError: If module_name or thread_id is not being tracked.
+    """
+    if module_name not in self._modules:
+      raise ValueError(f'{module_name} not found')
+
+    self._modules[module_name].SetThreadProgress(
+        thread_id, steps_taken, steps_expected)
     self.Draw()
 
   def Draw(self) -> None:

--- a/dftimewolf/lib/module.py
+++ b/dftimewolf/lib/module.py
@@ -216,6 +216,12 @@ class BaseModule(object):
   def SetUp(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
     """Sets up necessary module configuration options."""
 
+  def ProgressUpdate(self, steps_taken: int, steps_expected: int) -> None:
+    """Send an update to the state on progress."""
+    self.state.ProgressUpdate(
+        self.name, steps_taken, steps_expected)
+
+
 class PreflightModule(BaseModule):
   """Base class for preflight modules.
 

--- a/dftimewolf/lib/module.py
+++ b/dftimewolf/lib/module.py
@@ -8,6 +8,7 @@ import logging
 # we import them separately
 from logging import handlers
 import traceback
+import threading
 import sys
 
 from typing import Optional, Type, cast, TypeVar, Dict, Any, Sequence
@@ -315,3 +316,9 @@ class ThreadAwareModule(BaseModule):
     or pop them. Default behaviour is to keep the containers. Override this
     method to return false to pop them from the state."""
     return True
+
+  def ThreadProgressUpdate(self, steps_taken: int, steps_expected: int) -> None:
+    """Send an update to the state on progress."""
+    thread_id = threading.current_thread().getName()
+    self.state.ThreadProgressUpdate(
+        self.name, thread_id, steps_taken, steps_expected)

--- a/dftimewolf/lib/state.py
+++ b/dftimewolf/lib/state.py
@@ -639,7 +639,7 @@ class DFTimewolfState(object):
                      module_name: str,
                      steps_taken: int,
                      steps_expected: int) -> None:
-    """Currently unsupported with no UI in is use."""
+    """Currently unsupported when no UI is in use."""
     if not self._progress_warning_shown:
       self._progress_warning_shown = True
       logger.debug('ProgressUpdate called in unsupported display mode.')
@@ -649,7 +649,7 @@ class DFTimewolfState(object):
                            thread_id: str,
                            steps_taken: int,
                            steps_expected: int) -> None:
-    """Currently unsupported with no UI in is use."""
+    """Currently unsupported when no UI is in use."""
     if not self._progress_warning_shown:
       self._progress_warning_shown = True
       logger.debug('ProgressUpdate called in unsupported display mode.')

--- a/dftimewolf/lib/state.py
+++ b/dftimewolf/lib/state.py
@@ -635,6 +635,15 @@ class DFTimewolfState(object):
       is_error: True if the message is an error message, False otherwise.
     """
 
+  def ProgressUpdate(self,
+                     module_name: str,
+                     steps_taken: int,
+                     steps_expected: int) -> None:
+    """Currently unsupported with no UI in is use."""
+    if not self._progress_warning_shown:
+      self._progress_warning_shown = True
+      logger.debug('ProgressUpdate called in unsupported display mode.')
+
   def ThreadProgressUpdate(self,
                            module_name: str,
                            thread_id: str,
@@ -813,6 +822,20 @@ class DFTimewolfStateWithCDM(DFTimewolfState):
       message: The message content.
       is_error: True if the message is an error message, False otherwise."""
     self.cursesdm.EnqueueMessage(source, message, is_error)
+
+  def ProgressUpdate(self,
+                     module_name: str,
+                     steps_taken: int,
+                     steps_expected: int) -> None:
+    """Set the current completion status of a module.
+
+    Args:
+      module_name: The module in question.
+      steps_taken: The number of steps taken so far.
+      steps_expected: The number of total steps expected for completion.
+    """
+    self.cursesdm.SetModuleProgress(
+        module_name, steps_taken, steps_expected)
 
   def ThreadProgressUpdate(self,
                            module_name: str,

--- a/dftimewolf/lib/state.py
+++ b/dftimewolf/lib/state.py
@@ -68,6 +68,7 @@ class DFTimewolfState(object):
     self.streaming_callbacks = {}  # type: Dict[Type[interface.AttributeContainer], List[Callable[[Any], Any]]]  # pylint: disable=line-too-long
     self._abort_execution = False
     self.stdout_log = True
+    self._progress_warning_shown = False
 
   def _InvokeModulesInThreads(self, callback: Callable[[Any], Any]) -> None:
     """Invokes the callback function on all the modules in separate threads.
@@ -631,7 +632,19 @@ class DFTimewolfState(object):
     Args:
       source: The source of the message.
       message: The message content.
-      is_error: True if the message is an error message, False otherwise."""
+      is_error: True if the message is an error message, False otherwise.
+    """
+
+  def ThreadProgressUpdate(self,
+                           module_name: str,
+                           thread_id: str,
+                           steps_taken: int,
+                           steps_expected: int) -> None:
+    """Currently unsupported with no UI in is use."""
+    if not self._progress_warning_shown:
+      self._progress_warning_shown = True
+      logger.debug('ProgressUpdate called in unsupported display mode.')
+
 
 class DFTimewolfStateWithCDM(DFTimewolfState):
   """The main state class, extended to wrap methods with updates to a
@@ -800,3 +813,19 @@ class DFTimewolfStateWithCDM(DFTimewolfState):
       message: The message content.
       is_error: True if the message is an error message, False otherwise."""
     self.cursesdm.EnqueueMessage(source, message, is_error)
+
+  def ThreadProgressUpdate(self,
+                           module_name: str,
+                           thread_id: str,
+                           steps_taken: int,
+                           steps_expected: int) -> None:
+    """Set the current completion status of a module thread.
+
+    Args:
+      module_name: The module in question.
+      thread_id: The thread id in question.
+      steps_taken: The number of steps taken so far.
+      steps_expected: The number of total steps expected for completion.
+    """
+    self.cursesdm.SetModuleThreadProgress(
+        module_name, thread_id, steps_taken, steps_expected)

--- a/tests/cli/curses_display_manager.py
+++ b/tests/cli/curses_display_manager.py
@@ -162,6 +162,14 @@ class CursesDisplayManagerModuleTest(unittest.TestCase):
         self.m.Stringify(),
         ['     RuntimeName: Postprocessing'])
 
+  def testStringifyRunningWithProgress(self):
+    """Tests display of progress percentage."""
+    self.m.SetStatus(Status.RUNNING)
+    self.m.SetProgress(2, 5)
+    self.assertEqual(
+        self.m.Stringify(),
+        ['     RuntimeName: Running 40.0%'])
+
 
 class CursesDisplayManagerMessageTest(unittest.TestCase):
   """Tests for the Message helper class of the CursesDisplayManager."""
@@ -448,6 +456,7 @@ class CursesDisplayManagerTest(unittest.TestCase):
           'thread_4_0', 'container_4_0')
       self.cdm.UpdateModuleThreadState('4th Module', Status.RUNNING,
           'thread_4_0', 'container_4_4')
+      self.cdm.SetModuleProgress('2nd Module', 2, 5)
       self.cdm.SetModuleThreadProgress('3rd Module', 'thread_3_0', 1, 5)
 
       try:
@@ -474,7 +483,7 @@ class CursesDisplayManagerTest(unittest.TestCase):
           mock.call(3, 0,  '     2nd Preflight: Completed'),
           mock.call(4, 0,  '   Modules:'),
           mock.call(5, 0,  '     1st Module: Completed'),
-          mock.call(6, 0,  '     2nd Module: Running'),
+          mock.call(6, 0,  '     2nd Module: Running 40.0%'),
           mock.call(7, 0,  '     3rd Module: Processing - 1 of 5 containers completed'),
           mock.call(8, 0,  '       thread_3_0: Running 20.0% (container_3_4)'),
           mock.call(9, 0,  '       thread_3_1: Running (container_3_1)'),


### PR DESCRIPTION
Added an ability for modules to report progress updates. Currently, curses mode is supported, presented to the user as a percentage next to the module name for a single threaded module, and next to the thread for a threaded module.
```
 Recipe name
   Preflights:
     1st Preflight: Completed
     2nd Preflight: Completed
   Modules:
     1st Module: Completed
     2nd Module: Running 40.0%
     3rd Module: Processing - 1 of 5 containers completed
       thread_3_0: Running 20.0% (container_3_4)
```