### PR TITLE
Timesketch Exporter fix logged sketch URL

### DIFF
--- a/dftimewolf/lib/exporters/timesketch.py
+++ b/dftimewolf/lib/exporters/timesketch.py
@@ -276,7 +276,7 @@ class TimesketchExporter(module.ThreadAwareModule):
     if self.wait_for_timelines:
       self._WaitForTimelines()
 
-    sketch_url = '{0:s}sketches/{1:d}/'.format(host_url, self.sketch.id)
+    sketch_url = '{0:s}sketch/{1:d}/'.format(host_url, self.sketch.id)
     message = 'Your Timesketch URL is: {0:s}'.format(sketch_url)
     self.PublishMessage(message)
 

--- a/tests/lib/exporters/timesketch.py
+++ b/tests/lib/exporters/timesketch.py
@@ -102,7 +102,7 @@ class TimesketchExporterTest(unittest.TestCase):
     self.assertEqual(report.module_name, 'TimesketchExporter')
     self.assertEqual(
         report.text,
-        'Your Timesketch URL is: timesketch.com/sketches/1234/')
+        'Your Timesketch URL is: timesketch.com/sketch/1234/')
     self.assertEqual(report.text_format, 'markdown')
 
   # pylint: disable=invalid-name


### PR DESCRIPTION
This PR fixes the sketch URL posted to the log by the Timesketch Exporter module.