### PR TITLE
Updates to GCE Disk copying

### DIFF
--- a/dftimewolf/lib/collectors/gce_disk_copy.py
+++ b/dftimewolf/lib/collectors/gce_disk_copy.py
@@ -183,7 +183,7 @@ class GCEDiskCopy(module.ThreadAwareModule):
       c = containers.GCEDisk(new_disk.name, self.destination_project.project_id)
       c.metadata.update(container.metadata)
       c.metadata['SOURCE_DISK'] = container.name
-      self.StoreContainer()
+      self.StoreContainer(c)
     except lcf_errors.ResourceNotFoundError as exception:
       self.logger.error(f'Could not find disk "{container.name}": {exception}')
       self.warned = True

--- a/dftimewolf/lib/collectors/gce_disk_copy.py
+++ b/dftimewolf/lib/collectors/gce_disk_copy.py
@@ -133,15 +133,17 @@ class GCEDiskCopy(module.ThreadAwareModule):
     try:
       # Disks from the csv list passed in
       for d in self.disk_names:
-        self.StoreContainer(
-            containers.GCEDisk(d, self.source_project.project_id))
+        c = containers.GCEDisk(d, self.source_project.project_id)
+        c.metadata['SOURCE_MACHINE'] = 'UNKNOWN_MACHINE'
+        self.StoreContainer(c, for_self_only=True)
 
       # Disks from the instances passed in
       for i in self.remote_instance_names:
         try:
           for d in self._GetDisksFromInstance(i, self.all_disks):
-            self.StoreContainer(
-                containers.GCEDisk(d, self.source_project.project_id))
+            c = containers.GCEDisk(d, self.source_project.project_id)
+            c.metadata['SOURCE_MACHINE'] = i
+            self.StoreContainer(c, for_self_only=True)
             at_least_one_instance = True
 
         except lcf_errors.ResourceNotFoundError:
@@ -178,8 +180,10 @@ class GCEDiskCopy(module.ThreadAwareModule):
       self.at_least_one_success = True
       self.PublishMessage(f'Disk {container.name} successfully copied to '
           f'{new_disk.name}')
-      self.StoreContainer(containers.GCEDisk(
-          new_disk.name, self.destination_project.project_id))
+      c = containers.GCEDisk(new_disk.name, self.destination_project.project_id)
+      c.metadata.update(container.metadata)
+      c.metadata['SOURCE_DISK'] = container.name
+      self.StoreContainer()
     except lcf_errors.ResourceNotFoundError as exception:
       self.logger.error(f'Could not find disk "{container.name}": {exception}')
       self.warned = True

--- a/dftimewolf/lib/exporters/gce_disk_export.py
+++ b/dftimewolf/lib/exporters/gce_disk_export.py
@@ -121,6 +121,7 @@ class GoogleCloudDiskExport(GoogleCloudDiskExportBase):
     for source_disk in self.GetContainers(containers.GCEDisk):
       if source_disk.project != self._source_project.project_id:
         self.logger.info('Source project mismatch: skipping %s', str(source_disk))
+        continue
 
       image_object = self._analysis_project.compute.CreateImageFromDisk(
           self._source_project.compute.GetDisk(source_disk.name))

--- a/dftimewolf/lib/exporters/gce_disk_export.py
+++ b/dftimewolf/lib/exporters/gce_disk_export.py
@@ -35,10 +35,11 @@ class GoogleCloudDiskExport(GoogleCloudDiskExportBase):
     super().__init__(state, name=name, critical=critical)
     self._source_project: gcp_project.GoogleCloudProject = None
     self._analysis_project: gcp_project.GoogleCloudProject = None
-    self._gcs_output_location: str = None
-    self._image_format: str = None
-    self._exported_image_name: str = None
+    self._gcs_output_location: str = ''
+    self._image_format: str = ''
+    self._exported_image_name: str = ''
 
