### PR TITLE
Add log output with link to Turbinia WebUI on request creation.

### DIFF
--- a/dftimewolf/lib/processors/turbinia_base.py
+++ b/dftimewolf/lib/processors/turbinia_base.py
@@ -373,6 +373,8 @@ class TurbiniaProcessorBase(module.BaseModule):
       self.logger.success(
           'Creating Turbinia request {0!s} with evidence {1!s}'.format(
               request_id, evidence_name))
+      self.logger.success(
+          'Turbinia request status at {0!s}'.format(self.turbinia_api))
     except turbinia_api_lib.ApiException as exception:
       self.ModuleError(str(exception), critical=True)
 


### PR DESCRIPTION
Add a log message with a link to the Turbinia WebUI so a user can easily check the status of the generated request. The current OSDFIR deployment of Turbinia deploys the webui to the same http endpoint as the api server.