### PR TITLE
Updated GCPLoggingTimesketch attributes.

### DIFF
--- a/data/recipes/gcp_logging_ts.json
+++ b/data/recipes/gcp_logging_ts.json
@@ -26,8 +26,13 @@
       }
     },
     {
+      "wants": ["GCPLogsCollector"],
+      "name": "GCPLoggingTimesketch",
+      "args": {}
+    },
+    {
       "wants": [
-        "GCPLogsCollector"
+        "GCPLoggingTimesketch"
       ],
       "name": "TimesketchExporter",
       "args": {

--- a/dftimewolf/lib/processors/gcp_logging_timesketch.py
+++ b/dftimewolf/lib/processors/gcp_logging_timesketch.py
@@ -71,12 +71,10 @@ class GCPLoggingTimesketch(BaseModule):
     json_payload = log_record.get('jsonPayload', None)
     if json_payload:
       self._ParseJSONPayload(json_payload, timesketch_record)
-      timesketch_record['jsonPayload'] = json_payload
 
     proto_payload = log_record.get('protoPayload', None)
     if proto_payload:
       self._parse_proto_payload(proto_payload, timesketch_record)
-      timesketch_record['protoPayload'] = proto_payload
 
     text_payload = log_record.get('textPayload', None)
     if text_payload:

--- a/dftimewolf/lib/processors/gcp_logging_timesketch.py
+++ b/dftimewolf/lib/processors/gcp_logging_timesketch.py
@@ -250,7 +250,8 @@ class GCPLoggingTimesketch(BaseModule):
     """Processes a GCP logs container.
 
     Args:
-      logs_container (GCPLogs): logs container.
+      logs_container Union[containers.File, containers.Directory]:
+          container containing GCPLogsCollector output file.
     """
     if not logs_container.path:
       return
@@ -269,17 +270,13 @@ class GCPLoggingTimesketch(BaseModule):
     output_file.close()
 
     current_timestamp = datetime.utcnow().strftime('%Y%m%d%H%M%S')
-    timeline_name = f'gcp_log_{current_timestamp}'
+    timeline_name = f'{current_timestamp}'
 
     container = containers.File(name=timeline_name, path=output_path)
     self.StoreContainer(container)
 
   def Process(self) -> None:
     """Processes GCP logs containers for insertion into Timesketch."""
-    #logs_containers = self.GetContainers(containers.GCPLogs)
-    #for logs_container in logs_containers:
-    #  self._ProcessLogContainer(logs_container)
-
     combined_list = []
 
     for file_container in self.GetContainers(containers.File, pop=True):

--- a/dftimewolf/lib/processors/gcp_logging_timesketch.py
+++ b/dftimewolf/lib/processors/gcp_logging_timesketch.py
@@ -2,6 +2,7 @@
 """Processes Google Cloud Platform (GCP) logs for loading into Timesketch."""
 
 import json
+import re
 import tempfile
 from datetime import datetime
 from typing import Any, Dict, Optional, TYPE_CHECKING
@@ -84,41 +85,157 @@ class GCPLoggingTimesketch(BaseModule):
 
     return json.dumps(timesketch_record)
 
-  def _parse_proto_payload(
+  def _ParseAuthenticationInfo(
       self,
       proto_payload: Dict[str, Any],
-      timesketch_record: Dict[str, str]) -> None:
-    """Extracts information from a protoPayload field in a GCP log.
-
-    protoPayload is set for all cloud audit events.
+      timesketch_record: Dict[str, Any]) -> None:
+    """Extracts `protoPayload.authenticationInfo` field in a GCP log.
 
     Args:
-      proto_payload (dict): the contents of a GCP protoPayload field.
-      timesketch_record (dict): a dictionary that will be serialized to JSON
-        and uploaded to Timesketch.
+      proto_payload: the content of a GCP protoPaylaod field.
+      timesketch_record: a dictionary that will be serialized to JSON and
+          uploaded to Timesketch.
     """
     authentication_info = proto_payload.get('authenticationInfo', None)
     if authentication_info:
       principal_email = authentication_info.get('principalEmail', None)
       if principal_email:
-        timesketch_record['principalEmail'] = principal_email
+        timesketch_record['principal_email'] = principal_email
 
-    request_metadata = proto_payload.get('requestMetadata', None)
-    if request_metadata:
-      for attribute, value in request_metadata.items():
-        timesketch_attribute = attribute
-        timesketch_record[timesketch_attribute] = value
+      principal_subject = authentication_info.get('principalSubject', None)
+      if principal_subject:
+        timesketch_record['principal_subject'] = principal_subject
 
-    proto_attributes = ['serviceName', 'methodName', 'resourceName']
-    for attribute in proto_attributes:
-      value = proto_payload.get(attribute, None)
-      if value:
-        timesketch_record[attribute] = value
+      service_account_key_name = authentication_info.get(
+          'serviceAccountKeyName', None)
+      if service_account_key_name:
+        timesketch_record['service_account_key_name'] = service_account_key_name
 
-    request = proto_payload.get('request', None)
-    if request:
-      self._ParseProtoPayloadRequest(request, timesketch_record)
+      # Service account delegation information
+      delegations = []
 
+      delegation_info_list = authentication_info.get(
+          'serviceAccountDelegationInfo', [])
+      for delegation_info in delegation_info_list:
+        first_party_principal = delegation_info.get('firstPartyPrincipal', {})
+
+        first_party_principal_email = first_party_principal.get(
+            'principalEmail', None)
+        if first_party_principal_email:
+          delegations.append(first_party_principal_email)
+        else:
+          first_party_principal_subject = first_party_principal.get(
+              'principalSubject', None)
+          if first_party_principal_subject:
+            delegations.append(first_party_principal_subject)
+
+      if delegations:
+        timesketch_record['service_account_delegation'] = delegations
+        timesketch_record['delegation_chain'] = '->'.join(delegations)
+
+  def _ParseAuthorizationInfo(
+      self,
+      proto_payload: Dict[str, Any],
+      timesketch_record: Dict[str, Any]) -> None:
+    """Extracts `protoPayload.authorizationInfo` field in a GCP log.
+
+    Args:
+      proto_payload: the content of a GCP protoPaylaod field.
+      timesketch_record: a dictionary that will be serialized to JSON and
+          uploaded to Timesketch.
+    """
+    permissions = []
+
+    authorization_info_list = proto_payload.get('authorizationInfo', [])
+    for authorization_info in authorization_info_list:
+      permission = authorization_info.get('permission', None)
+      if permission:
+        permissions.append(permission)
+
+    if permissions:
+      timesketch_record['permissions'] = permissions
+
+  def _ParseRequestMetadata(
+      self,
+      proto_payload: Dict[str, Any],
+      timesketch_record: Dict[str, str]) -> None:
+    """Extracts `protoPayload.requestMetadata` field in a GCP log.
+
+    Args:
+      proto_payload: the content of a GCP protoPaylaod field.
+      timesketch_record: a dictionary that will be serialized to JSON and
+          uploaded to Timesketch.
+    """
+    request_metadata = proto_payload.get('requestMetadata', {})
+
+    # `protoPayload.callerIp` can be empty for some requests.
+    caller_ip = request_metadata.get('callerIp', '')
+    timesketch_record['caller_ip'] = caller_ip
+
+    # `protoPayload.callerSuppliedUserAgent` can be empty for some requests.
+    user_agent = request_metadata.get('callerSuppliedUserAgent', '')
+    timesketch_record['user_agent'] = user_agent
+
+    # Check for gcloud command invocation
+    if user_agent:
+      if 'command/' in user_agent:
+        command_regex = re.search(r'command/([^\s]+)', user_agent)
+        if command_regex:
+          command_string = str(command_regex.group(1))
+          command_string = command_string.replace('.', ' ')
+
+          timesketch_record['gcloud_command_partial'] = command_string
+
+      if 'invocation-id/' in user_agent:
+        invocation_regex = re.search(r'invocation-id/()', user_agent)
+        if invocation_regex:
+          invocation_id = str(invocation_regex.group(1))
+          timesketch_record['gcloud_command_id'] = invocation_id
+
+  def _ParseProtoPayloadStatus(
+      self,
+      proto_payload: Dict[str, Any],
+      timesketch_record: Dict[str, str]) -> None:
+    """Extracts `protoPayload.status` field in a GCP log.
+
+    Args:
+      proto_payload: the content of a GCP protoPaylaod field.
+      timesketch_record: a dictionary that will be serialized to JSON and
+          uploaded to Timesketch.
+    """
+    status = proto_payload.get('status', {})
+
+    # `protoPayload.status` can be an empty object which indicates successful
+    # operation.
+    #
+    # Empty `status_code` and `status_message` are added to reflect the same.
+    if not status:
+      timesketch_record['status_code'] = ''
+      timesketch_record['status_message'] = ''
+
+      return
+
+    # A non-empty `protoPayload.status` field could have empty
+    # `protoPayload.status.code` and `protoPayload.status.message` fields.
+    # Empty `code` and `message` fields would indicate the operation was
+    # successful.
+    status_code = str(status.get('code', ''))
+    status_message = status.get('message', '')
+
+    timesketch_record['status_code'] = status_code
+    timesketch_record['status_message'] = status_message
+
+  def _ParseServiceData(
+      self,
+      proto_payload: Dict[str, Any],
+      timesketch_record: Dict[str, Any]) -> None:
+    """Extracts information from `protoPayload.serviceData` field in a GCP log.
+
+    Args:
+      proto_payload: the content of a GCP protoPayload field.
+      timesketch_record: a dictionary that will be serialized to JSON and
+          uploaded to Timesketch.
+    """
     service_data = proto_payload.get('serviceData', None)
     if service_data:
       policy_delta = service_data.get('policyDelta', None)
@@ -131,20 +248,111 @@ class GCPLoggingTimesketch(BaseModule):
                 '{0:s} {1:s} with role {2:s}'.format(
                     bd.get('action', ''), bd.get('member', ''),
                     bd.get('role', '')))
-          timesketch_record['policyDelta'] = ', '.join(policy_deltas)
+          timesketch_record['policy_delta'] = ', '.join(policy_deltas)
 
-  def _ParseProtoPayloadRequest(
+  def _parse_proto_payload(
       self,
-      request: Dict[str, Any],
+      proto_payload: Dict[str, Any],
       timesketch_record: Dict[str, Any]) -> None:
-    """Extracts information from the request field of a protoPayload field.
+    """Extracts information from a protoPayload field in a GCP log.
+
+    protoPayload is set for all cloud audit events.
 
     Args:
-      request (dict): the contents of a GCP request field from a
-          protoPayload field.
+      proto_payload (dict): the contents of a GCP protoPayload field.
       timesketch_record (dict): a dictionary that will be serialized to JSON
         and uploaded to Timesketch.
     """
+    service_name = proto_payload.get('serviceName', '')
+    if service_name:
+      timesketch_record['service_name'] = service_name
+
+    method_name = proto_payload.get('methodName', '')
+    if service_name:
+      timesketch_record['method_name'] = method_name
+
+    resource_name = proto_payload.get('resourceName', '')
+    if resource_name:
+      timesketch_record['resource_name'] = resource_name
+
+    self._ParseAuthenticationInfo(proto_payload, timesketch_record)
+    self._ParseAuthorizationInfo(proto_payload, timesketch_record)
+    self._ParseRequestMetadata(proto_payload, timesketch_record)
+    self._ParseProtoPayloadRequest(proto_payload, timesketch_record)
+    self._ParseProtoPayloadStatus(proto_payload, timesketch_record)
+    self._ParseServiceData(proto_payload, timesketch_record)
+
+  def _ParseComputeInstancesInsert(
+      self,
+      request: Dict[str, Any],
+      timesketch_record: Dict[str, Any]) -> None:
+    """ Extracts information related to compute instances insert.
+
+    Args:
+      request: the `protoPayload.request` field in a GCP log.
+      timesketch_record: a dictionary that will be serialized to JSON and
+          uploaded to Timesketch.
+    """
+    if not request:
+      return
+
+    request_type = request.get('@type', None)
+    if not request_type:
+      return
+
+    if request_type != 'type.googleapis.com/compute.instances.insert':
+      return
+
+    # Source images are useful during investigaions.
+    source_images = []
+
+    disks = request.get('disks', [])
+    for disk in disks:
+      initialize_params = disk.get('initializeParams', {})
+
+      source_image = initialize_params.get('sourceImage', None)
+      if source_image:
+        source_images.append(source_image)
+
+    if source_images:
+      timesketch_record['source_images'] = source_images
+
+    # Default Compute Engine Service Account (dcsa)
+    dcsa_emails = []
+    dcsa_scopes = []
+
+    service_accounts = request.get('serviceAccounts', [])
+    for service_account in service_accounts:
+      email = service_account.get('email', None)
+      if email:
+        dcsa_emails.append(email)
+
+      scopes = service_account.get('scopes', [])
+      if scopes:
+        dcsa_scopes.extend(scopes)
+
+    if dcsa_emails:
+      timesketch_record['dcsa_email'] = ','.join(dcsa_emails)
+
+    if dcsa_scopes:
+      timesketch_record['dcsa_scopes'] = dcsa_scopes
+
+  def _ParseProtoPayloadRequest(
+      self,
+      proto_payload: Dict[str, Any],
+      timesketch_record: Dict[str, Any]) -> None:
+    """Extracts information from the `protoPayload.request` field of a GCP log.
+
+    Args:
+      proto_payload: the contents of a GCP protoPayload field from a
+          protoPayload field.
+      timesketch_record: a dictionary that will be serialized to JSON
+        and uploaded to Timesketch.
+    """
+    request = proto_payload.get('request', {})
+    if not request:
+      return
+
     request_attributes = [
         'name', 'description', 'direction', 'member', 'targetTags', 'email',
         'account_id'
@@ -179,6 +387,8 @@ class GCPLoggingTimesketch(BaseModule):
     if 'service_account' in request:
       service_account_name = request['service_account'].get('display_name')
       timesketch_record['service_account_display_name'] = service_account_name
+
+    self._ParseComputeInstancesInsert(request, timesketch_record)
 
   def _ParseJSONPayload(self,
       json_payload: Dict[str, Any],
@@ -216,19 +426,19 @@ class GCPLoggingTimesketch(BaseModule):
     resource = ''
 
     # Ordered from least to most preferred value
-    user_attributes = ['principalEmail', 'user']
+    user_attributes = ['principal_email', 'user']
     for attribute in user_attributes:
       if attribute in timesketch_record:
         user = timesketch_record[attribute]
 
     # Ordered from least to most preferred value
-    action_attributes = ['methodName', 'event_subtype']
+    action_attributes = ['method_name', 'event_subtype']
     for attribute in action_attributes:
       if attribute in timesketch_record:
         action = timesketch_record[attribute]
 
     # Ordered from least to most preferred value
-    resource_attributes = ['resource_label_instance_id', 'resourceName']
+    resource_attributes = ['resource_label_instance_id', 'resource_name']
     for attribute in resource_attributes:
       if attribute in timesketch_record:
         resource = timesketch_record[attribute]

--- a/dftimewolf/lib/processors/gcp_logging_timesketch.py
+++ b/dftimewolf/lib/processors/gcp_logging_timesketch.py
@@ -4,7 +4,7 @@
 import json
 import tempfile
 from datetime import datetime
-from typing import Any, Dict, Optional, Union, TYPE_CHECKING
+from typing import Any, Dict, Optional, TYPE_CHECKING
 
 from dftimewolf.lib.containers import containers
 from dftimewolf.lib.module import BaseModule
@@ -243,13 +243,12 @@ class GCPLoggingTimesketch(BaseModule):
 
     timesketch_record['message'] = message
 
-  def _ProcessLogContainer(self,
-      logs_container: Union[containers.File, containers.Directory]) -> None:
+  def _ProcessLogContainer(self, logs_container: containers.File) -> None:
     """Processes a GCP logs container.
 
     Args:
-      logs_container Union[containers.File, containers.Directory]:
-          container containing GCPLogsCollector output file.
+      logs_container (containers.File): container containing GCPLogsCollector
+          output file.
     """
     if not logs_container.path:
       return
@@ -275,17 +274,8 @@ class GCPLoggingTimesketch(BaseModule):
 
   def Process(self) -> None:
     """Processes GCP logs containers for insertion into Timesketch."""
-    combined_list = []
-
     for file_container in self.GetContainers(containers.File, pop=True):
-      combined_list.append(file_container)
-
-    for directory_container in self.GetContainers(
-        containers.Directory, pop=True):
-      combined_list.append(directory_container)
-
-    for log_container in combined_list:
-      self._ProcessLogContainer(log_container)
+      self._ProcessLogContainer(file_container)
 
 
 modules_manager.ModulesManager.RegisterModule(GCPLoggingTimesketch)

--- a/tests/lib/processors/gcp_logging_timesketch.py
+++ b/tests/lib/processors/gcp_logging_timesketch.py
@@ -71,23 +71,21 @@ class GCPLoggingTimesketchTest(unittest.TestCase):
     expected_addition_record = {
         'query':
             'test_query',
-        'project_name':
-            'test_project',
         'data_type':
             'gcp:log:json',
         'datetime':
             '2019-06-06T09:00:41.797000Z',
         'timestamp_desc':
             'Event Recorded',
-        'resource_label_firewall_rule_id':
+        'firewall_rule_id':
             '2527368186053355716',
-        'resource_label_project_id':
+        'project_id':
             'ketchup-research',
         'principalEmail':
             'heinz-57@ketchup-research.iam.gserviceaccount.com',
-        'requestMetadata_callerIp':
+        'callerIp':
             'gce-internal-ip',
-        'requestMetadata_callerSuppliedUserAgent':
+        'callerSuppliedUserAgent':
             'google-cloud-sdk gcloud/249.0.0',
         'serviceName':
             'compute.googleapis.com',
@@ -104,7 +102,7 @@ class GCPLoggingTimesketchTest(unittest.TestCase):
 
     # pylint: disable=protected-access
     actual_timesketch_record = processor._ProcessLogLine(
-        firewall_addition_json, 'test_query', 'test_project')
+        firewall_addition_json, 'test_query')
     actual_timesketch_record = json.loads(actual_timesketch_record)
     self.assertDictEqual(expected_addition_record, actual_timesketch_record)
 
@@ -202,23 +200,21 @@ class GCPLoggingTimesketchTest(unittest.TestCase):
     expected_creation_record = {
         'query':
             'test_query',
-        'project_name':
-            'test_project',
         'data_type':
             'gcp:log:json',
         'datetime':
             '2019-06-06T09:00:27.066000Z',
         'timestamp_desc':
             'Event Recorded',
-        'resource_label_firewall_rule_id':
+        'firewall_rule_id':
             '2527368186053355716',
-        'resource_label_project_id':
+        'project_id':
             'ketchup-research',
         'principalEmail':
             'heinz-57@ketchup-research.iam.gserviceaccount.com',
-        'requestMetadata_callerIp':
+        'callerIp':
             'gce-internal-ip',
-        'requestMetadata_callerSuppliedUserAgent':
+        'callerSuppliedUserAgent':
             'google-cloud-sdk gcloud/249.0.0',
         'serviceName':
             'compute.googleapis.com',
@@ -243,7 +239,7 @@ class GCPLoggingTimesketchTest(unittest.TestCase):
     }
 
     actual_timesketch_record = processor._ProcessLogLine(
-        firewall_creation_json, 'test_query', 'test_project')
+        firewall_creation_json, 'test_query')
     actual_timesketch_record = json.loads(actual_timesketch_record)
     self.assertDictEqual(expected_creation_record, actual_timesketch_record)
 
@@ -297,25 +293,23 @@ class GCPLoggingTimesketchTest(unittest.TestCase):
     expected_timesketch_record = {
         'query':
             'test_query',
-        'project_name':
-            'test_project',
         'data_type':
             'gcp:log:json',
         'datetime':
             '2019-06-06T09:29:04.499000Z',
         'timestamp_desc':
             'Event Recorded',
-        'resource_label_zone':
+        'zone':
             'europe-west1-c',
-        'resource_label_project_id':
+        'project_id':
             'ketchup-research',
-        'resource_label_instance_id':
+        'instance_id':
             '6662286141402997301',
         'principalEmail':
             'heinz-57@ketchup-research.iam.gserviceaccount.com',
-        'requestMetadata_callerIp':
+        'callerIp':
             'gce-internal-ip',
-        'requestMetadata_callerSuppliedUserAgent':
+        'callerSuppliedUserAgent':
             'google-cloud-sdk gcloud/249.0.0',
         'serviceName':
             'compute.googleapis.com',
@@ -334,7 +328,7 @@ class GCPLoggingTimesketchTest(unittest.TestCase):
 
     # pylint: disable=protected-access
     actual_timesketch_record = processor._ProcessLogLine(
-        gce_creation, 'test_query', 'test_project')
+        gce_creation, 'test_query')
     actual_timesketch_record = json.loads(actual_timesketch_record)
     self.assertDictEqual(expected_timesketch_record, actual_timesketch_record)
 
@@ -429,26 +423,24 @@ class GCPLoggingTimesketchTest(unittest.TestCase):
     expected_timesketch_record = {
         'query':
             'test_query',
-        'project_name':
-            'test_project',
         'data_type':
             'gcp:log:json',
         'datetime':
             '2020-06-16T05:09:57.427874505Z',
         'timestamp_desc':
             'Event Recorded',
-        'resource_label_location':
+        'location':
             'us-east1',
-        'resource_label_project_id':
+        'project_id':
             'ketchup-research',
         'principalEmail':
             'heinz-57@ketchup-research.iam.gserviceaccount.com',
-        'requestMetadata_callerIp':
+        'callerIp':
             '100.100.100.100',
-        'requestMetadata_callerSuppliedUserAgent':
+        'callerSuppliedUserAgent':
             'google-cloud-sdk gcloud/249.0.0',
-        'requestMetadata_destinationAttributes': {},
-        'requestMetadata_requestAttributes': {
+        'destinationAttributes': {},
+        'requestAttributes': {
             'auth': {},
             'time': '2020-06-16T05:09:57.437288734Z',
         },
@@ -458,7 +450,7 @@ class GCPLoggingTimesketchTest(unittest.TestCase):
             'storage.buckets.create',
         'resourceName':
             'projects/_/buckets/test_bucket_1',
-        'resource_label_bucket_name':
+        'bucket_name':
             'test_bucket_1',
         'policyDelta':
             'ADD projectEditor:ketchup-research with role '
@@ -476,7 +468,7 @@ class GCPLoggingTimesketchTest(unittest.TestCase):
 
     # pylint: disable=protected-access
     actual_timesketch_record = processor._ProcessLogLine(
-        gcs_creation, 'test_query', 'test_project')
+        gcs_creation, 'test_query')
     actual_timesketch_record = json.loads(actual_timesketch_record)
     self.assertDictEqual(expected_timesketch_record, actual_timesketch_record)
 
@@ -522,18 +514,17 @@ class GCPLoggingTimesketchTest(unittest.TestCase):
         'filename': 'application_000004_0005.container_113_05_1833_01.'
                     'prelaunch.err',
         'message': 'line 470: /etc/selinux/config: Permission denied',
-        'project_name': 'test_project',
         'query': 'test_query',
         'data_type': 'gcp:log:json',
-        'resource_label_cluster_name': 'cluster-ca8b',
-        'resource_label_cluster_uuid': '44444-444444-444-4444-4444',
-        'resource_label_project_id': 'metastore-playground',
-        'resource_label_region': 'us-central1',
+        'cluster_name': 'cluster-ca8b',
+        'cluster_uuid': '44444-444444-444-4444-4444',
+        'project_id': 'metastore-playground',
+        'region': 'us-central1',
         'timestamp_desc': 'Event Recorded'}
 
     # pylint: disable=protected-access
     actual_timesketch_record = processor._ProcessLogLine(
-        yarn_log, 'test_query', 'test_project')
+        yarn_log, 'test_query')
     actual_timesketch_record = json.loads(actual_timesketch_record)
     self.assertDictEqual(expected_timesketch_record, actual_timesketch_record)
 

--- a/tests/lib/processors/gcp_logging_timesketch.py
+++ b/tests/lib/processors/gcp_logging_timesketch.py
@@ -81,18 +81,20 @@ class GCPLoggingTimesketchTest(unittest.TestCase):
             '2527368186053355716',
         'project_id':
             'ketchup-research',
-        'principalEmail':
+        'principal_email':
             'heinz-57@ketchup-research.iam.gserviceaccount.com',
-        'callerIp':
+        'caller_ip':
             'gce-internal-ip',
-        'callerSuppliedUserAgent':
+        'user_agent':
             'google-cloud-sdk gcloud/249.0.0',
-        'serviceName':
+        'service_name':
             'compute.googleapis.com',
-        'methodName':
+        'method_name':
             'v1.compute.firewalls.insert',
-        'resourceName':
+        'resource_name':
             'projects/ketchup-research/global/firewalls/deny-tomchop-access',
+        'status_code': '',
+        'status_message': '',
         'message':
             'User heinz-57@ketchup-research.iam.gserviceaccount.com '
             'performed v1.compute.firewalls.insert '
@@ -208,19 +210,21 @@ class GCPLoggingTimesketchTest(unittest.TestCase):
             'Event Recorded',
         'firewall_rule_id':
             '2527368186053355716',
+        'permissions': [
+            'compute.firewalls.create', 'compute.networks.updatePolicy'],
         'project_id':
             'ketchup-research',
-        'principalEmail':
+        'principal_email':
             'heinz-57@ketchup-research.iam.gserviceaccount.com',
-        'callerIp':
+        'caller_ip':
             'gce-internal-ip',
-        'callerSuppliedUserAgent':
+        'user_agent':
             'google-cloud-sdk gcloud/249.0.0',
-        'serviceName':
+        'service_name':
             'compute.googleapis.com',
-        'methodName':
+        'method_name':
             'v1.compute.firewalls.insert',
-        'resourceName':
+        'resource_name':
             'projects/ketchup-research/global/firewalls/deny-tomchop-access',
         'request_name':
             'deny-tomchop-access',
@@ -231,6 +235,8 @@ class GCPLoggingTimesketchTest(unittest.TestCase):
             '0.0.0.0/0',
         'denied_tcp_ports':
             'all',
+        'status_code': '',
+        'status_message': '',
         'message':
             'User heinz-57@ketchup-research.iam.gserviceaccount.com '
             'performed v1.compute.firewalls.insert on '
@@ -284,10 +290,52 @@ class GCPLoggingTimesketchTest(unittest.TestCase):
                 'projects/ketchup-research/zones/europe-west1-c/instances/'
                 'example-instance-2',
             'request': {
-                '@type': 'type.googleapis.com/compute.instances.insert'
+              "@type": "type.googleapis.com/compute.instances.insert",
+              "description": "GCE instance created for training.",
+              "disks": [
+                {
+                  "autoDelete": 'true',
+                  "boot": 'true',
+                  "initializeParams": {
+                    "diskSizeGb": "100",
+                    "diskType": "zones/europe-west1-c/diskTypes/pd-ssd",
+                    "sourceImage": 'projects/ketchup-research/global/images/'
+                        'my-custom-os'
+                  }
+                }
+              ],
+              "labels": [],
+              "machineType": "zones/europe-west1-c/machineTypes/n1-highmem-8",
+              "name": "training-instance",
+              "networkInterfaces": [
+                {
+                  "accessConfigs": [
+                    {
+                      "name": "External NAT",
+                      "type": "ONE_TO_ONE_NAT"
+                    }
+                  ],
+                  "network": "global/networks/default"
+                }
+              ],
+              "scheduling": {
+                "automaticRestart": 'true'
+              },
+              "serviceAccounts": [
+                {
+                  "email": "my-sa2@ketchup-research.iam.gserviceaccount.com",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/devstorage.full_control",
+                    "https://www.googleapis.com/auth/logging.read",
+                    "https://www.googleapis.com/auth/logging.write",
+                    "https://www.googleapis.com/auth/monitoring.write",
+                  ]
+                }
+              ]
             }
         }
     }