+  # pylint: disable=arguments-differ
   def SetUp(self,
             source_project_name: str,
             gcs_output_location: str,

--- a/dftimewolf/lib/exporters/gce_disk_export.py
+++ b/dftimewolf/lib/exporters/gce_disk_export.py
@@ -3,6 +3,7 @@
 
 
 from libcloudforensics.providers.gcp.internal import project as gcp_project
+from libcloudforensics import errors as lcf_errors
 
 from dftimewolf.lib.containers import containers
 from dftimewolf.lib.modules import manager as modules_manager
@@ -118,6 +119,9 @@ class GoogleCloudDiskExport(GoogleCloudDiskExportBase):
   def Process(self) -> None:
     """Creates and exports disk image to the output bucket."""
     for source_disk in self.GetContainers(containers.GCEDisk):
+      if source_disk.project != self._source_project.project_id:
+        self.logger.info('Source project mismatch: skipping %s', str(source_disk))
+
       image_object = self._analysis_project.compute.CreateImageFromDisk(
           self._source_project.compute.GetDisk(source_disk.name))
       # If self.exported_image_name = None, default output_name is

--- a/dftimewolf/lib/exporters/gce_disk_export.py
+++ b/dftimewolf/lib/exporters/gce_disk_export.py
@@ -3,7 +3,6 @@
 
 
 from libcloudforensics.providers.gcp.internal import project as gcp_project
-from libcloudforensics import errors as lcf_errors
 
 from dftimewolf.lib.containers import containers
 from dftimewolf.lib.modules import manager as modules_manager

--- a/dftimewolf/lib/exporters/gce_disk_export.py
+++ b/dftimewolf/lib/exporters/gce_disk_export.py
@@ -2,10 +2,7 @@
 """Export disk image from a GCP project to Google Cloud Storage."""
 
 
-from typing import List, Optional
-
 from libcloudforensics.providers.gcp.internal import project as gcp_project
-from libcloudforensics.providers.gcp.internal.compute import GoogleComputeDisk
 
 from dftimewolf.lib.containers import containers
 from dftimewolf.lib.modules import manager as modules_manager
@@ -13,32 +10,18 @@ from dftimewolf.lib.state import DFTimewolfState
 from dftimewolf.lib.exporters.gce_disk_export_base import GoogleCloudDiskExportBase  # pylint: disable=line-too-long
 
 
+# pylint: disable=line-too-long
+
+
 class GoogleCloudDiskExport(GoogleCloudDiskExportBase):
   """Google Cloud Platform (GCP) Disk Export.
 
-  Attributes:
-    source_project (gcp_project.GoogleCloudProject): Source project
-        containing the disk/s to export.
-    gcs_output_location (str): Google Cloud Storage parent bucket/folder
-        path of the exported image.
-    analysis_project (gcp_project.GoogleCloudProject): Project where the
-        disk image is created then exported.
-        If not exit, source_project will be used.
-    remote_instance_name (str): Instance that needs forensicating.
-    source_disk_names (list[str]): Comma-separated list of disk names to copy.
-    all_disks (bool): True if all disks attached to the source
-        instance should be copied.
-    source_disks (list[gcp_project.compute.GoogleComputeDisk]): List of disks
-        to be exported.
-    exported_image_name (Optional[str]): Optional. Name of the output file, must
-        comply with ^[A-Za-z0-9-]*$' and '.tar.gz' will be appended to the name.
-        Default, if not exist or if more than one disk is selected, exported
-        image name as "exported-image-{TIMESTAMP('%Y%m%d%H%M%S')}".
+  This module copies a GCE Disk into GCS storage.
   """
 
   def __init__(self,
                state: DFTimewolfState,
-               name: Optional[str]=None,
+               name: str | None=None,
                critical: bool=False) -> None:
     """Initializes a Google Cloud Platform (GCP) Disk Export.
 
@@ -48,47 +31,22 @@ class GoogleCloudDiskExport(GoogleCloudDiskExportBase):
       critical (Optional[bool]): True if the module is critical, which causes
           the entire recipe to fail if the module encounters an error.
     """
-    super(GoogleCloudDiskExport, self).__init__(
-        state, name=name, critical=critical)
-    self.source_project = None  # type: gcp_project.GoogleCloudProject
-    self.gcs_output_location = str()
-    self.analysis_project = None  # type: gcp_project.GoogleCloudProject
-    self.remote_instance_name = None  # type: Optional[str]
-    self.source_disk_names = []  # type: List[str]
-    self.all_disks = False
-    self.source_disks = []  # type: List[GoogleComputeDisk]
-    self.exported_image_name = str()
-    self.image_format = str()
+    super().__init__(state, name=name, critical=critical)
+    self._source_project: gcp_project.GoogleCloudProject = None
+    self._analysis_project: gcp_project.GoogleCloudProject = None
+    self._gcs_output_location: str = None
+    self._image_format: str = None
+    self._exported_image_name: str = None
 
-  def Process(self) -> None:
-    """Creates and exports disk image to the output bucket."""
-    for source_disk in self.source_disks:
-      image_object = self.analysis_project.compute.CreateImageFromDisk(
-          source_disk)
-      # If self.exported_image_name = None, default output_name is
-      # {src_disk.name}-{TIMESTAMP('%Y%m%d%H%M%S')}.tar.gz
-      output_url = image_object.ExportImage(
-          self.gcs_output_location,
-          output_name=self.exported_image_name,
-          image_format=self.image_format)
-      image_object.Delete()
-      self.logger.info(f'Disk was exported to: {output_url}')
-      container = containers.GCSObject(path=output_url)
-      if self.remote_instance_name:
-        container.metadata['SOURCE_MACHINE'] = self.remote_instance_name
-      container.metadata['SOURCE_DISK'] = source_disk.name
-      self.StoreContainer(container)
-
-  # pylint: disable=arguments-differ
   def SetUp(self,
             source_project_name: str,
             gcs_output_location: str,
-            analysis_project_name: Optional[str]=None,
-            source_disk_names: Optional[str]=None,
-            remote_instance_name: Optional[str]=None,
-            all_disks: bool=False,
-            exported_image_name: Optional[str]=None,
-            image_format: str='') -> None:
+            analysis_project_name: str,
+            source_disk_names: str,
+            remote_instance_name: str,
+            all_disks: bool,
+            exported_image_name: str,
+            image_format: str) -> None:
     """Sets up a Google Cloud Platform (GCP) Disk Export.
 
     This method creates the required objects to initialize
@@ -130,24 +88,48 @@ class GoogleCloudDiskExport(GoogleCloudDiskExportBase):
           "exported-image-{TIMESTAMP('%Y%m%d%H%M%S')}".
       image_format: The image format to use.
     """
