### PR TITLE
Updates to GRR Osquery modules

### DIFF
--- a/dftimewolf/lib/collectors/grr_hosts.py
+++ b/dftimewolf/lib/collectors/grr_hosts.py
@@ -458,7 +458,7 @@ class GRRFlow(GRRBaseModule, module.ThreadAwareModule):
         # We don't do anything with any collected files for now as we are just
         # interested in the osquery results.
         self.logger.info(
-            f'Skipping collected file - {payload.stat_entry.path_spec}.')
+            f'Skipping collected file - {payload.stat_entry.pathspec}.')
         continue
       if not isinstance(payload, osquery_flows.OsqueryResult):
         self.logger.error(f'Incorrect results format from flow ID {flow_id}')
@@ -1213,7 +1213,7 @@ class GRROsqueryCollector(GRRFlow):
       if isinstance(payload, osquery_flows.OsqueryCollectedFile):
         # We don't do anything with any collected files for now as we are just
         # interested in the osquery results.
-        self.logger.info(f'File collected - {payload.stat_entry.path_spec}.')
+        self.logger.info(f'File collected - {payload.stat_entry.pathspec}.')
         continue
       if not isinstance(payload, osquery_flows.OsqueryResult):
         self.logger.error(f'Incorrect results format from flow ID {grr_flow}')

--- a/dftimewolf/lib/collectors/grr_hunt.py
+++ b/dftimewolf/lib/collectors/grr_hunt.py
@@ -913,7 +913,7 @@ class GRRHuntOsqueryDownloader(GRRHuntDownloaderBase):
       if isinstance(payload, osquery_flows.OsqueryCollectedFile):
         # We don't do anything with any collected files for now as we are just
         # interested in the osquery results.
-        self.logger.info(f'File collected - {payload.stat_entry.path_spec}.')
+        self.logger.info(f'File collected - {payload.stat_entry.pathspec}.')
         continue
 
       if not isinstance(payload, osquery_flows.OsqueryResult):


### PR DESCRIPTION
* Fixes `pathspec` proto field name (from `path_spec`).  
* Adds client hostname and client ID as additional columns when collecting osquery hunt results