+
     gce_creation = json.dumps(gce_creation)
 
     expected_timesketch_record = {
@@ -299,23 +347,32 @@ class GCPLoggingTimesketchTest(unittest.TestCase):
             '2019-06-06T09:29:04.499000Z',
         'timestamp_desc':
             'Event Recorded',
+        'dcsa_email': 'my-sa2@ketchup-research.iam.gserviceaccount.com',
+        'dcsa_scopes': [
+          'https://www.googleapis.com/auth/devstorage.full_control',
+          'https://www.googleapis.com/auth/logging.read',
+           'https://www.googleapis.com/auth/logging.write',
+            'https://www.googleapis.com/auth/monitoring.write',
+        ],
         'zone':
             'europe-west1-c',
         'project_id':
             'ketchup-research',
         'instance_id':
             '6662286141402997301',
-        'principalEmail':
+        'principal_email':
             'heinz-57@ketchup-research.iam.gserviceaccount.com',
-        'callerIp':
+        'caller_ip':
             'gce-internal-ip',
-        'callerSuppliedUserAgent':
+        'user_agent':
             'google-cloud-sdk gcloud/249.0.0',
-        'serviceName':
+        'service_name':
             'compute.googleapis.com',
-        'methodName':
+        'method_name':
             'v1.compute.instances.insert',
-        'resourceName':
+        'request_description': 'GCE instance created for training.',
+        'request_name': 'training-instance',
+        'resource_name':
             'projects/ketchup-research/zones/europe-west1-c/instances/'
             'example-instance-2',
         'message':
@@ -323,7 +380,11 @@ class GCPLoggingTimesketchTest(unittest.TestCase):
             'performed v1.compute.instances.insert '
             'on projects/ketchup-research/zones/europe-west1-c/instances/'
             'example-instance-2',
-        'severity': 'NOTICE'
+        'severity': 'NOTICE',
+        'source_images': [
+          'projects/ketchup-research/global/images/my-custom-os'],
+        'status_code': '',
+        'status_message': ''
     }
 
     # pylint: disable=protected-access
