### PR TITLE
updated docs link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ Github actions |  [Codecov](https://codecov.io/) | [CodeFactor](https://codefact
 
 ### Getting started
 
-[Documentation](https://log2timeline.github.io/dftimewolf/) is hosted on GitHub pages.
+[Documentation](https://dftimewolf.readthedocs.io/en/dev/getting-started.html) is hosted on readthedocs.io.


### PR DESCRIPTION
The link to the docs in README is broken.  Updating the link to point to dfTimewolf docs and adjusting related phrasing accordingly.