### PR TITLE
Update turbinia-api-client calls

### DIFF
--- a/dftimewolf/lib/processors/turbinia_base.py
+++ b/dftimewolf/lib/processors/turbinia_base.py
@@ -170,7 +170,7 @@ class TurbiniaProcessorBase(module.BaseModule):
         self.client)
     try:
       task_id = task_data.get('id')
-      api_response = api_instance.get_task_output(
+      api_response = api_instance.get_task_output_with_http_info(
           task_id, _preload_content=False)
       filename = f'{task_id}-'
 
@@ -180,8 +180,7 @@ class TurbiniaProcessorBase(module.BaseModule):
       local_path = file.name
       self.logger.info(f'Downloading output for task {task_id} to {local_path}')
       # Read the response and write to the file.
-      for chunk in api_response.read_chunked():
-        file.write(chunk)
+      file.write(api_response.raw_data)
       file.close()
 
       # Extract the files from the tgz file.


### PR DESCRIPTION
Update the calls to Turbinia API due to updates of the API.  Corresponding API change is https://github.com/google/turbinia/pull/1357/files .