### PR TITLE
Add support for downloading osquery results with GrrFlowCollector

### DIFF
--- a/dftimewolf/lib/collectors/grr_hosts.py
+++ b/dftimewolf/lib/collectors/grr_hosts.py
@@ -1130,6 +1130,11 @@ class GRROsqueryCollector(GRRFlow):
     results = []
     for result in list_results:
       payload = result.payload
+      if isinstance(payload, osquery_flows.OsqueryCollectedFile):
+        # We don't do anything with any collected files for now as we are just
+        # interested in the osquery results.
+        self.logger.info(f'File collected - {payload.stat_entry.path_spec}.')
+        continue
       if not isinstance(payload, osquery_flows.OsqueryResult):
         self.logger.error(f'Incorrect results format from flow ID {grr_flow}')
         continue

--- a/dftimewolf/lib/collectors/grr_hosts.py
+++ b/dftimewolf/lib/collectors/grr_hosts.py
@@ -443,7 +443,7 @@ class GRRFlow(GRRBaseModule, module.ThreadAwareModule):
     
     Returns:
       str: the path to the CSV file or None if there are no results.
-    """"
+    """
     grr_flow = client.Flow(flow_id)
     list_results = list(grr_flow.ListResults())
 

--- a/dftimewolf/lib/collectors/grr_hosts.py
+++ b/dftimewolf/lib/collectors/grr_hosts.py
@@ -440,7 +440,7 @@ class GRRFlow(GRRBaseModule, module.ThreadAwareModule):
       client: the GRR Client.
       flow_id: the Osquery flow ID to download results from.
       flow_output_dir: the directory to store the downloaded timeline.
