### PR TITLE
Upgrade jenkins script

### DIFF
--- a/config/e2e/e2e_grr_artifact_hosts.sh
+++ b/config/e2e/e2e_grr_artifact_hosts.sh
@@ -7,6 +7,7 @@ set -e
 sudo sysctl -w vm.max_map_count=262144
 bash ./config/e2e/jenkins_dftimewolf_install.sh include-docker include-grr include-timesketch include-plaso
 export DFTIMEWOLF_NO_RAINBOW=true
+export DFTIMEWOLF_DEBUG=true
 PYTHONPATH=. poetry run python tests/test_dftimewolf.py
 PYTHONPATH=. poetry run python dftimewolf/cli/dftimewolf_recipes.py --help
 PYTHONPATH=. poetry run python dftimewolf/cli/dftimewolf_recipes.py grr_artifact_ts $NODE_NAME test --artifacts LinuxAuditLogs --timesketch_endpoint http://localhost:80/ --timesketch_username test --timesketch_password test

--- a/config/e2e/jenkins_dftimewolf_install.sh
+++ b/config/e2e/jenkins_dftimewolf_install.sh
@@ -33,7 +33,7 @@ if [[ "$*" =~ "include-docker" ]]; then
     sudo apt-get update
 
     echo "install docker packages"
-    sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+    sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 fi
 
 if [[ "$*" =~ "include-grr" ]]; then

--- a/config/e2e/jenkins_dftimewolf_install.sh
+++ b/config/e2e/jenkins_dftimewolf_install.sh
@@ -17,16 +17,17 @@ python3 --version
 if [[ "$*" =~ "include-docker" ]]; then
     # follow instructions at https://docs.docker.com/engine/install/debian/
     echo "Removing conflicting packages"
-    for pkg in docker.io docker-doc docker-compose podman-docker containerd runc; do sudo apt-get remove $pkg; done
+    for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do sudo apt-get remove $pkg; done
 
     echo "adding docker key"
+    sudo apt-get update
     sudo apt-get install -y ca-certificates curl
     sudo install -m 0755 -d /etc/apt/keyrings
-    sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+    sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
     sudo chmod a+r /etc/apt/keyrings/docker.asc
 
     echo \
-        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
         $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
         sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     sudo apt-get update

--- a/config/e2e/jenkins_dftimewolf_install.sh
+++ b/config/e2e/jenkins_dftimewolf_install.sh
@@ -74,8 +74,8 @@ if [[ "$*" =~ "include-timesketch" ]]; then
     cd timesketch
     cd docker
     cd e2e
-    echo "Running the Timesketch docker-compose script"
-    sudo -E docker-compose up -d
+    echo "Running the Timesketch docker compose script"
+    sudo -E docker compose up -d
     # Wait for Timesketch to initialize
     echo "Sleeping 300 seconds..."
     /bin/sleep 300

--- a/config/e2e/jenkins_dftimewolf_install.sh
+++ b/config/e2e/jenkins_dftimewolf_install.sh
@@ -15,18 +15,24 @@ python3 --version
 
 
 if [[ "$*" =~ "include-docker" ]]; then
-    echo "Adding docker key"
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-    sudo add-apt-repository \
-       "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-       $(lsb_release -cs) \
-       stable"
-    echo "apt update and install docker-ce"
-    sudo apt-get update -qq
-    sudo apt-get install -qq -y docker-ce
-    curl -L https://github.com/docker/compose/releases/download/1.26.1/docker-compose-$(uname -s)-$(uname -m) -o docker-compose
-    sudo cp docker-compose /usr/local/bin/docker-compose
-    sudo chmod +x /usr/local/bin/docker-compose
+    # follow instructions at https://docs.docker.com/engine/install/debian/
+    echo "Removing conflicting packages"
+    for pkg in docker.io docker-doc docker-compose podman-docker containerd runc; do sudo apt-get remove $pkg; done
+
+    echo "adding docker key"
+    sudo apt-get install -y ca-certificates curl
+    sudo install -m 0755 -d /etc/apt/keyrings
+    sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+    sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+    echo \
+        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+        $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+        sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+    sudo apt-get update
+
+    echo "install docker packages"
+    sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 fi
 
 if [[ "$*" =~ "include-grr" ]]; then

--- a/docker/dev/README.md
+++ b/docker/dev/README.md
@@ -23,21 +23,21 @@ Make sure you have Docker installed (sudoless) and run:
 
 ```bash
 cd docker/dev
-docker-compose run --rm dftw tests
+docker compose run --rm dftw tests
 ```
 
 This will build the dfTimewolf Docker image using `docker/dev/Dockerfile`, and
 run the dfTimewolf tests against the version of the code that lives on the host
 filesystem.
 
-The `docker-compose` scripts mounts the top-level directory of the dfTimewolf
+The `docker compose` scripts mounts the top-level directory of the dfTimewolf
 code repo on `/app` in the container, and tests are run from there.
 
 ## Shell access
 
 ```bash
 $ cd docker/dev
-$ docker-compose run --rm dftw envshell
+$ docker compose run --rm dftw envshell
 (dftimewolf-py3.10) root@f3a2cc77dc3e:/app# python -m unittest discover -s tests -p '*.py'
 ```
 

--- a/docker/dftimewolf-release/README.md
+++ b/docker/dftimewolf-release/README.md
@@ -23,21 +23,21 @@ Make sure you have Docker installed (sudoless) and run:
 
 ```bash
 cd docker/dftimewolf-dev
-docker-compose run --rm dftw tests
+docker compose run --rm dftw tests
 ```
 
 This will build the dfTimewolf Docker image using `docker/dev/Dockerfile`, and
 run the dfTimewolf tests against the version of the code that lives on the host
 filesystem.
 
-The `docker-compose` scripts mounts the top-level directory of the dfTimewolf
+The `docker compose` scripts mounts the top-level directory of the dfTimewolf
 code repo on `/app` in the container, and tests are run from there.
 
 ## Shell access
 
 ```bash
 $ cd docker/dftimewolf-dev
-$ docker-compose run --rm dftw envshell
+$ docker compose run --rm dftw envshell
 (dftimewolf-py3.10) root@f3a2cc77dc3e:/app# python -m unittest discover -s tests -p '*.py'
 ```
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -30,7 +30,7 @@ dependencies in.
 
 ```
 $ cd docker/dev
-$ docker-compose run --rm dftw envshell
+$ docker compose run --rm dftw envshell
 [...]
 (dftimewolf-py3.10) root@3bb3a1ddec53:/app# poetry run dftimewolf -h
 ```
@@ -136,5 +136,5 @@ Docker equivalent:
 
 ```bash
 cd docker/dev
-docker-compose run --rm dftw tests
+docker compose run --rm dftw tests
 ```


### PR DESCRIPTION
Upgrades the docker instructions to use the modern `docker compose` instead of legacy `docker-compose`