-    self.source_project = gcp_project.GoogleCloudProject(source_project_name)
+    self._image_format = image_format
+    self._gcs_output_location = gcs_output_location
+    self._exported_image_name = exported_image_name
+
+    self._source_project = gcp_project.GoogleCloudProject(source_project_name)
     if analysis_project_name:
-      self.analysis_project = gcp_project.GoogleCloudProject(
-          analysis_project_name)
+      self._analysis_project = gcp_project.GoogleCloudProject(analysis_project_name)
     else:
-      self.analysis_project = self.source_project
-    self.remote_instance_name = remote_instance_name
-    self.source_disk_names = []
+      self._analysis_project = self._source_project
+
+    if remote_instance_name:
+      instance_disks = self._GetDisksFromInstance(instance_name=remote_instance_name,
+                                                  all_disks=all_disks)
+      for d in instance_disks:
+        container = containers.GCEDisk(name=d.name, project=source_project_name)
+        container.metadata['SOURCE_MACHINE'] = self.remote_instance_name
+        container.metadata['SOURCE_DISK'] = d.name
+        self.StoreContainer(container, for_self_only=True)
+
     if source_disk_names:
-      self.source_disk_names = source_disk_names.split(',')
-    self.all_disks = all_disks
+      disk_names = list(filter(None, [d.strip().lower() for d in source_disk_names.split(',') if d]))
+      for d in disk_names:
+        container = containers.GCEDisk(name=d, project=source_project_name)
+        container.metadata['SOURCE_MACHINE'] = 'UNKNOWN_MACHINE'
+        container.metadata['SOURCE_DISK'] = d
+        self.StoreContainer(container, for_self_only=True)
 
-    self.source_disks = self._FindDisksToCopy()
-    self.gcs_output_location = gcs_output_location
-    if exported_image_name and len(self.source_disks) == 1:
-      self.exported_image_name = exported_image_name
-
-    self.image_format = image_format
+  def Process(self) -> None:
+    """Creates and exports disk image to the output bucket."""
+    for source_disk in self.GetContainers(containers.GCEDisk):
+      image_object = self._analysis_project.compute.CreateImageFromDisk(
+          self._source_project.compute.GetDisk(source_disk.name))
+      # If self.exported_image_name = None, default output_name is
+      # {src_disk.name}-{TIMESTAMP('%Y%m%d%H%M%S')}.tar.gz
+      output_url = image_object.ExportImage(self._gcs_output_location,
+                                            output_name=self._exported_image_name,
+                                            image_format=self._image_format)
+      image_object.Delete()
+      self.logger.info(f'Disk was exported to: {output_url}')
+      container = containers.GCSObject(path=output_url)
+      container.metadata.update(source_disk.metadata)
+      self.StoreContainer(container)
 
 
 modules_manager.ModulesManager.RegisterModule(GoogleCloudDiskExport)

