### PR TITLE
Reimplement container popping in new container manager.

### DIFF
--- a/dftimewolf/lib/containers/manager.py
+++ b/dftimewolf/lib/containers/manager.py
@@ -84,6 +84,7 @@ class ContainerManager():
   def GetContainers(self,
                     requesting_module: str,
                     container_class: Type[interface.AttributeContainer],
+                    pop: bool = False,
                     metadata_filter_key: str | None = None,
                     metadata_filter_value: Any = None
       ) -> Sequence[interface.AttributeContainer]:
@@ -95,6 +96,9 @@ class ContainerManager():
     Args:
       requesting_module: The module requesting the containers.
       container_class: The type of container to retrieve.
+      pop: True if the returned containers should be removed from the state.
+          False otherwise. Ignored if the source and requesting module do not
+          match. That is, a module can only pop containers it has stored.
       metadata_filter_key: An optional metadata key to use to filter.
       metadata_filter_value: An optional metadata value to use to filter.
 
@@ -120,6 +124,12 @@ class ContainerManager():
               c.metadata.get(metadata_filter_key) != metadata_filter_value)):
             continue
           ret_val.append(c)
+
+      if pop:
+        # A module can only pop containers it has stored.
+        for c in ret_val:
+          if c in self._modules[requesting_module].storage:
+            self._modules[requesting_module].storage.remove(c)
 
     return cast(Sequence[interface.AttributeContainer], ret_val)
 

--- a/dftimewolf/lib/state.py
+++ b/dftimewolf/lib/state.py
@@ -282,10 +282,12 @@ class DFTimewolfState(object):
         pop=pop,
         metadata_filter_key=metadata_filter_key,
         metadata_filter_value=metadata_filter_value)
-    containers_cm = self._container_manager.GetContainers(requesting_module,
-                                                          container_class,
-                                                          metadata_filter_key,
-                                                          metadata_filter_value)
+    containers_cm = self._container_manager.GetContainers(
+        requesting_module=requesting_module,
+        container_class=container_class,
+        pop=pop,
+        metadata_filter_key=metadata_filter_key,
+        metadata_filter_value=metadata_filter_value)
 
     if (sorted([str(c) for c in containers_orig]) !=
         sorted([str(c) for c in containers_cm])):

--- a/tests/lib/containers/manager.py
+++ b/tests/lib/containers/manager.py
@@ -563,6 +563,51 @@ class ContainerManagerTest(unittest.TestCase):
           requesting_module='ModuleE', container_class=_TestContainer1)
       self.assertEqual(0, len(actual))
 
+  def test_PopContainers(self):
+    """Tests GetContainers with pop=True."""
+    self._container_manager.ParseRecipe(_TEST_RECIPE)
+
+    # Store some containers as prep
+    self._container_manager.StoreContainer(
+        source_module='Preflight1',
+        container=_TestContainer1('Stored by Preflight1'))
+    self._container_manager.StoreContainer(
+        source_module='ModuleA',
+        container=_TestContainer2('Stored by ModuleA'))
+
+    with self.subTest('wrong_source'):
+      for _ in range(0, 5):
+        # "pop" should be ignored when the requesting module is not the one that
+        # stored the container.
+        actual = self._container_manager.GetContainers(
+          requesting_module='ModuleA',
+          container_class=_TestContainer1,
+          pop=True)
+        self.assertEqual(len(actual), 1)
+        self.assertIn(_TestContainer1('Stored by Preflight1'), actual)
+
+    with self.subTest('same_source'):
+      actual = self._container_manager.GetContainers(
+        requesting_module='ModuleA',
+        container_class=_TestContainer2,
+        pop=True)
+      self.assertEqual(len(actual), 1)
+      self.assertIn(_TestContainer2('Stored by ModuleA'), actual)
+
+      # subsequent call returns nothing
+      actual = self._container_manager.GetContainers(
+        requesting_module='ModuleA',
+        container_class=_TestContainer2,
+        pop=True)
+      self.assertEqual(len(actual), 0)
+
+      # Other containers unaffected
+      actual = self._container_manager.GetContainers(
+        requesting_module='ModuleA',
+        container_class=_TestContainer1)
+      self.assertEqual(len(actual), 1)
+      self.assertIn(_TestContainer1('Stored by Preflight1'), actual)
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Re-implement container popping in the new container manager. Modules can only pop containers that they stored, otherwise popping is ignored. 

This is to allow modules to use and remove containers as their own temporary storage, as some modules do, which breaks compatibility with the new container manager.