### PR TITLE
Remove py3.11 installation from jenkins set up script

### DIFF
--- a/config/e2e/jenkins_dftimewolf_install.sh
+++ b/config/e2e/jenkins_dftimewolf_install.sh
@@ -8,8 +8,6 @@ set -e
 
 sudo add-apt-repository ppa:gift/dev -y
 sudo apt-get update -qq
-# Ubuntu 20.04 comes with python 3.8, we only support >= 3.11
-sudo apt-get install -y python3.11
 sudo apt-get install -y python3-pip
 sudo apt-get install --reinstall python3-apt
 python3 --version


### PR DESCRIPTION
The Jenkins runners have been updated, and now come with py3.12 by default. 