### PR TITLE
Unify telemetry time units as ms

### DIFF
--- a/dftimewolf/cli/dftimewolf_recipes.py
+++ b/dftimewolf/cli/dftimewolf_recipes.py
@@ -522,10 +522,7 @@ def RunTool(cdm: Optional[CursesDisplayManager] = None) -> int:
     tool.telemetry.LogTelemetry('module', module, 'core', recipe_name)
 
   tool.telemetry.LogTelemetry(
-    'workflow_start',
-    datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
-    'core',
-    recipe_name)
+      'workflow_start', time.time() * 1000, 'core', recipe_name)
 
   try:
     tool.ValidateArguments(tool.dry_run)

--- a/dftimewolf/lib/collectors/grr_base.py
+++ b/dftimewolf/lib/collectors/grr_base.py
@@ -112,13 +112,14 @@ class GRRBaseModule:
     approval_sent = False
     approval_url = None
     approval_url_shown = False
-    start = time.time()
+    # Log time in ms
+    start = time.time() * 1000
     telemetry_callback({"mpa_start": str(start)})
     while True:
       try:
         result = grr_function(*args, **kwargs)
-        telemetry_callback({"mpa_success": str(time.time())})
-        telemetry_callback({"mpa_duration": str(time.time() - start)})
+        telemetry_callback({"mpa_success": str(time.time() * 1000)})
+        telemetry_callback({"mpa_duration": str((time.time() * 1000) - start)})
         return result
       except grr_errors.AccessForbiddenError as exception:
         logger.warning(f"No valid approval found: {exception!s}")


### PR DESCRIPTION
Most other telemetry is being logged as epoch milliseconds so updating these instances from seconds to match.

I also changed the `workflow_start` time from a human readable datetime string to be logged in ms to have a consistent time format.  Not sure if there was a reason this was a datetime instead of float, so let me know if you want that one changed back.