### PR TITLE
Refactor datetime calls to remove deprecation warnings

### DIFF
--- a/dftimewolf/lib/collectors/grr_hosts.py
+++ b/dftimewolf/lib/collectors/grr_hosts.py
@@ -102,10 +102,10 @@ class GRRFlow(GRRBaseModule, module.ThreadAwareModule):
     Returns:
       boolean: True if the timestamp is in last month from now.
     """
-    last_seen_datetime = datetime.datetime.utcfromtimestamp(
-        timestamp / 1000000)
+    last_seen_datetime = datetime.datetime.fromtimestamp(
+        timestamp / 1000000, datetime.timezone.utc)
     # 30 days before now()
-    month_ago = datetime.datetime.utcnow() - datetime.timedelta(30)
+    month_ago = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(30)
     return  last_seen_datetime > month_ago
 
   def _FilterActiveClients(
@@ -186,12 +186,12 @@ class GRRFlow(GRRBaseModule, module.ThreadAwareModule):
 
     last_seen, client = clients[0]
     # Remove microseconds and create datetime object
-    last_seen_datetime = datetime.datetime.utcfromtimestamp(
-        last_seen / 1000000)
+    last_seen_datetime = datetime.datetime.fromtimestamp(
+        last_seen / 1000000, datetime.timezone.utc)
     # Timedelta between now and when the client was last seen, in minutes.
     # First, count total seconds. This will return a float.
     last_seen_seconds = (
-        datetime.datetime.utcnow() - last_seen_datetime).total_seconds()
+        datetime.datetime.now(datetime.timezone.utc) - last_seen_datetime).total_seconds()
     last_seen_minutes = int(round(last_seen_seconds / 60))
 
     self.logger.info(f'Found client: {client.client_id:s}')

--- a/dftimewolf/lib/processors/gcp_logging_timesketch.py
+++ b/dftimewolf/lib/processors/gcp_logging_timesketch.py
@@ -35,13 +35,13 @@ The following attributes are extracted by the processor:
   status_reason: operation failure reasons.
   textPayload: text payload for logs not using a JSON or proto payload.
   timestamp_desc: description of timestamp.
-  user: user or requestor.
+  user: user or requester.
 """
 
 import json
 import re
 import tempfile
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional, TYPE_CHECKING
 
 from dftimewolf.lib.containers import containers
@@ -263,7 +263,7 @@ class GCPLoggingTimesketch(BaseModule):
     timesketch_record['status_message'] = status_message
 
     # `protoPayload.status` struction may contain `details` attribute when
-    # opertion fails. The reason attribute contains the reason the operation
+    # operation fails. The reason attribute contains the reason the operation
     # failed.
     status_reasons = []
 
@@ -536,7 +536,7 @@ class GCPLoggingTimesketch(BaseModule):
           output_file.write('\n')
     output_file.close()
 
-    current_timestamp = datetime.utcnow().strftime('%Y%m%d%H%M%S')
+    current_timestamp = datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')
     timeline_name = f'{project_id}_{current_timestamp}'
 
     container = containers.File(name=timeline_name, path=output_path)

--- a/tests/lib/collectors/test_data/mock_grr_hosts.py
+++ b/tests/lib/collectors/test_data/mock_grr_hosts.py
@@ -38,8 +38,10 @@ client_proto1 = """
       }}
   }}
 """.format(int(
-    (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(20)).timestamp(
-    )*1000000)
+    (
+        datetime.datetime.now(datetime.timezone.utc)
+        - datetime.timedelta(20)
+    ).timestamp()*1000000)
 )
 
 # This has a more recent install_date and last_seen date than client_proto1
@@ -66,8 +68,10 @@ client_proto2 = """
       }}
   }}
 """.format(int(
-    (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(25)).timestamp(
-    )*1000000)
+    (
+        datetime.datetime.now(datetime.timezone.utc)
+        - datetime.timedelta(25)
+    ).timestamp()*1000000)
 )
 
 client_windows_1 = """
@@ -93,8 +97,10 @@ client_windows_1 = """
       }}
   }}
 """.format(int(
-    (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(20)).timestamp(
-    )*1000000)
+    (
+        datetime.datetime.now(datetime.timezone.utc)
+        - datetime.timedelta(20)
+    ).timestamp()*1000000)
 )
 
 MOCK_CLIENT = client.Client(

--- a/tests/lib/collectors/test_data/mock_grr_hosts.py
+++ b/tests/lib/collectors/test_data/mock_grr_hosts.py
@@ -38,7 +38,7 @@ client_proto1 = """
       }}
   }}
 """.format(int(
-    (datetime.datetime.utcnow() - datetime.timedelta(20)).timestamp(
+    (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(20)).timestamp(
     )*1000000)
 )
 
@@ -66,7 +66,7 @@ client_proto2 = """
       }}
   }}
 """.format(int(
-    (datetime.datetime.utcnow() - datetime.timedelta(25)).timestamp(
+    (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(25)).timestamp(
     )*1000000)
 )
 
@@ -93,7 +93,7 @@ client_windows_1 = """
       }}
   }}
 """.format(int(
-    (datetime.datetime.utcnow() - datetime.timedelta(20)).timestamp(
+    (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(20)).timestamp(
     )*1000000)
 )
 


### PR DESCRIPTION
# PR Summary
This PR resolves the `datetime` deprecation warnings which you can see in the [CI logs](https://github.com/log2timeline/dftimewolf/actions/runs/14746769827/job/41395497052#step:5:296):
```python
/home/runner/work/dftimewolf/dftimewolf/dftimewolf/lib/collectors/grr_hosts.py:189: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).

/home/runner/work/dftimewolf/dftimewolf/dftimewolf/lib/collectors/grr_hosts.py:194: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).

...
```