@@ -431,28 +492,24 @@ class GCPLoggingTimesketchTest(unittest.TestCase):
             'Event Recorded',
         'location':
             'us-east1',
+        'permissions': ['storage.buckets.create'],
         'project_id':
             'ketchup-research',
-        'principalEmail':
+        'principal_email':
             'heinz-57@ketchup-research.iam.gserviceaccount.com',
-        'callerIp':
+        'caller_ip':
             '100.100.100.100',
-        'callerSuppliedUserAgent':
+        'user_agent':
             'google-cloud-sdk gcloud/249.0.0',
-        'destinationAttributes': {},
-        'requestAttributes': {
-            'auth': {},
-            'time': '2020-06-16T05:09:57.437288734Z',
-        },
-        'serviceName':
+        'service_name':
             'storage.googleapis.com',
-        'methodName':
+        'method_name':
             'storage.buckets.create',
-        'resourceName':
+        'resource_name':
             'projects/_/buckets/test_bucket_1',
         'bucket_name':
             'test_bucket_1',
-        'policyDelta':
+        'policy_delta':
             'ADD projectEditor:ketchup-research with role '
             'roles/storage.legacyBucketOwner, ADD '
             'projectOwner:ketchup-research with role '
@@ -463,7 +520,9 @@ class GCPLoggingTimesketchTest(unittest.TestCase):
             'User heinz-57@ketchup-research.iam.gserviceaccount.com '
             'performed storage.buckets.create on '
             'projects/_/buckets/test_bucket_1',
