### PR TITLE
TurbiniaProcessorBase: Refresh credentials and handle additional exception

### DIFF
--- a/dftimewolf/lib/processors/turbinia_base.py
+++ b/dftimewolf/lib/processors/turbinia_base.py
@@ -272,7 +272,8 @@ class TurbiniaProcessorBase(module.BaseModule):
     """Refreshes credentials and initializes new API client."""
     refresh = False
     if self.credentials and self.credentials.expired:
-      self.PublishMessage("Credentials invalid or expired. Re-authenticating...")
+      self.PublishMessage(
+          "Turbinia credentials invalid or expired. Re-authenticating...")
       self.credentials = self.GetCredentials(
           self.credentials_path, self.client_secrets_path)
       self.client = self.InitializeTurbiniaApiClient(self.credentials)

--- a/dftimewolf/lib/processors/turbinia_base.py
+++ b/dftimewolf/lib/processors/turbinia_base.py
@@ -476,7 +476,8 @@ class TurbiniaProcessorBase(module.BaseModule):
               processed_paths.add(path)
               yield task, path
 
-      except turbinia_api_lib.exceptions.ApiException as exception:
+      except (turbinia_api_lib.exceptions.ApiException,
+          turbinia_api_lib.exceptions.UnauthorizedException) as exception:
         retries += 1
         self.logger.warning(f'Retrying after exception: {exception.body}')
 

--- a/dftimewolf/lib/processors/turbinia_base.py
+++ b/dftimewolf/lib/processors/turbinia_base.py
@@ -272,6 +272,7 @@ class TurbiniaProcessorBase(module.BaseModule):
     """Refreshes credentials and initializes new API client."""
     refresh = False
     if self.credentials and self.credentials.expired:
+      self.PublishMessage("Credentials invalid or expired. Re-authenticating...")
       self.credentials = self.GetCredentials(
           self.credentials_path, self.client_secrets_path)
       self.client = self.InitializeTurbiniaApiClient(self.credentials)
@@ -397,6 +398,11 @@ class TurbiniaProcessorBase(module.BaseModule):
 
     # Send the request to the API server.
     try:
+      # Refresh token if needed
+      if self.RefreshClientCredentials():
+        self.requests_api_instance = (
+            turbinia_requests_api.TurbiniaRequestsApi(self.client)
+        )
       api_response = self.requests_api_instance.create_request_with_http_info(
         request) # type: ignore
       decoded_response = self._decode_api_response(api_response)
@@ -444,6 +450,7 @@ class TurbiniaProcessorBase(module.BaseModule):
     while status == 'running' and retries < 3:
       time.sleep(interval)
       try:
+        # Refresh token if needed
         if self.RefreshClientCredentials():
           self.requests_api_instance = (
               turbinia_requests_api.TurbiniaRequestsApi(self.client)
@@ -483,6 +490,7 @@ class TurbiniaProcessorBase(module.BaseModule):
 
   def TurbiniaFinishReport(self, request_id: str) -> str:
     """This method generates a report for a Turbinia request."""
+    # Refresh token if needed
     if self.RefreshClientCredentials():
       self.requests_api_instance = turbinia_requests_api.TurbiniaRequestsApi(
           self.client


### PR DESCRIPTION
This PR should handle some authentication errors that were previously missed, for example by not checking if the token was still valid before sending a request in TurbiniaStart(). This is rare but can happen if another module takes 8+ hours before passing data along to the Turbinia module, by which time the access token expires.