-    
+
     Returns:
       str: the path to the CSV file or None if there are no results.
     """
@@ -457,7 +457,8 @@ class GRRFlow(GRRBaseModule, module.ThreadAwareModule):
       if isinstance(payload, osquery_flows.OsqueryCollectedFile):
         # We don't do anything with any collected files for now as we are just
         # interested in the osquery results.
-        self.logger.info(f'Skipping collected file - {payload.stat_entry.path_spec}.')
+        self.logger.info(
+            f'Skipping collected file - {payload.stat_entry.path_spec}.')
         continue
       if not isinstance(payload, osquery_flows.OsqueryResult):
         self.logger.error(f'Incorrect results format from flow ID {flow_id}')
@@ -472,12 +473,12 @@ class GRRFlow(GRRBaseModule, module.ThreadAwareModule):
 
     fqdn = client.data.os_info.fqdn.lower()
     output_file_path = os.path.join(
-        flow_output_dir, 
+        flow_output_dir,
         '.'.join(str(val) for val in (fqdn, flow_id, 'csv')))
     with open(output_file_path, mode='w') as fd:
       merged_data_frame = pd.concat(results)
       merged_data_frame.to_csv(fd)
-    
+
     return output_file_path
 
   def _DownloadFiles(self, client: Client, flow_id: str) -> Optional[str]:
@@ -497,12 +498,13 @@ class GRRFlow(GRRBaseModule, module.ThreadAwareModule):
     os.makedirs(flow_output_dir, exist_ok=True)
 
     flow_name = flow_handle.data.name
-    if flow_name == "TimelineFlow":
-      self.logger.debug("Downloading timeline from GRR")
+    if flow_name == 'TimelineFlow':
+      self.logger.debug('Downloading timeline from GRR')
       self._DownloadTimeline(client, flow_handle, flow_output_dir)
       return flow_output_dir
-    elif flow_name == 'OsqueryFlow':
-      self.logger.debug("Downloading osquery results from GRR")
+    
+    if flow_name == 'OsqueryFlow':
+      self.logger.debug('Downloading osquery results from GRR')
       self._DownloadOsquery(client, flow_id, flow_output_dir)
       return flow_output_dir
 

--- a/dftimewolf/lib/collectors/grr_hosts.py
+++ b/dftimewolf/lib/collectors/grr_hosts.py
@@ -1192,20 +1192,20 @@ class GRROsqueryCollector(GRRFlow):
       self.state.StoreContainer(results_container)
       return
 
-    for data_frame in results:
-      self.logger.info(
-          f'{str(flow_id)} ({hostname}): {len(data_frame)} rows collected')
+    merged_results = pd.concat(results)
+    self.logger.info(
+        f'{str(flow_id)} ({hostname}): {len(merged_results)} rows collected')
 
-      dataframe_container = containers.OsqueryResult(
-          name=name,
-          description=description,
-          query=query,
-          hostname=hostname,
-          data_frame=data_frame,
-          flow_identifier=flow_identifier,
-          client_identifier=client_identifier)
+    dataframe_container = containers.OsqueryResult(
+        name=name,
+        description=description,
+        query=query,
+        hostname=hostname,
+        data_frame=merged_results,
+        flow_identifier=flow_identifier,
+        client_identifier=client_identifier)
 
-      self.state.StoreContainer(dataframe_container)
+    self.state.StoreContainer(dataframe_container)
 
   def Process(self, container: containers.Host
               ) -> None:  # pytype: disable=signature-mismatch

--- a/dftimewolf/lib/collectors/grr_hosts.py
+++ b/dftimewolf/lib/collectors/grr_hosts.py
@@ -502,7 +502,7 @@ class GRRFlow(GRRBaseModule, module.ThreadAwareModule):
       self.logger.debug('Downloading timeline from GRR')
       self._DownloadTimeline(client, flow_handle, flow_output_dir)
       return flow_output_dir
-    
+
     if flow_name == 'OsqueryFlow':
       self.logger.debug('Downloading osquery results from GRR')
       self._DownloadOsquery(client, flow_id, flow_output_dir)

--- a/dftimewolf/lib/collectors/grr_hosts.py
+++ b/dftimewolf/lib/collectors/grr_hosts.py
@@ -428,6 +428,58 @@ class GRRFlow(GRRBaseModule, module.ThreadAwareModule):
     timeline.WriteToFile(final_bodyfile_path)
     return final_bodyfile_path
 
+  def _DownloadOsquery(
+      self,
+      client: Client,
+      flow_id: str,
+      flow_output_dir: str
+  ) -> Optional[str]:
+    """Download osquery results as a CSV file.
+
+    Args:
+      client: the GRR Client.
+      flow_id: the Osquery flow ID to download results from.
+      flow_output_dir: the directory to store the downloaded timeline.
+    
+    Returns:
+      str: the path to the CSV file or None if there are no results.
+    """"
+    grr_flow = client.Flow(flow_id)
+    list_results = list(grr_flow.ListResults())
+
+    if not list_results:
+      self.logger.warning(f"No results returned for flow ID {flow_id}")
+      return None
+
+    results = []
+    for result in list_results:
+      payload = result.payload
+      if isinstance(payload, osquery_flows.OsqueryCollectedFile):
+        # We don't do anything with any collected files for now as we are just
+        # interested in the osquery results.
+        self.logger.info(f'Skipping collected file - {payload.stat_entry.path_spec}.')
+        continue
+      if not isinstance(payload, osquery_flows.OsqueryResult):
+        self.logger.error(f'Incorrect results format from flow ID {flow_id}')
+        continue
+
+      headers = [column.name for column in payload.table.header.columns]
+      data = []
+      for row in payload.table.rows:
+        data.append(row.values)
+      data_frame = pd.DataFrame.from_records(data, columns=headers)
+      results.append(data_frame)
+
+    fqdn = client.data.os_info.fqdn.lower()
+    output_file_path = os.path.join(
+        flow_output_dir, 
+        '.'.join(str(val) for val in (fqdn, flow_id, 'csv')))
+    with open(output_file_path, mode='w') as fd:
+      merged_data_frame = pd.concat(results)
+      merged_data_frame.to_csv(fd)
+    
+    return output_file_path
+
   def _DownloadFiles(self, client: Client, flow_id: str) -> Optional[str]:
     """Download files/results from the specified flow.
 
@@ -448,6 +500,10 @@ class GRRFlow(GRRBaseModule, module.ThreadAwareModule):
     if flow_name == "TimelineFlow":
       self.logger.debug("Downloading timeline from GRR")
       self._DownloadTimeline(client, flow_handle, flow_output_dir)