-        'severity': 'NOTICE'
+        'severity': 'NOTICE',
+        'status_code': '',
+        'status_message': ''
     }
 
     # pylint: disable=protected-access
@@ -525,6 +584,122 @@ class GCPLoggingTimesketchTest(unittest.TestCase):
     # pylint: disable=protected-access
     actual_timesketch_record = processor._ProcessLogLine(
         yarn_log, 'test_query')
+    actual_timesketch_record = json.loads(actual_timesketch_record)
+    self.assertDictEqual(expected_timesketch_record, actual_timesketch_record)
+
+  def testComputeInstancesInsert(self):
+    """Tests `type.googleapis.com/compute.instances.insert` is parsed
+        correctly.
+    """
+    test_state = state.DFTimewolfState(config.Config)
+    processor = gcp_logging_timesketch.GCPLoggingTimesketch(test_state)
+
+    compute_instance_insert_log = {
+      'insertId':'-ft34ekedkmxm',
+      'labels': {
+        'compute.googleapis.com/root_trigger_id':
+            'bcbc8a09-25db-4183-ab94-43d53ab987ca'
+      },
+      'logName':'projects/ketchup/logs/cloudaudit.googleapis.com%2F'
+          'data_access',
+      'protoPayload': {
+        '@type':'type.googleapis.com/google.cloud.audit.AuditLog',
+        'authenticationInfo': {
+          'principalEmail': 'service-account123@ketchup.iam.'
+              'gserviceaccount.com',
+          'principalSubject': 'serviceAccount:service-account123'
+              '@ketchup.iam.gserviceaccount.com',
+          'serviceAccountDelegationInfo': [
+            {
+              'firstPartyPrincipal':{
+                'principalEmail': 'my-sa@ketchup.iam.gserviceaccount.com'
+              }
+            }
+          ]
+        },
+        'authorizationInfo': [
+          {
+            'granted': 'true',
+            'permission': 'compute.instances.get',
+            'permissionType': 'ADMIN_READ',
+            'resource': 'projects/ketchup/zones/us-central1-a/instances/'
+                'my-cluster',
+            'resourceAttributes': {
+              'name': 'projects/ketchup/zones/us-central1-a/instances/'
+                  'my-cluster',
+              'service': 'compute',
+              'type': 'compute.instances'
+            }
+          }
+        ],
+      'methodName': 'v1.compute.instances.get',
+      'request': {
+        '@type': 'type.googleapis.com/compute.instances.get'
+      },
+      'requestMetadata': {
+        'callerIp': '34.X.Y.Z',
+        'callerNetwork': '//compute.googleapis.com/projects/ketchup/global/'
+            'networks/__unknown__',
+        'callerSuppliedUserAgent': 'special-user-agent-string',
+        'destinationAttributes': {},
+        'requestAttributes': {
+          'auth': {},
+          'time': '2024-10-26T19:55:40.930578Z'
+        }
+      },
+      'resourceLocation': {
+        'currentLocations': ['us-central1-a']
+      },
+      'resourceName': 'projects/1234567890/zones/us-central1-a/instances/'
+          'my-cluster',
+      'serviceName': 'compute.googleapis.com'
+      },
+      'receiveTimestamp': '2024-10-26T19:55:41.937084378Z',
+      'resource': {
+        'labels': {
+          'instance_id': '9876543210',
+          'project_id': 'ketchup',
+          'zone': 'us-central1-a'
+        },
+        'type': 'gce_instance'
+      },
+      'severity': 'INFO',
+      'timestamp': '2024-10-26T19:55:40.876410Z'
+    }
+
+    expected_timesketch_record = {
+      'query': 'test_query',
+      'data_type': 'gcp:log:json',
+      'datetime': '2024-10-26T19:55:40.876410Z',
+      'timestamp_desc': 'Event Recorded',
+      'caller_ip': '34.X.Y.Z',
+      'delegation_chain': 'my-sa@ketchup.iam.gserviceaccount.com',
+      'instance_id': '9876543210',
+      'method_name': 'v1.compute.instances.get',
+      'message': 'User service-account123@ketchup.iam.gserviceaccount.com '
+          'performed v1.compute.instances.get on projects/1234567890/zones/'
+          'us-central1-a/instances/my-cluster',
+      'permissions': ['compute.instances.get'],
+      'principal_email': 'service-account123@ketchup.iam.gserviceaccount.com',
+      'principal_subject': 'serviceAccount:service-account123@ketchup.iam.'
+          'gserviceaccount.com',
+      'project_id': 'ketchup',
+      'resource_name': 'projects/1234567890/zones/us-central1-a/instances/'
+          'my-cluster',
+      'service_name': 'compute.googleapis.com',
+      'service_account_delegation': ['my-sa@ketchup.iam.gserviceaccount.com'],
+      'severity': 'INFO',
+      'status_code': '',
+      'status_message': '',
+      'user_agent': 'special-user-agent-string',
+      'zone': 'us-central1-a'
+    }
+
+    compute_instance_insert_log = json.dumps(compute_instance_insert_log)
+
+    # pylint: disable=protected-access
+    actual_timesketch_record = processor._ProcessLogLine(
+        compute_instance_insert_log, 'test_query')
     actual_timesketch_record = json.loads(actual_timesketch_record)
     self.assertDictEqual(expected_timesketch_record, actual_timesketch_record)
 

