### PR TITLE
New GC Recipe gcp_logging_l2t_ts

### DIFF
--- a/data/recipes/gcp_logging_l2t_ts.json
+++ b/data/recipes/gcp_logging_l2t_ts.json
@@ -1,0 +1,64 @@
+{
+  "name": "gcp_logging_l2t_ts",
+  "short_description": "Collects logs from a GCP project and sends them to Timesketch.",
+  "description": "Collects logs from a GCP project, parses the logs with Plaso, and sends them to Timesketch. https://cloud.google.com/logging/docs/view/query-library for example queries.",
+  "test_params": "project-name filter_expression",
+  "preflights": [
+    {
+      "wants": [],
+      "name": "GCPTokenCheck",
+      "args": {
+        "project_name": "@project_name"
+      }
+    }
+  ],
+  "modules": [
+    {
+      "wants": [],
+      "name": "GCPLogsCollector",
+      "args": {
+        "project_name": "@project_name",
+        "filter_expression": "@filter_expression",
+        "backoff": "@backoff",
+        "delay": "@delay",
+        "start_time": null,
+        "end_time": null
+      }
+    },{
+      "wants": ["GCPLogsCollector"],
+      "name": "LocalPlasoProcessor",
+      "args": {
+        "timezone": null,
+        "use_docker": "@use_docker"
+      }
+  }, {
+      "wants": ["LocalPlasoProcessor"],
+      "name": "TimesketchExporter",
+      "args": {
+        "incident_id": "@incident_id",
+        "token_password": "@token_password",
+        "endpoint": "@timesketch_endpoint",
+        "username": "@timesketch_username",
+        "password": "@timesketch_password",
+        "sketch_id": "@sketch_id",
+        "analyzers": "@analyzers",
+        "wait_for_timelines": "@wait_for_timelines"
+      }
+    }
+  ],
+  "args": [
+    ["project_name", "Name of the GCP project to collect logs from.", null, {"format": "regex", "comma_separated": false, "regex": "^[a-z][-a-z0-9]{4,28}[a-z0-9]$"}],
+    ["filter_expression", "Filter expression to use to query GCP logs. See https://cloud.google.com/logging/docs/view/query-library for examples.", "resource.type = 'gce_instance'"],
+    ["--backoff", "If GCP Cloud Logging API query limits are exceeded, retry with an increased delay between each query to try complete the query at a slower rate.", false],
+    ["--delay", "Number of seconds to wait between each GCP Cloud Logging query to avoid hitting API query limits", "0", {"format": "integer"}],
+    ["--analyzers", "Timesketch analyzers to run.", null],
+    ["--sketch_id", "Timesketch sketch to which the timeline should be added.", null, {"format": "integer"}],
+    ["--timesketch_endpoint", "Timesketch endpoint", "http://localhost:5000/"],
+    ["--timesketch_username", "Username for Timesketch server.", null],
+    ["--timesketch_password", "Password for Timesketch server.", null],
+    ["--token_password", "Optional custom password to decrypt Timesketch credential file with.", ""],
+    ["--incident_id", "Incident ID (used for Timesketch description).", null],
+    ["--wait_for_timelines", "Whether to wait for Timesketch to finish processing all timelines.", true],
+    ["--use_docker", "Use Plaso in a Docker Container", true]
+  ]
+}


### PR DESCRIPTION
Added a new recipe that will collect the logs from GC, and then parse them with Docker Plaso, and then submit to Timesketch.

The current gcp_logging_ts doesn't process the data via Plaso. As such, the data is in a different format then with other gcp log collection options. This resolves that issue.