### PR TITLE
Make OpenRelik module errors non critical for now

### DIFF
--- a/dftimewolf/lib/processors/openrelik.py
+++ b/dftimewolf/lib/processors/openrelik.py
@@ -88,7 +88,7 @@ class OpenRelikProcessor(module.ThreadAwareModule):
     if tasks and len(tasks) > 0:
       status = tasks[0].get("status_short")
     if not status:
-      self.ModuleError("Error polling workflow status", critical=True)
+      self.ModuleError("Error polling workflow status", critical=False)
     self.logger.info(f"Waiting for workflow {workflow_id} to finish.")
     output_file_ids = {}
     while status not in ("SUCCESS", "FAILURE"):
@@ -102,7 +102,7 @@ class OpenRelikProcessor(module.ThreadAwareModule):
         status = tasks[0].get("status_short")
     self.logger.debug(f"Workflow {workflow_id} status: {status}")
     if status == "FAILURE":
-      self.ModuleError(f"Workflow {workflow_id} failed", critical=True)
+      self.ModuleError(f"Workflow {workflow_id} failed", critical=False)
 
     for task in tasks:
       output_files = task.get("output_files", [])

--- a/tests/lib/processors/openrelik.py
+++ b/tests/lib/processors/openrelik.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 from openrelik_api_client import api_client, folders, workflows
 
-from dftimewolf.lib import errors
+# from dftimewolf.lib import errors
 from dftimewolf.lib.containers import containers
 from dftimewolf.lib.processors import openrelik as openrelik_processor
 from tests.lib import modules_test_base

--- a/tests/lib/processors/openrelik.py
+++ b/tests/lib/processors/openrelik.py
@@ -42,8 +42,8 @@ class OpenRelikProcessorTest(modules_test_base.ModuleTestBase):
     self._module.openrelik_workflow_client = workflows.WorkflowsAPI(
       api_client.APIClient("fake_api", "fake_key")
     )
-    status_generator = self._module.PollWorkflowStatus(456)
-    self.assertRaises(errors.DFTimewolfError, next, status_generator)
+    # status_generator = self._module.PollWorkflowStatus(456)
+    # self.assertRaises(errors.DFTimewolfError, next, status_generator)
 
     # Create some fake data for a successful workflow
     fake_workflow = {

--- a/tests/lib/processors/openrelik.py
+++ b/tests/lib/processors/openrelik.py
@@ -42,6 +42,9 @@ class OpenRelikProcessorTest(modules_test_base.ModuleTestBase):
     self._module.openrelik_workflow_client = workflows.WorkflowsAPI(
       api_client.APIClient("fake_api", "fake_key")
     )
+    # Commenting this out since now the module won't raise a ciritical error
+    # Uncomment these two lines when critical errors are re-enabled.
+
     # status_generator = self._module.PollWorkflowStatus(456)
     # self.assertRaises(errors.DFTimewolfError, next, status_generator)
 

--- a/tests/lib/processors/openrelik.py
+++ b/tests/lib/processors/openrelik.py
@@ -42,6 +42,8 @@ class OpenRelikProcessorTest(modules_test_base.ModuleTestBase):
     self._module.openrelik_workflow_client = workflows.WorkflowsAPI(
       api_client.APIClient("fake_api", "fake_key")
     )
+    status_generator = self._module.PollWorkflowStatus(456)
+    self._AssertNoErrors()
 
     # Create some fake data for a successful workflow
     fake_workflow = {

--- a/tests/lib/processors/openrelik.py
+++ b/tests/lib/processors/openrelik.py
@@ -42,11 +42,6 @@ class OpenRelikProcessorTest(modules_test_base.ModuleTestBase):
     self._module.openrelik_workflow_client = workflows.WorkflowsAPI(
       api_client.APIClient("fake_api", "fake_key")
     )
-    # Commenting this out since now the module won't raise a ciritical error
-    # Uncomment these two lines when critical errors are re-enabled.
-
-    # status_generator = self._module.PollWorkflowStatus(456)
-    # self.assertRaises(errors.DFTimewolfError, next, status_generator)
 
     # Create some fake data for a successful workflow
     fake_workflow = {

--- a/tests/lib/processors/openrelik.py
+++ b/tests/lib/processors/openrelik.py
@@ -5,7 +5,6 @@ from unittest import mock
 
 from openrelik_api_client import api_client, folders, workflows
 
-# from dftimewolf.lib import errors
 from dftimewolf.lib.containers import containers
 from dftimewolf.lib.processors import openrelik as openrelik_processor
 from tests.lib import modules_test_base


### PR DESCRIPTION
Temporarily make module errors non critical while the module is tested out.