--- a/tests/lib/processors/gcp_logging_timesketch.py
+++ b/tests/lib/processors/gcp_logging_timesketch.py
@@ -347,7 +347,7 @@ class GCPLoggingTimesketchTest(unittest.TestCase):
             '2019-06-06T09:29:04.499000Z',
         'timestamp_desc':
             'Event Recorded',
-        'dcsa_email': 'my-sa2@ketchup-research.iam.gserviceaccount.com',
+        'dcsa_emails': ['my-sa2@ketchup-research.iam.gserviceaccount.com'],
         'dcsa_scopes': [
           'https://www.googleapis.com/auth/devstorage.full_control',
           'https://www.googleapis.com/auth/logging.read',
@@ -700,6 +700,136 @@ class GCPLoggingTimesketchTest(unittest.TestCase):
     # pylint: disable=protected-access
     actual_timesketch_record = processor._ProcessLogLine(
         compute_instance_insert_log, 'test_query')
+    actual_timesketch_record = json.loads(actual_timesketch_record)
+    self.assertDictEqual(expected_timesketch_record, actual_timesketch_record)
+
+  def testServiceAccountCreateFailed(self):
+    """Test the failed service account create logs with reasons."""
+    test_state = state.DFTimewolfState(config.Config)
+    processor = gcp_logging_timesketch.GCPLoggingTimesketch(test_state)
+
+    service_create_log = {
+      'protoPayload': {
+        '@type': 'type.googleapis.com/google.cloud.audit.AuditLog',
+        'status': {
+          'code': 7,
+          'message': ('Permission \'iam.serviceAccounts.create\' denied on '
+              'resource (or it may not exist).'),
+          'details': [
+            {
+              '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
+              'reason': 'IAM_PERMISSION_DENIED',
+              'domain': 'iam.googleapis.com',
+              'metadata': {
+                'permission': 'iam.serviceAccounts.create'
+              }
+            }
+          ]
+        },
+        'authenticationInfo': {
+          'principalEmail': ('dvwa-service-account@ketchup'
+              '.iam.gserviceaccount.com'),
+          'serviceAccountDelegationInfo': [
+            {
+              'firstPartyPrincipal': {
+                'principalEmail': ('service-1234567890@compute-system.iam.'
+                    'gserviceaccount.com')
+              }
+            }
+          ],
+          'principalSubject': ('serviceAccount:dvwa-service-account@'
+              'ketchup.iam.gserviceaccount.com')
+        },
+        'requestMetadata': {
+          'callerIp': '34.72.217.225',
+          'callerSuppliedUserAgent': '(gzip),gzip(gfe)',
+          'requestAttributes': {
+            'time': '2024-12-03T17:58:45.019694350Z',
+            'auth': {}
+          },
+          'destinationAttributes': {}
+        },
+        'serviceName': 'iam.googleapis.com',
+        'methodName': 'google.iam.admin.v1.CreateServiceAccount',
+        'authorizationInfo': [
+          {
+            'resource': 'projects/ketchup',
+            'permission': 'iam.serviceAccounts.create',
+            'resourceAttributes': {
+              'type': 'iam.googleapis.com/ServiceAccount'
+            },
+            'permissionType': 'ADMIN_WRITE'
+          }
+        ],
+        'resourceName': 'projects/ketchup',
+        'request': {
+          'service_account': {
+            'display_name': 'This is the attacker account'
+          },
+          'account_id': 'theattacker',
+          'name': 'projects/ketchup',
+          '@type': ('type.googleapis.com/google.iam.admin.v1.'
+              'CreateServiceAccountRequest')
+        },
+        'response': {
+          '@type': 'type.googleapis.com/google.iam.admin.v1.ServiceAccount'
+        }
+      },
+      'insertId': '1awjxggeaxqgz',
+      'resource': {
+        'type': 'service_account',
+        'labels': {
+          'unique_id': '',
+          'project_id': 'ketchup',
+          'email_id': ''
+        }
+      },
+      'timestamp': '2024-12-03T17:58:44.882119699Z',
+      'severity': 'ERROR',
+      'logName': ('projects/ketchup/logs/cloudaudit.'
+          'googleapis.com%2Factivity'),
+      'receiveTimestamp': '2024-12-03T17:58:45.716564605Z'
+    }
+
+    expected_timesketch_record = {
+      'query': 'test_query',
+      'data_type': 'gcp:log:json',
+      'datetime': '2024-12-03T17:58:44.882119699Z',
+      'timestamp_desc': 'Event Recorded',
+      'caller_ip': '34.72.217.225',
+      'delegation_chain': ('service-1234567890@compute-system.iam.'
+          'gserviceaccount.com'),
+      'email_id': '',
+      'message': ('User dvwa-service-account@ketchup.iam.'
+          'gserviceaccount.com performed google.iam.admin.v1.'
+          'CreateServiceAccount on projects/ketchup'),
+      'method_name': 'google.iam.admin.v1.CreateServiceAccount',
+      'permissions': ['iam.serviceAccounts.create'],
+      'principal_email': ('dvwa-service-account@ketchup.'
+          'iam.gserviceaccount.com'),
+      'principal_subject': ('serviceAccount:dvwa-service-account@'
+          'ketchup.iam.gserviceaccount.com'),
+      'project_id': 'ketchup',
+      'request_account_id': 'theattacker',
+      'request_name': 'projects/ketchup',
+      'resource_name': 'projects/ketchup',
+      'service_account_delegation': [
+          'service-1234567890@compute-system.iam.gserviceaccount.com'],
+      'service_account_display_name': 'This is the attacker account',
+      'service_name': 'iam.googleapis.com',
+      'severity': 'ERROR',
+      'status_code': '7',
+      'status_message': ('Permission \'iam.serviceAccounts.create\' denied on'
+          ' resource (or it may not exist).'),
+      'status_reasons': ['IAM_PERMISSION_DENIED'],
+      'unique_id': '',
+      'user_agent': '(gzip),gzip(gfe)'
+    }
+
+    failed_service_account_create_log = json.dumps(service_create_log)
+
+    actual_timesketch_record = processor._ProcessLogLine(
+        failed_service_account_create_log, 'test_query')
     actual_timesketch_record = json.loads(actual_timesketch_record)
     self.assertDictEqual(expected_timesketch_record, actual_timesketch_record)
 


### PR DESCRIPTION
Changes in `gcp_logging_timesketch.py`.
- Added attributes in GCPLoggingTimesketch to make reviewing extracted attributes easier.
- Change attribute `dcsa_email: str` to `dcsa_emails: list[str]`.
- Added new attribute `status_reasons: list[str]`.

Changes unit test file `gcp_logging_timesketch.py`
- Changed attribute name from `dcsa_email` to `dcsa_emails`
- Added new test `testServiceAccountCreateFailed`