--- a/tests/lib/exporters/gce_disk_export.py
+++ b/tests/lib/exporters/gce_disk_export.py
@@ -109,7 +109,7 @@ class GoogleCloudDiskExportTest(modules_test_base.ModuleTestBase):
                        all_disks=False,
                        exported_image_name='image-df-export-temp',
                        image_format='qcow2')
-    
+
     container = containers.GCEDisk(name='fake-source-disk', project='fake-source-project')
     container.metadata['SOURCE_MACHINE'] = 'fake-source-machine'
     container.metadata['SOURCE_DISK'] = 'fake-source-disk'

--- a/tests/lib/exporters/gce_disk_export.py
+++ b/tests/lib/exporters/gce_disk_export.py
@@ -26,6 +26,9 @@ FAKE_IMAGE = compute.GoogleComputeImage(
     'fake-source-disk-image-df-export-temp')
 
 
+# pylint: disable=line-too-long
+
+
 class GoogleCloudDiskExportTest(modules_test_base.ModuleTestBase):
   """Tests for the Google Cloud disk exporter."""
 
@@ -36,61 +39,30 @@ class GoogleCloudDiskExportTest(modules_test_base.ModuleTestBase):
     self._InitModule(gce_disk_export.GoogleCloudDiskExport)
     super().setUp()
 
-  # pylint: disable=line-too-long
-  @mock.patch('libcloudforensics.providers.gcp.internal.compute.GoogleCloudCompute.GetDisk')
-  @mock.patch('libcloudforensics.providers.gcp.internal.project.GoogleCloudProject')
-  def testSetUp(
-      self,
-      mock_gcp_project,
-      mock_get_disk):
-    """Tests that the exporter can be initialized."""
-    mock_gcp_project.return_value = FAKE_SOURCE_PROJECT
-    FAKE_SOURCE_PROJECT.compute.GetDisk = mock_get_disk
-    mock_get_disk.return_value = FAKE_DISK
-    self._module.SetUp(
-        'fake-source-project',
-        'gs://fake-bucket',
-        None,
-        'fake-source-disk',
-        None,
-        False,
-        'image-df-export-temp'
-    )
-    self.assertEqual(self._module.analysis_project.project_id,
-                     'fake-source-project')
-    self.assertEqual(self._module.source_project.project_id,
-                     'fake-source-project')
-    self.assertEqual(self._module.source_disks[0].name,
-                     'fake-source-disk')
-    self.assertEqual(self._module.gcs_output_location,
-                     'gs://fake-bucket')
-    self.assertEqual(self._module.exported_image_name,
-                     'image-df-export-temp')
-
-  # pylint: disable=line-too-long
   @mock.patch('libcloudforensics.providers.gcp.internal.compute.GoogleComputeImage.Delete')
   @mock.patch('libcloudforensics.providers.gcp.internal.compute.GoogleComputeImage.ExportImage')
   @mock.patch('libcloudforensics.providers.gcp.internal.compute.GoogleCloudCompute.CreateImageFromDisk')
   @mock.patch('libcloudforensics.providers.gcp.internal.compute.GoogleCloudCompute.GetDisk')
   @mock.patch('libcloudforensics.providers.gcp.internal.project.GoogleCloudProject')
-  def testProcess(self,
-                  mock_gcp_project,
-                  mock_get_disk,
-                  mock_create_image_from_disk,
-                  mock_export_image,
-                  mock_delete_image):
+  def testProcessDiskParams(self,
+                            mock_gcp_project,
+                            mock_get_disk,
+                            mock_create_image_from_disk,
+                            mock_export_image,
+                            mock_delete_image):
     """Tests the exporter's Process() function."""
     mock_export_image.return_value = 'gs://fake-bucket/image-df-export-temp.tar.gz'
     mock_gcp_project.return_value = FAKE_SOURCE_PROJECT
     FAKE_SOURCE_PROJECT.compute.GetDisk = mock_get_disk
     mock_get_disk.return_value = FAKE_DISK
