### PR TITLE
Timesketch exporter: Handle sketch names > 230 characters

### DIFF
--- a/dftimewolf/lib/exporters/timesketch.py
+++ b/dftimewolf/lib/exporters/timesketch.py
@@ -153,6 +153,11 @@ class TimesketchExporter(module.ThreadAwareModule):
       timesketch_api_client.Sketch: An instance of the sketch object.
     """
     if incident_id:
+      if len(incident_id) > 230:
+        self.logger.warning(
+          'Provided "incident_id" is > 230 characters. It will be truncated!'
+          )
+        incident_id = incident_id[:227]+'...'
       sketch_name = 'Sketch for incident ID: ' + incident_id
     else:
       sketch_name = 'Untitled sketch'


### PR DESCRIPTION
Timesketch has a character limit for sketch names of 255. (Database limitation)

This PR introduces a check for the `incident_id` length and will truncate it so that the final `sketch_name` will be max 255 characters.
Since this logic changes the user provided `incident_id`, it also logs a warning to let the user know about the change.