+      return flow_output_dir
+    elif flow_name == 'OsqueryFlow':
+      self.logger.debug("Downloading osquery results from GRR")
+      self._DownloadOsquery(client, flow_id, flow_output_dir)
       return flow_output_dir
 
     payloads = []

--- a/dftimewolf/lib/collectors/grr_hunt.py
+++ b/dftimewolf/lib/collectors/grr_hunt.py
@@ -910,6 +910,12 @@ class GRRHuntOsqueryDownloader(GRRHuntDownloaderBase):
       grr_client = list(self.grr_api.SearchClients(result.client.client_id))[0]
       client_hostname = grr_client.data.os_info.fqdn.lower()
 
+      if isinstance(payload, osquery_flows.OsqueryCollectedFile):
+        # We don't do anything with any collected files for now as we are just
+        # interested in the osquery results.
+        self.logger.info(f'File collected - {payload.stat_entry.path_spec}.')
+        continue
+
       if not isinstance(payload, osquery_flows.OsqueryResult):
         self.ModuleError(
             f'Incorrect results format from {result.client.client_id} '

--- a/tests/lib/collectors/grr_hosts.py
+++ b/tests/lib/collectors/grr_hosts.py
@@ -163,6 +163,14 @@ class GRRFlowTests(unittest.TestCase):
       "/tmp/random/tomchop/F:12345", exist_ok=True
     )
 
+  def testDownloadOsqueryForFlow(self):
+    """Tests if Osquery results are downloaded in the correct directories."""
+    self.grr_flow_module.output_path = "/tmp/random"
+    mock_Get.return_value.data.name = 'OsqueryFlow'
+    mock_Get.return_value.ListResults = mock.MagicMock()
+    return_value = self.grr_flow_module._DownloadOsquery(
+        mock_grr_hosts.MOCK_CLIENT, 'F:12345')
+    self.assertEqual(return_value, '/tmp/random/tomchop/F:12345')
 
 class GRRArtifactCollectorTest(unittest.TestCase):
   """Tests for the GRR artifact collector."""

--- a/tests/lib/collectors/grr_hosts.py
+++ b/tests/lib/collectors/grr_hosts.py
@@ -163,14 +163,18 @@ class GRRFlowTests(unittest.TestCase):
       "/tmp/random/tomchop/F:12345", exist_ok=True
     )
 
-  def testDownloadOsqueryForFlow(self):
+  @mock.patch("builtins.open")
+  @mock.patch('grr_api_client.flow.FlowBase.ListResults')
+  def testDownloadOsqueryForFlow(self, mock_ListResults, unused_mock_open):
     """Tests if Osquery results are downloaded in the correct directories."""
-    self.grr_flow_module.output_path = "/tmp/random"
-    mock_Get.return_value.data.name = 'OsqueryFlow'
-    mock_Get.return_value.ListResults = mock.MagicMock()
+    mock_flowresult = mock.MagicMock()
+    mock_flowresult.payload = osquery_pb2.OsqueryResult()
+    mock_ListResults.return_value = [
+        mock_flowresult
+    ]
     return_value = self.grr_flow_module._DownloadOsquery(
-        mock_grr_hosts.MOCK_CLIENT, 'F:12345')
-    self.assertEqual(return_value, '/tmp/random/tomchop/F:12345')
+        mock_grr_hosts.MOCK_CLIENT, 'F:12345', '/tmp/random')
+    self.assertEqual(return_value, '/tmp/random/tomchop.F:12345.csv')
 
 class GRRArtifactCollectorTest(unittest.TestCase):
   """Tests for the GRR artifact collector."""


### PR DESCRIPTION
Fixes #755 

In addition, GRR "chunks" osquery results [0] which when being retrieved, results in multiple OsqueryResult payloads and subsequently multiple dataframes/CSVs.  This PR changes the behaviour in GRROsqueryCollector and GRRHuntOsqueryDownloader to merge results into a single dataframe (as with the new method in GrrFlowCollector)

[0] https://github.com/google/grr/blob/master/grr/client/grr_response_client/client_actions/osquery.py#L81