-    self._module.SetUp(
-        source_project_name='fake-source-project',
-        gcs_output_location='gs://fake-bucket',
-        source_disk_names='fake-source-disk',
-        exported_image_name='image-df-export-temp',
-        image_format='qcow2'
-    )
+    self._module.SetUp(source_project_name='fake-source-project',
+                       gcs_output_location='gs://fake-bucket',
+                       analysis_project_name=None,
+                       source_disk_names='fake-source-disk',
+                       remote_instance_name=None,
+                       all_disks=False,
+                       exported_image_name='image-df-export-temp',
+                       image_format='qcow2')
     FAKE_SOURCE_PROJECT.compute.CreateImageFromDisk = mock_create_image_from_disk
     mock_create_image_from_disk.return_value = FAKE_IMAGE
     FAKE_IMAGE.ExportImage = mock_export_image
@@ -109,7 +81,61 @@ class GoogleCloudDiskExportTest(modules_test_base.ModuleTestBase):
     self.assertLen(urls, 1)
     self.assertEqual(urls[0].path, output_url)
     self.assertIn('SOURCE_DISK', urls[0].metadata)
+    self.assertIn('SOURCE_MACHINE', urls[0].metadata)
     self.assertEqual(urls[0].metadata['SOURCE_DISK'], 'fake-source-disk')
+    self.assertEqual(urls[0].metadata['SOURCE_MACHINE'], 'UNKNOWN_MACHINE')
+
+  @mock.patch('libcloudforensics.providers.gcp.internal.compute.GoogleComputeImage.Delete')
+  @mock.patch('libcloudforensics.providers.gcp.internal.compute.GoogleComputeImage.ExportImage')
+  @mock.patch('libcloudforensics.providers.gcp.internal.compute.GoogleCloudCompute.CreateImageFromDisk')
+  @mock.patch('libcloudforensics.providers.gcp.internal.compute.GoogleCloudCompute.GetDisk')
+  @mock.patch('libcloudforensics.providers.gcp.internal.project.GoogleCloudProject')
+  def testProcessDiskFromState(self,
+                               mock_gcp_project,
+                               mock_get_disk,
+                               mock_create_image_from_disk,
+                               mock_export_image,
+                               mock_delete_image):
+    """Tests the exporter's Process() function."""
+    mock_export_image.return_value = 'gs://fake-bucket/image-df-export-temp.tar.gz'
+    mock_gcp_project.return_value = FAKE_SOURCE_PROJECT
+    FAKE_SOURCE_PROJECT.compute.GetDisk = mock_get_disk
+    mock_get_disk.return_value = FAKE_DISK
+    self._module.SetUp(source_project_name='fake-source-project',
+                       gcs_output_location='gs://fake-bucket',
+                       analysis_project_name=None,
+                       source_disk_names=None,
+                       remote_instance_name=None,
+                       all_disks=False,
+                       exported_image_name='image-df-export-temp',
+                       image_format='qcow2')
+    
+    container = containers.GCEDisk(name='fake-source-disk', project='fake-source-project')
+    container.metadata['SOURCE_MACHINE'] = 'fake-source-machine'
+    container.metadata['SOURCE_DISK'] = 'fake-source-disk'
+    self._module.StoreContainer(container)
+
+    FAKE_SOURCE_PROJECT.compute.CreateImageFromDisk = mock_create_image_from_disk
+    mock_create_image_from_disk.return_value = FAKE_IMAGE
+    FAKE_IMAGE.ExportImage = mock_export_image
+    FAKE_IMAGE.Delete = mock_delete_image
+    self._ProcessModule()
+    mock_create_image_from_disk.assert_called_with(
+        FAKE_DISK)
+    mock_export_image.assert_called_with(
+        'gs://fake-bucket',
+        output_name='image-df-export-temp',
+        image_format='qcow2')
+    mock_delete_image.assert_called_once()
+    output_url = os.path.join(
+        'gs://fake-bucket', 'image-df-export-temp.tar.gz')
+    urls = self._module.GetContainers(containers.GCSObject)
+    self.assertLen(urls, 1)
+    self.assertEqual(urls[0].path, output_url)
+    self.assertIn('SOURCE_DISK', urls[0].metadata)
+    self.assertIn('SOURCE_MACHINE', urls[0].metadata)
+    self.assertEqual(urls[0].metadata['SOURCE_DISK'], 'fake-source-disk')
+    self.assertEqual(urls[0].metadata['SOURCE_MACHINE'], 'fake-source-machine')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Plumb instance and disk names through two modules, `GoogleCloudDiskExport` and `GCEDiskCopy`
* Refactor `GoogleCloudDiskExport` to process disks from previous modules