### PR TITLE
Revert update of GRR client approval links

### DIFF
--- a/dftimewolf/lib/collectors/grr_base.py
+++ b/dftimewolf/lib/collectors/grr_base.py
@@ -152,8 +152,9 @@ class GRRBaseModule:
         approval_sent = True
         if hasattr(approval, "client_id"):
           approval_url = (
-            f"{self.grr_url}/v2/_clients/{approval.client_id}/approvals/"
-            f"{approval.approval_id}/users/{approval.username}"
+            # pylint: disable=line-too-long
+            f"{self.grr_url}/v2/clients/{approval.client_id}/users/{approval.username}/approvals/{approval.approval_id}"
+            # pylint: enable=line-too-long
           )
         elif hasattr(approval, "hunt_id"):
           approval_url = (

--- a/dftimewolf/lib/collectors/grr_hosts.py
+++ b/dftimewolf/lib/collectors/grr_hosts.py
@@ -246,8 +246,9 @@ class GRRFlow(GRRBaseModule, module.ThreadAwareModule):
     )
 
     approval_url = (
-      f"{self.grr_url}/v2/_clients/{approval.client_id}/approvals/"
-      f"{approval.approval_id}/users/{approval.username}"
+      # pylint: disable=line-too-long
+      f"{self.grr_url}/v2/clients/{approval.client_id}/users/{approval.username}/approvals/{approval.approval_id}"
+      # pylint: enable=line-too-long
     )
     self.PublishMessage(f"Approval URL: {approval_url}")
     approval.WaitUntilValid()

--- a/tests/lib/collectors/grr_base.py
+++ b/tests/lib/collectors/grr_base.py
@@ -117,7 +117,7 @@ class GRRBaseModuleTest(unittest.TestCase):
 
     mock_publish_message.assert_has_calls([
       # pylint: disable=line-too-long
-      mock.call('Approval needed at: http://fake/endpoint/v2/_clients/abcd/approvals/dcba/users/nobody', False)
+      mock.call('Approval needed at: http://fake/endpoint/v2/clients/abcd/users/nobody/approvals/dcba', False)
       # pylint: enable=line-too-long
     ])
     self.assertEqual(mock_publish_message.call_count, 1)


### PR DESCRIPTION
GRR open source version was not yet updated, so we keep the links to GRR client approvals in dftimewolf in the GitHub version as they were before https://github.com/log2timeline/dftimewolf/pull/1016. 
Write approvals links in one line to patch them when we import the code.