### PR TITLE
Allow a module to store containers only itself can retrieve

### DIFF
--- a/dftimewolf/lib/containers/manager.py
+++ b/dftimewolf/lib/containers/manager.py
@@ -90,7 +90,8 @@ class ContainerManager():
 
   def StoreContainer(self,
                      source_module: str,
-                     container: interface.AttributeContainer) -> None:
+                     container: interface.AttributeContainer,
+                     for_self_only: bool=False) -> None:
     """Adds a container to storage for later retrieval.
 
     This method will also invoke any applicable callbacks that have been
@@ -99,6 +100,8 @@ class ContainerManager():
     Args:
       source_module: The module that generated the container.
       container: The container to store.
+      for_self_only: True of the container should only be available to the same
+          module that stored it.
 
     Raises:
       RuntimeError: If the manager has not been configured with a recipe yet.
@@ -111,6 +114,8 @@ class ContainerManager():
 
       for _, module in self._modules.items():
         if source_module in module.dependencies:
+          if for_self_only and module.name != source_module:
+            continue
           callbacks = module.GetCallbacksForContainer(container.CONTAINER_TYPE)
           if callbacks and module.name != source_module:
             # This module has registered callbacks - Use those, rather than storing

--- a/dftimewolf/lib/containers/manager.py
+++ b/dftimewolf/lib/containers/manager.py
@@ -95,12 +95,13 @@ class ContainerManager():
     """Adds a container to storage for later retrieval.
 
     This method will also invoke any applicable callbacks that have been
-    registered.
+    registered (callbacks for the same module are never invoked to prevent
+    infinite recursion.)
 
     Args:
       source_module: The module that generated the container.
       container: The container to store.
-      for_self_only: True of the container should only be available to the same
+      for_self_only: True if the container should only be available to the same
           module that stored it.
 
     Raises:

--- a/tests/lib/containers/manager.py
+++ b/tests/lib/containers/manager.py
@@ -699,9 +699,16 @@ class ContainerManagerTest(unittest.TestCase):
     self.assertEqual(len(actual), 1)
     self.assertEqual(actual[0], _TestContainer1('From Preflight1'))
 
-  def test_ForSelfOnly(self):
+  def test_ForSelfOnlyStoreContainer(self):
     """Tests the for_self_only param of container storage."""
     self._container_manager.ParseRecipe(_TEST_RECIPE)
+
+    # Register a streaming callback that will only get called once
+    mock_callback = mock.MagicMock()
+    self._container_manager.RegisterStreamingCallback(
+        module_name='Preflight2_1',
+        container_type=_TestContainer1,
+        callback=mock_callback)
 
     # Store two containers of the same type, one with for_self_only=True
     self._container_manager.StoreContainer(
@@ -712,6 +719,11 @@ class ContainerManagerTest(unittest.TestCase):
         source_module='Preflight1',
         container=_TestContainer1('for_self_only=True'),
         for_self_only=True)
+
+    # Check callback
+    self.assertEqual(mock_callback.call_count, 1)
+    mock_callback.assert_called_once_with(
+        _TestContainer1('for_self_only=False'))
 
     # The same module can retrieve both
     actual = self._container_manager.GetContainers(

--- a/tests/lib/containers/manager.py
+++ b/tests/lib/containers/manager.py
@@ -699,6 +699,38 @@ class ContainerManagerTest(unittest.TestCase):
     self.assertEqual(len(actual), 1)
     self.assertEqual(actual[0], _TestContainer1('From Preflight1'))
 
+  def test_ForSelfOnly(self):
+    """Tests the for_self_only param of container storage."""
+    self._container_manager.ParseRecipe(_TEST_RECIPE)
+
+    # Store two containers of the same type, one with for_self_only=True
+    self._container_manager.StoreContainer(
+        source_module='Preflight1',
+        container=_TestContainer1('for_self_only=False'),
+        for_self_only=False)
+    self._container_manager.StoreContainer(
+        source_module='Preflight1',
+        container=_TestContainer1('for_self_only=True'),
+        for_self_only=True)
+
+    # The same module can retrieve both
+    actual = self._container_manager.GetContainers(
+        requesting_module='Preflight1',
+        container_class=_TestContainer1)
+
+    self.assertEqual(len(actual), 2)
+    self.assertIn(_TestContainer1('for_self_only=False'), actual)
+    self.assertIn(_TestContainer1('for_self_only=True'), actual)
+
+    # A dependant module can only retreieve the one
+    actual = self._container_manager.GetContainers(
+        requesting_module='ModuleA',
+        container_class=_TestContainer1)
+
+    self.assertEqual(len(actual), 1)
+    self.assertIn(_TestContainer1('for_self_only=False'), actual)
+    self.assertNotIn(_TestContainer1('for_self_only=True'), actual)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/lib/containers/manager.py
+++ b/tests/lib/containers/manager.py
@@ -734,7 +734,7 @@ class ContainerManagerTest(unittest.TestCase):
     self.assertIn(_TestContainer1('for_self_only=False'), actual)
     self.assertIn(_TestContainer1('for_self_only=True'), actual)
 
-    # A dependant module can only retreieve the one
+    # A dependant module can only retrieve the one
     actual = self._container_manager.GetContainers(
         requesting_module='ModuleA',
         container_class=_TestContainer1)


### PR DESCRIPTION
This allows the module to use container storage as a personal cache