### PR TITLE
Extract Telemetry from init to its own method

### DIFF
--- a/dftimewolf/cli/dftimewolf_recipes.py
+++ b/dftimewolf/cli/dftimewolf_recipes.py
@@ -115,7 +115,6 @@ class DFTimewolfTool(object):
     if not workflow_uuid:
       workflow_uuid = str(uuid.uuid4())
     self.uuid = workflow_uuid
-    self.telemetry = telemetry.GetTelemetry(uuid=self.uuid)
 
     self._DetermineDataFilesPath()
 
@@ -377,6 +376,10 @@ class DFTimewolfTool(object):
   def RecipesManager(self) -> recipes_manager.RecipesManager:
     """Returns the recipes manager."""
     return self._recipes_manager
+
+  def InitializeTelemetry(self) -> None:
+    """Initializes the telemetry object."""
+    self.telemetry = telemetry.GetTelemetry(uuid=self.uuid)
 
 
 def SignalHandler(*unused_argvs: Any) -> None:

--- a/dftimewolf/cli/dftimewolf_recipes.py
+++ b/dftimewolf/cli/dftimewolf_recipes.py
@@ -116,6 +116,7 @@ class DFTimewolfTool(object):
       workflow_uuid = str(uuid.uuid4())
     self.uuid = workflow_uuid
 
+    self.InitializeTelemetry()
     self._DetermineDataFilesPath()
 
   @property


### PR DESCRIPTION
This allows the telemetry object to be loaded with a new configuration after initializing DFTimewolfTool