### PR TITLE
Clear logging handlers on module init.

### DIFF
--- a/dftimewolf/lib/module.py
+++ b/dftimewolf/lib/module.py
@@ -57,6 +57,7 @@ class BaseModule(object):
     self.state = state
     self.logger = cast(logging_utils.WolfLogger,
                        logging.getLogger(name=self.name))
+    self.logger.handlers.clear()
     self.logger.propagate = False
     self.SetupLogging()
 


### PR DESCRIPTION
When dfTimewolf is used as a library, loading modules more than once would registger their handlers again, duplicating logging in stdout.