### PR TITLE
Add workspace device logs recipe

### DIFF
--- a/data/recipes/workspace_user_device_ts.json
+++ b/data/recipes/workspace_user_device_ts.json
@@ -1,0 +1,51 @@
+{
+  "name": "workspace_user_device_ts",
+  "description": "Collects mobile (Device Audit activity) records for a Workspace user and adds them to Timesketch.",
+  "short_description": "Collects mobile records and adds to Timesketch",
+  "preflights": [],
+  "modules": [
+    {
+      "wants": [],
+      "name": "WorkspaceAuditCollector",
+      "args": {
+        "application_name": "mobile",
+        "user_key": "@user",
+        "filter_expression": "@filter_expression",
+        "start_time": "@start_time",
+        "end_time": "@end_time"
+      }
+    },
+    {
+      "wants": ["WorkspaceAuditCollector"],
+      "name": "WorkspaceAuditTimesketch",
+      "args": {}
+    },
+    {
+      "wants": ["WorkspaceAuditTimesketch"],
+      "name": "TimesketchExporter",
+      "args": {
+        "incident_id": "@incident_id",
+        "token_password": "@token_password",
+        "endpoint": "@timesketch_endpoint",
+        "username": "@timesketch_username",
+        "password": "@timesketch_password",
+        "sketch_id": "@sketch_id",
+        "analyzers": null,
+        "wait_for_timelines": "@wait_for_timelines"
+      }
+    }
+  ],
+  "args": [
+    ["user", "email address of the user to query logs for",""],
+    ["--start_time", "Start time.", null, {"format": "datetime", "before": "@end_time"}],
+    ["--end_time", "End time.", null, {"format": "datetime_end", "after": "@start_time"}],
+    ["--filter_expression", "Filter expression to use to query Workspace logs. See https://developers.google.com/admin-sdk/reports/reference/rest/v1/activities/list",""],
+    ["--incident_id", "Incident ID (used for Timesketch description).", null],
+    ["--sketch_id", "Timesketch sketch to which the timeline should be added.", null, {"format": "regex", "regex": "^\\d+$"}],
+    ["--timesketch_endpoint", "Timesketch endpoint", "http://localhost:5000/"],
+    ["--timesketch_username", "Username for Timesketch server.", null],
+    ["--timesketch_password", "Password for Timesketch server.", null],
+    ["--token_password", "Optional custom password to decrypt Timesketch credential file with.", ""],
+    ["--wait_for_timelines", "Whether to wait for Timesketch to finish processing all timelines.", true]
+  ]
+}


### PR DESCRIPTION
Adds a new workspace mobile/device recipe to pull these logs and put them into Timesketch to help with correlation with other workspace logs.

Recreated from https://github.com/log2timeline/dftimewolf/pull/866 as seemed to have pulled all the new commits as part of the PR 